### PR TITLE
fix(web): Dockerfile prod deps + response_stream モード削除

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,10 +1,17 @@
-FROM public.ecr.aws/docker/library/node:22-slim AS builder
+FROM public.ecr.aws/docker/library/node:22-slim AS base
 
 WORKDIR /app
 
 RUN corepack enable pnpm
 
 COPY package.json pnpm-lock.yaml .npmrc ./
+
+FROM base AS prod-deps
+
+RUN --mount=type=secret,id=github_token \
+    GITHUB_TOKEN=$(cat /run/secrets/github_token) pnpm install --frozen-lockfile --prod
+
+FROM base AS builder
 
 RUN --mount=type=secret,id=github_token \
     GITHUB_TOKEN=$(cat /run/secrets/github_token) pnpm install --frozen-lockfile
@@ -14,13 +21,13 @@ RUN pnpm build
 
 FROM public.ecr.aws/docker/library/node:22-slim
 
-COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.0 /lambda-adapter /opt/extensions/lambda-adapter
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
 
 ENV PORT=8080
-ENV AWS_LWA_INVOKE_MODE=response_stream
 
 WORKDIR /app
 
+COPY --from=prod-deps /app/node_modules ./node_modules
 COPY --from=builder /app/build ./build
 COPY --from=builder /app/package.json ./
 


### PR DESCRIPTION
## Summary

- adapter-node の \`dependencies\` は externalize される仕様 → 本番イメージに \`node_modules\` を含める必要があった
- pnpm 公式の multi-stage ビルドパターン (base / prod-deps / builder / runtime) に変更
- \`AWS_LWA_INVOKE_MODE=response_stream\` を削除 (API Gateway HTTP API は response streaming 非対応、REST API のみ対応)

詳細は #7 参照。

## Test plan

- [x] ローカル \`docker build\` 成功
- [x] ECR push + Lambda update 成功
- [x] \`https://planner.tommykeyapp.com/\` で SSR レンダリング確認 (Status 200)
- [x] ResourceTimeline コンポーネントの描画確認