### PR TITLE
security: state encryption + Clerk secret を SSM SecureString に移行

### DIFF
--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,7 +1,9 @@
 terraform {
   backend "s3" {
-    bucket = "tommykeyapp-tfstate"
-    key    = "resource-planner/terraform.tfstate"
-    region = "ap-northeast-1"
+    bucket       = "tommykeyapp-tfstate"
+    key          = "resource-planner/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
   }
 }

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -52,6 +52,30 @@ resource "aws_iam_role_policy" "lambda_dynamodb" {
   })
 }
 
+resource "aws_iam_role_policy" "lambda_ssm" {
+  name = "${var.project}-ssm-policy"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["ssm:GetParameter"]
+        Resource = [
+          aws_ssm_parameter.clerk_secret_key.arn,
+          aws_ssm_parameter.clerk_publishable_key.arn,
+        ]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = "arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"
+      }
+    ]
+  })
+}
+
 resource "aws_lambda_function" "app" {
   function_name = var.project
   role          = aws_iam_role.lambda.arn
@@ -62,10 +86,10 @@ resource "aws_lambda_function" "app" {
 
   environment {
     variables = {
-      ORIGIN                       = "https://${var.domain}"
-      DYNAMODB_TABLE               = aws_dynamodb_table.main.name
-      PUBLIC_CLERK_PUBLISHABLE_KEY = var.clerk_publishable_key
-      CLERK_SECRET_KEY             = var.clerk_secret_key
+      ORIGIN                      = "https://${var.domain}"
+      DYNAMODB_TABLE              = aws_dynamodb_table.main.name
+      CLERK_SECRET_KEY_PARAM      = aws_ssm_parameter.clerk_secret_key.name
+      CLERK_PUBLISHABLE_KEY_PARAM = aws_ssm_parameter.clerk_publishable_key.name
     }
   }
 

--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -15,3 +15,17 @@ resource "aws_ssm_parameter" "lambda_function_name" {
   type  = "String"
   value = aws_lambda_function.app.function_name
 }
+
+resource "aws_ssm_parameter" "clerk_secret_key" {
+  name  = "/${var.project}/clerk-secret-key"
+  type  = "SecureString"
+  value = var.clerk_secret_key
+  tier  = "Standard"
+}
+
+resource "aws_ssm_parameter" "clerk_publishable_key" {
+  name  = "/${var.project}/clerk-publishable-key"
+  type  = "String"
+  value = var.clerk_publishable_key
+  tier  = "Standard"
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 5.100"
     }
   }
 }


### PR DESCRIPTION
## Summary

- terraform state に `encrypt = true` + `use_lockfile = true` (S3 native locking) を明示
- `required_version >= 1.10`、AWS provider `~> 5.100` に pin
- Clerk secret を Lambda 環境変数から削除、SSM SecureString に移行
- Lambda IAM に `ssm:GetParameter` + `kms:Decrypt` 付与

詳細は #9 参照。

## ベストプラクティス根拠

| 変更 | 根拠 |
|------|------|
| `encrypt = true` | belt-and-suspenders (S3 デフォルト暗号化と併用、明示的に意図表明) |
| `use_lockfile = true` | Terraform 1.10+ の S3 native locking。DynamoDB locking は **deprecated** |
| `~> 5.100` pin | lockfile (`.terraform.lock.hcl`) は既に 5.100.0、constraint を揃える |
| SSM SecureString | $0/月 (Standard tier)、Clerk は rotation API なしで Secrets Manager の高度機能不要 |
| env var → SSM | `aws lambda get-function-configuration` で平文取得を防ぐ。SDK で起動時取得 (Clerk 統合時) |

## アプリ側変更なし

Clerk 統合 (`hooks.server.ts`) は未実装のため、SSM 取得コードは別 issue。今回は基盤のみ整備し、Clerk 統合時に `withClerkHandler({ secretKey, publishableKey })` 経由で渡す予定。

## Test plan

- [x] `terraform validate` 成功
- [ ] CI で `terraform plan` 成功 (新 SSM resources + Lambda env 整理)
- [ ] merge 後に手動 apply (CD は PR #2 で作成):
  - `cd infra && terraform init -reconfigure && terraform apply`
  - `aws lambda get-function-configuration --function-name resource-planner` の env に旧 secret なし
  - `aws ssm get-parameter --name /resource-planner/clerk-secret-key --with-decryption` で値取得
  - https://planner.tommykeyapp.com/ が 200
- [ ] Clerk Dashboard で旧 sk_test_* を Revoke