### PR TITLE
chore: default_tags + DynamoDB protection + CloudFront Security Headers

### DIFF
--- a/infra/apigateway.tf
+++ b/infra/apigateway.tf
@@ -1,10 +1,6 @@
 resource "aws_apigatewayv2_api" "api" {
   name          = "${var.project}-api"
   protocol_type = "HTTP"
-
-  tags = {
-    Project = var.project
-  }
 }
 
 resource "aws_apigatewayv2_integration" "lambda" {
@@ -25,8 +21,4 @@ resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.api.id
   name        = "$default"
   auto_deploy = true
-
-  tags = {
-    Project = var.project
-  }
 }

--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -22,8 +22,9 @@ resource "aws_cloudfront_distribution" "app" {
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
 
-    cache_policy_id          = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
-    origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+    cache_policy_id            = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+    origin_request_policy_id   = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
   }
 
   ordered_cache_behavior {
@@ -34,7 +35,8 @@ resource "aws_cloudfront_distribution" "app" {
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
 
-    cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    cache_policy_id            = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+    response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
   }
 
   restrictions {
@@ -47,9 +49,5 @@ resource "aws_cloudfront_distribution" "app" {
     acm_certificate_arn      = data.aws_acm_certificate.wildcard.arn
     ssl_support_method       = "sni-only"
     minimum_protocol_version = "TLSv1.2_2021"
-  }
-
-  tags = {
-    Project = var.project
   }
 }

--- a/infra/cloudwatch.tf
+++ b/infra/cloudwatch.tf
@@ -1,8 +1,4 @@
 resource "aws_cloudwatch_log_group" "lambda" {
   name              = "/aws/lambda/${var.project}"
   retention_in_days = 14
-
-  tags = {
-    Project = var.project
-  }
 }

--- a/infra/dynamodb.tf
+++ b/infra/dynamodb.tf
@@ -1,8 +1,9 @@
 resource "aws_dynamodb_table" "main" {
-  name         = var.project
-  billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "pk"
-  range_key    = "sk"
+  name                        = var.project
+  billing_mode                = "PAY_PER_REQUEST"
+  hash_key                    = "pk"
+  range_key                   = "sk"
+  deletion_protection_enabled = true
 
   attribute {
     name = "pk"
@@ -14,7 +15,11 @@ resource "aws_dynamodb_table" "main" {
     type = "S"
   }
 
-  tags = {
-    Project = var.project
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
   }
 }

--- a/infra/ecr.tf
+++ b/infra/ecr.tf
@@ -6,10 +6,6 @@ resource "aws_ecr_repository" "app" {
   image_scanning_configuration {
     scan_on_push = true
   }
-
-  tags = {
-    Project = var.project
-  }
 }
 
 resource "aws_ecr_lifecycle_policy" "app" {

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -15,10 +15,6 @@ resource "aws_iam_role" "lambda" {
       }
     ]
   })
-
-  tags = {
-    Project = var.project
-  }
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_basic" {
@@ -92,10 +88,6 @@ resource "aws_lambda_function" "app" {
       CLERK_SECRET_KEY_PARAM      = aws_ssm_parameter.clerk_secret_key.name
       CLERK_PUBLISHABLE_KEY_PARAM = aws_ssm_parameter.clerk_publishable_key.name
     }
-  }
-
-  tags = {
-    Project = var.project
   }
 
   depends_on = [aws_ecr_repository.app]

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -11,9 +11,19 @@ terraform {
 
 provider "aws" {
   region = var.region
+  default_tags {
+    tags = {
+      Project = var.project
+    }
+  }
 }
 
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
+  default_tags {
+    tags = {
+      Project = var.project
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- **default_tags**: 各 provider に `Project = var.project` を設定、全 resource の重複削除
- **DynamoDB**: PITR + deletion_protection + 明示的 SSE (in-place、データ保持)
- **CloudFront SecurityHeadersPolicy**: AWS managed policy attach (HSTS/X-Frame-Options 等)

詳細は #13 参照。

## ベストプラクティス根拠

| 項目 | 根拠 |
|------|------|
| `default_tags` | DRY、tag 管理の一元化、AWS provider v5+ で perpetual diff 問題は解消済 |
| DynamoDB PITR | AWS-recommended for production tables、35 日復元 |
| DynamoDB deletion_protection | 誤削除防止、本番テーブル必須 |
| DynamoDB SSE 明示 | 暗黙のデフォルトを明示化 (コードで意図表明) |
| SecurityHeadersPolicy | Mozilla Web Security Guidelines 準拠、コスト無料 |

## Test plan

- [x] `terraform validate` 成功
- [x] `terraform plan` で 0 add, **16 change in-place**, 0 destroy (replace なし)
- [ ] CI で plan 成功
- [ ] merge → CD 自動 trigger → infra apply
- [ ] verification:
  - `aws dynamodb describe-table --table-name resource-planner` で PITR/DeletionProtection/SSE が ENABLED
  - `curl -I https://planner.tommykeyapp.com/` で `strict-transport-security` / `x-content-type-options` / `x-frame-options` が含まれる
  - 全リソースに `Project=resource-planner` タグ