### PR TITLE
fix(auth): url.hash + init timeout

### DIFF
--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -76,7 +76,7 @@ resource "aws_lambda_function" "app" {
   image_uri     = "${aws_ecr_repository.app.repository_url}:latest"
   architectures = ["arm64"]
   timeout       = 30
-  memory_size   = 512
+  memory_size   = 1024
 
   environment {
     variables = {

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -12,7 +12,7 @@ export const load: LayoutServerLoad = ({ locals, url }) => {
 		if (!pk) {
 			throw new Error('PUBLIC_CLERK_PUBLISHABLE_KEY env is not set');
 		}
-		const returnTo = url.origin + url.pathname + url.search + url.hash;
+		const returnTo = url.origin + url.pathname + url.search;
 		redirect(307, buildSignInUrl(pk, returnTo));
 	}
 


### PR DESCRIPTION
## Summary

PR #16 後 Lambda が 504 を返していた問題の hotfix。

### 問題 1: url.hash アクセスエラー
SvelteKit は server-side で event.url.hash アクセスを禁止 (HTTP リクエストに hash fragment は含まれない仕様)。
+layout.server.ts の returnTo から url.hash を削除。

### 問題 2: Lambda init phase 10s timeout
cold start で svelte-clerk + AWS SDK + 大型 SvelteKit bundle の初期化が 512MB の CPU 性能では 10s 制限を超過。
memory_size を 1024MB に増強 (Lambda は memory に比例して CPU が割り当てられる)。

## Test plan
- [x] pnpm check 成功
- [ ] CI 通過
- [ ] merge 後 cold start で 504 が解消、未認証で sign-in に redirect