### PR TITLE
fix(infra): CloudFront origin に X-Forwarded-Host を固定送信

### DIFF
--- a/infra/cloudfront.tf
+++ b/infra/cloudfront.tf
@@ -7,6 +7,16 @@ resource "aws_cloudfront_distribution" "app" {
     domain_name = "${aws_apigatewayv2_api.api.id}.execute-api.${var.region}.amazonaws.com"
     origin_id   = "apigw"
 
+    custom_header {
+      name  = "X-Forwarded-Host"
+      value = var.domain
+    }
+
+    custom_header {
+      name  = "X-Forwarded-Proto"
+      value = "https"
+    }
+
     custom_origin_config {
       http_port              = 80
       https_port             = 443


### PR DESCRIPTION
## 概要

PR #19 後、サインイン後の URL が API Gateway 直 URL に化ける問題の根本修正。

```
$ curl -sI https://planner.tommykeyapp.com/  # サインイン後
HTTP/2 307
location: https://4iu03iqfgj.execute-api.ap-northeast-1.amazonaws.com/  ← AWS URL に化ける
```

## Root cause (ソース確認済)

`@clerk/backend/tokens/clerkRequest.ts` の \`deriveUrlFromHeaders()\` は SvelteKit の \`event.url\` や \`ORIGIN\` env を見ず、生の HTTP headers から URL を再構築する:

```ts
const forwardedHost = req.headers.get('X-Forwarded-Host');
const host = req.headers.get('Host');
const resolvedHost = forwardedHost ?? host;
// → clerkUrl.origin = ${proto}://${resolvedHost}
```

CloudFront \`AllViewerExceptHostHeader\` policy は viewer Host を strip するが **X-Forwarded-Host を自動付与しない**。Lambda は Host header に API Gateway 自身のドメインしか持たない → Clerk が AWS URL を origin と認識 → redirect が AWS URL になる。

## 修正

infra/cloudfront.tf の \`origin\` block に固定値の custom_header を追加:

\`\`\`hcl
custom_header {
  name  = "X-Forwarded-Host"
  value = var.domain         # planner.tommykeyapp.com
}
custom_header {
  name  = "X-Forwarded-Proto"
  value = "https"
}
\`\`\`

CloudFront → API Gateway HTTP API は payload v2 \`event.headers\` に lowercase で含めて Lambda に転送 (公式 docs 確認済)。Lambda Web Adapter が HTTP request に再構築 → svelte-clerk \`patchRequest\` が headers 保持 → Clerk Backend SDK が X-Forwarded-Host を読んで正しい origin を解決。

## terraform plan
\`\`\`
Plan: 0 to add, 1 to change, 0 to destroy.
\`\`\`
in-place 更新、CloudFront 反映に数分。

## Test plan

- [x] terraform fmt + validate + plan 成功
- [ ] CI 通過
- [ ] CD で deploy-infra 成功
- [ ] Lambda CloudWatch Logs で \`x-forwarded-host: planner.tommykeyapp.com\` が届いていることを確認
- [ ] ブラウザで https://planner.tommykeyapp.com/ アクセス → サインイン → URL bar が \`planner.tommykeyapp.com\` のまま (AWS URL に化けない)

## 残リスク

API Gateway HTTP API が CloudFront からの custom header を Lambda に転送するか実機検証必要 (公式 payload v2 spec では転送される記述、実機確認は deploy 後に Lambda Logs で)。もし届かなかった場合は Lambda@Edge で書き換えに pivot (別 PR)。

## スコープ外
- web/ コード変更なし (Clerk SDK / svelte-clerk 任せで動作)
- Org 必須問題 (Clerk Dashboard) は別 issue