### PR TITLE
fix(auth): createClerkClient で domainCheck の Missing Secret Key 解消

### DIFF
--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -2,7 +2,7 @@ import { sequence } from '@sveltejs/kit/hooks';
 import { error, type Handle } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
-import { withClerkHandler, clerkClient } from 'svelte-clerk/server';
+import { withClerkHandler, createClerkClient } from 'svelte-clerk/server';
 
 if (!env.CLERK_SECRET_KEY_PARAM) {
 	throw new Error('CLERK_SECRET_KEY_PARAM env not set');
@@ -22,6 +22,7 @@ if (!secretKey) {
 }
 
 const clerkHandler = withClerkHandler({ secretKey });
+const clerk = createClerkClient({ secretKey });
 
 const emailCache = new Map<string, string>();
 
@@ -38,7 +39,7 @@ const domainCheck: Handle = async ({ event, resolve }) => {
 		if (!email) email = emailCache.get(auth.userId);
 
 		if (!email) {
-			const user = await clerkClient.users.getUser(auth.userId);
+			const user = await clerk.users.getUser(auth.userId);
 			email = user.primaryEmailAddress?.emailAddress?.toLowerCase();
 			if (email) emailCache.set(auth.userId, email);
 		}


### PR DESCRIPTION
## 概要

PR #20 後、URL 化けは解消したがサインイン後に 500:

\`\`\`
Error: Missing Clerk Secret Key. Go to https://dashboard.clerk.com...
at clerkClient.users.getUser
at domainCheck (hooks.server.ts:167)
\`\`\`

## Root cause (ソース確認済)

svelte-clerk の \`clerkClient\` は \`@clerk/backend\` の \`createClerkClient\` で作られた **singleton で module load 時に eager 初期化**される:

\`\`\`ts
// svelte-clerk/src/lib/server/clerkClient.ts
export const clerkClient = createClerkClient({
  secretKey: SECRET_KEY,  // ← module load 時の env var (undefined)
  ...
});

// constants.ts
export const SECRET_KEY = getDynamicPrivateEnvVariables().secretKey;
\`\`\`

本プロジェクトは secret を **SSM から runtime 取得** する pattern なので、svelte-clerk の import 時 (svelte-clerk import が hooks.server.ts の SSM fetch より先に評価される) には env に値がなく、singleton が secret なしで壊れた状態に。

\`withClerkHandler\` は \`{ secretKey }\` 引数で渡しているので動作 (canonical pattern)。一方 \`clerkClient.users.getUser\` は singleton が壊れているので失敗。

## 修正 (3 行)

SSM 取得した secret で自前の \`createClerkClient\` instance を作り、domainCheck で使う:

\`\`\`diff
-import { withClerkHandler, clerkClient } from 'svelte-clerk/server';
+import { withClerkHandler, createClerkClient } from 'svelte-clerk/server';

 const clerkHandler = withClerkHandler({ secretKey });
+const clerk = createClerkClient({ secretKey });

-    const user = await clerkClient.users.getUser(auth.userId);
+    const user = await clerk.users.getUser(auth.userId);
\`\`\`

(\`createClerkClient\` は svelte-clerk が \`@clerk/backend\` を re-export しているので import 可能。)

## Test plan

- [x] \`pnpm check\` 成功
- [x] \`pnpm build\` 成功
- [ ] CI 通過
- [ ] merge 後、ブラウザでサインイン → 500 解消 → ResourceTimeline 表示