### PR TITLE
docs: GitHub Pages で docs/db/ を公開

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,47 @@
+name: Deploy Docs to GitHub Pages
+
+# docs/db/ (tbls 自動生成 + 手書き entities/access-patterns) を Jekyll で HTML 化して
+# GitHub Pages に公開する。
+#
+# 公開 URL: https://tommykey-apps.github.io/resource-planner/db/
+#
+# 注: repo Settings > Pages > Source を「GitHub Actions」に設定する手動操作が
+# 1 度だけ必要 (issue #26 の手順を参照)。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/db/**"
+      - ".github/workflows/pages.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs/db
+          destination: ./_site
+
+      - uses: actions/upload-pages-artifact@v3
+
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- `.github/workflows/pages.yaml` を新規作成。`main` への push で `docs/db/**` が変わったら Jekyll で HTML 化して Pages に deploy。
- repo Settings > Pages > Source = **GitHub Actions** を `gh api -X POST repos/.../pages -f build_type=workflow` で設定済 (この PR 作成前に実施)。
- 公開 URL: https://tommykey-apps.github.io/resource-planner/db/

## 構成

burnnote の `pages.yaml` をベースに、resource-planner には Swagger 対象の API endpoint が無いため Swagger UI build ステップをドロップ。残りは confirmed pattern:

- `actions/configure-pages@v5` → `actions/jekyll-build-pages@v1` (source: `./docs/db`) → `actions/upload-pages-artifact@v3` → `actions/deploy-pages@v4`
- permissions は `contents: read` / `pages: write` / `id-token: write` のみ
- concurrency `group: pages` で deploy 競合防止

## 依存関係

`docs/db/` 配下の content は #25 (PR #29) に含まれる。先に #25 が merge されていると初回 Pages deploy で意味のあるドキュメントが公開される。

## 受け入れ基準

- [x] main で `docs/db/**` を変更すると Pages が自動更新される (workflow の trigger 設定)
- [x] permissions が最小限 (pages / id-token のみ)
- [x] concurrency 設定済で deploy 競合しない
- [ ] (#25 merge 後) 公開 URL `https://tommykey-apps.github.io/resource-planner/db/` で DB schema docs が閲覧できる

## Test plan

- [ ] この PR が merge された後、main の `pages.yaml` workflow が成功する (docs/db が無い時点では空 deploy になるが workflow 自体は緑)
- [ ] #25 が main に merge された後の auto-trigger で公開 URL に DB docs が表示される
- [ ] Page 内のリンク (`entities.md` → `entities.html` など `jekyll-relative-links` 解決) が 200 で返る

Closes #26