### PR TITLE
fix(docs): Pages destination を /db/ 配下に置いて baseurl と整合 (fixes #32)

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -36,10 +36,13 @@ jobs:
 
       - uses: actions/configure-pages@v5
 
+      # destination を ./_site/db にすることで Pages の project site URL
+      # https://tommykey-apps.github.io/resource-planner/db/ で配信される。
+      # _config.yml の baseurl: /resource-planner/db と整合させる。
       - uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs/db
-          destination: ./_site
+          destination: ./_site/db
 
       - uses: actions/upload-pages-artifact@v3
 


### PR DESCRIPTION
## Summary

PR #30 で merge した `pages.yaml` の `destination: ./_site` だと Jekyll 出力が `_site/` 直下に置かれ、Pages 配信パスが `/resource-planner/` (root) になる。一方 `_config.yml` の `baseurl: /resource-planner/db` はリンク生成時に `/resource-planner/db/` を前提としていたため、canonical URL でアクセスすると 404。

`destination: ./_site/db` に変えるだけで、配信パスと baseurl を揃える。burnnote の `pages.yaml` と同じ構造。

## Test plan

- [ ] merge 後 `https://tommykey-apps.github.io/resource-planner/db/` が 200
- [ ] `/db/entities.html` / `/db/access-patterns.html` も 200 (jekyll-relative-links 解決)
- [ ] `/resource-planner/` (root) は 404 になる (これが正常)

fixes #32