### PR TITLE
docs: 型駆動 docs 戦略の制度化 (ADR + use-cases + feature テンプレ)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 設計ドキュメント
+    url: https://github.com/tommykey-apps/resource-planner/tree/main/docs
+    about: アーキテクチャ図、ADR、use-cases、DB schema は docs/ 配下に集約 (Pages 公開: https://tommykey-apps.github.io/resource-planner/db/)

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,78 @@
+name: Feature
+description: 新機能の追加・既存機能の拡張
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        新機能の起票テンプレ。設計判断の記録 (ADR) と振る舞いの仕様 (use-case)、API 契約 (TS 型) を AC に含める。
+        詳細は [`docs/adr/`](https://github.com/tommykey-apps/resource-planner/tree/main/docs/adr) と
+        [ADR 0001](https://github.com/tommykey-apps/resource-planner/blob/main/docs/adr/0001-typescript-types-as-api-spec.md) 参照。
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景 / 動機
+      description: なぜこの機能が必要か。何を解決したいか。誰のための機能か。
+      placeholder: |
+        - ユーザーが ... できないため ...
+        - 既存の ... を改善するため ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 含むもの (このイシューのスコープ)
+      description: 実装するファイル / 機能を箇条書き。スコープ外は「含まないもの」へ。
+      placeholder: |
+        - `web/src/routes/.../+page.server.ts` の actions.xxxx
+        - `web/src/lib/schemas/xxxx.ts` (Zod schema)
+        - `web/src/lib/db/xxxx.ts` (DynamoDB アクセス)
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: 含まないもの (別 issue に切り出し)
+      description: 関連はするが本イシューでは扱わない範囲。スコープクリープ防止のため明示する。
+
+  - type: textarea
+    id: design
+    attributes:
+      label: 設計メモ
+      description: |
+        実装前に方針を簡潔に書く。複雑な判断 (代替案の比較、トレードオフ、制約) があれば
+        ADR に切り出す候補。
+
+  - type: checkboxes
+    id: docs-acceptance
+    attributes:
+      label: 受け入れ基準 — ドキュメント
+      description: |
+        本リポジトリは型駆動 docs 戦略を採用している ([ADR 0001](https://github.com/tommykey-apps/resource-planner/blob/main/docs/adr/0001-typescript-types-as-api-spec.md))。
+        **すべての AC を満たした PR を merge する**。チェックを外して良いのは「該当しない」場合のみ (理由を PR 本文に書く)。
+      options:
+        - label: TypeScript 型 (interface / type / Zod・Valibot schema) で input/output 契約を定義した
+        - label: "`docs/use-cases.md` に該当するユースケースの Mermaid sequence diagram を追加した"
+        - label: 設計判断が必要な場合 `docs/adr/NNNN-*.md` を追加した (Nygard 形式、Status=Accepted)
+        - label: 関連する既存 ADR を Superseded by N にした (該当時のみ)
+        - label: "`docs/db/entities.md` / `docs/db/access-patterns.md` を必要に応じて更新した (DB アクセス追加 / 変更時のみ)"
+
+  - type: checkboxes
+    id: code-acceptance
+    attributes:
+      label: 受け入れ基準 — コード
+      options:
+        - label: "`pnpm check` (svelte-check) が緑"
+        - label: "`pnpm lint` が緑"
+        - label: "Terraform 変更時 `terraform validate` が緑"
+        - label: 既存テストが緑、新機能のテストを追加した (該当時)
+
+  - type: textarea
+    id: references
+    attributes:
+      label: 参考リンク
+      description: 関連 issue、設計時に参照した記事、公式ドキュメント等。

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ pnpm format                # Prettier 自動修正
 > [docs/architecture.drawio](docs/architecture.drawio) を draw.io で開くと編集できる。
 > 図を更新したら `drawio-png` skill (またはローカル draw.io GUI) で `docs/architecture.png` を再 export して commit する。
 
+## 設計ドキュメントの読み方
+
+本リポジトリは **型駆動 docs 戦略** を採用している ([ADR 0001](docs/adr/0001-typescript-types-as-api-spec.md))。
+OpenAPI は使わず、TypeScript 型 + Zod schema を API 仕様の正本とし、自然言語ドキュメントは
+役割を分けて 4 箇所に集約する:
+
+| 何が知りたい | どこを見る |
+|---|---|
+| **構造** (どのコンポーネントがどう繋がっているか) | [`docs/architecture.drawio`](docs/architecture.drawio) ([PNG](docs/architecture.png)) — C4 Container 図 |
+| **なぜ** その判断をしたか | [`docs/adr/`](docs/adr/) — Architecture Decision Records (Michael Nygard 形式) |
+| **どう動く** か (画面 → action → DB の流れ) | [`docs/use-cases.md`](docs/use-cases.md) — Mermaid sequence diagrams |
+| **データモデル** (PK / SK / 属性 / クエリパターン) | [`docs/db/`](docs/db/) — tbls 自動生成 + 手書き entities/access-patterns ([Pages 公開](https://tommykey-apps.github.io/resource-planner/db/)) |
+| **API 仕様** (関数の入出力) | TypeScript 型 (`web/src/lib/types.ts`, Zod schema) — コードを直接読む |
+
+新機能を追加するときは [`.github/ISSUE_TEMPLATE/feature.yml`](.github/ISSUE_TEMPLATE/feature.yml) を使う。
+ADR / use-case / 型定義の追加が AC に含まれる。
+
 ## 関連リポジトリ
 
 - [tommykey-apps/ui-components](https://github.com/tommykey-apps/ui-components) — Svelte コンポーネントライブラリ

--- a/docs/adr/0001-typescript-types-as-api-spec.md
+++ b/docs/adr/0001-typescript-types-as-api-spec.md
@@ -1,0 +1,65 @@
+# 0001. TypeScript 型を API 仕様の正本とする
+
+- **Status**: Accepted
+- **Date**: 2026-05-08
+- **Deciders**: @tommykey0925
+
+## Context
+
+resource-planner は SvelteKit (`+page.server.ts` の load + form actions) で SSR + サーバーサイド処理を完結させる **内部 RPC スタイル** のアプリ。外部公開する REST / GraphQL API は持たない。
+
+この構成で「アプリの基本設計 / API 仕様」をどう文書化するかを決めたい。選択肢:
+
+- (A) **OpenAPI** を採用し、SvelteKit form actions も「内部 API」として仕様書を書く
+- (B) **TypeScript 型 + Zod/Valibot schema** を仕様の正本にし、自然言語ドキュメントは Mermaid sequence (`docs/use-cases.md`) と ADR で補完する
+
+業界調査 (SvelteKit / Remix / Next.js Server Actions / tRPC 文化) では、内部 RPC アプリでは **(B) 型駆動** が多数派という結論。理由:
+
+- OpenAPI は HTTP request/response の **外部契約** を記述するモデル。SvelteKit form actions は `multipart/form-data` POST + `ActionFailure` or redirect という SvelteKit ランタイム前提のセマンティクスで、HTTP レイヤを直接設計するモデルではない
+- OpenAPI の主要メリット (typed SDK 生成 → 別言語クライアントへ配布) は、TS 単一言語 / 公開 API なし の本アプリでは活きない
+- スキーマ定義 + コード + コード生成ステップを全廃し、TS 型推論を **単一情報源** にしたほうが DRY、ドリフト防止になる (tRPC 流派)
+
+## Decision
+
+**OpenAPI は採用しない。** API 仕様の正本は以下とする:
+
+1. **TypeScript 型** (`web/src/lib/types.ts` 想定) — request/response の型定義
+2. **Zod / Valibot schema** — 実行時検証も兼ねる仕様 (form action の入力バリデーション)
+3. **`docs/use-cases.md`** — Mermaid sequence diagram で動的振る舞いを記述
+4. **`docs/adr/`** — 判断の経緯を残す
+5. **`docs/architecture.drawio`** — Container 図 (C4 model 準拠)
+6. **`docs/db/`** — データモデル仕様 (tbls 自動生成 + 手書き entities/access-patterns)
+
+## Consequences
+
+### Positive
+
+- **DRY**: 型 = 仕様。注釈や手書き OpenAPI を二重管理しない
+- **ドリフト不可**: TS コンパイラが型と実装の不整合を検出。`pnpm check` で半自動検証
+- **学習コスト最小**: SvelteKit の標準パターンに乗る。新規メンバーが Svelte/TS だけ覚えれば良い
+- **runtime + compile-time 両対応**: Zod/Valibot で実行時の入力検証も同じ schema でカバー
+
+### Negative
+
+- **外部 API 公開時は別途対応が必要**: 将来 SaaS 化や別言語クライアント要件が出たら、API gateway 層に OpenAPI を後付けする (現時点では先払いコストのほうが大きい)
+- **言語境界を超えて型を共有できない**: TS 単一言語前提。別言語の client が直接型を読めない
+- **stakeholder 向けの綺麗な API ドキュメント (Swagger UI 風) が無い**: 必要になったら ADR を更新して採用判断する
+
+### Neutral
+
+- ADR + Mermaid + 型 の 3 本柱を **メンテし続ける** 文化的コミットメントが必要。型は IDE が守るが、ADR / use-cases.md は手動更新。issue テンプレで AC 化することで運用コストを下げる (#31 参照)
+
+## Alternatives considered
+
+- **OpenAPI 採用 (案 A)**: 上記 Context 通り、内部 RPC モデルとセマンティクスが噛み合わない。形だけ書いても消費者がいない
+- **JSDoc / TypeDoc を主軸**: TypeDoc は型を docs 化するが、生成 docs を読む文化が小規模チームでは定着しにくい。型そのものを読ませるほうが直接的
+- **Schema-first (Zod だけで完結)**: Zod schema から型を `z.infer<>` するパターンは検討した。本 ADR と矛盾しないため、各 entity ごとに採用可 (ADR レベルでは固定しない)
+
+## References
+
+- [SvelteKit form actions discussion #9717](https://github.com/sveltejs/kit/discussions/9717) — OpenAPI と form actions の不整合議論
+- [tRPC - Move Fast and Break Nothing](https://trpc.io/) — 型 = ドキュメント哲学
+- [Type-Driven HTTP: tRPC vs OpenAPI vs RPC (Medium)](https://medium.com/@2nick2patel2/type-driven-http-trpc-vs-openapi-vs-rpc-714ab8ba2764)
+- [How to Document Architectural Decisions: ADRs and the C4 Model - Vijay Anant](https://vijayanant.com/posts/from-patterns-to-practice/documenting-your-decision/) — ADR + C4 の組み合わせ推奨
+- [architecture-decision-record (joelparkerhenderson)](https://github.com/joelparkerhenderson/architecture-decision-record) — Nygard テンプレ参照実装
+- 関連 issue: [#31](https://github.com/tommykey-apps/resource-planner/issues/31)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,42 @@
+# Architecture Decision Records (ADR)
+
+resource-planner の設計判断を Michael Nygard 形式で記録するディレクトリ。
+
+## 目的
+
+- **「なぜ」を残す**: コードと PR からは「何をしたか」しか分からない。**なぜそう決めたか / なぜ別案を採らなかったか** を後から追える形で残す
+- **引き継ぎ性**: 過去の判断の制約条件 (Azure 不可、社内ツール、TS 単一言語等) が時間とともに変わっても、当時の前提を読み返せる
+- **議論の打ち切り**: 一度決めた話題を毎回再議論しないための参照点
+
+## 命名規則
+
+- ファイル名: `NNNN-kebab-case-title.md` (例: `0001-typescript-types-as-api-spec.md`)
+- 番号は連番、欠番禁止 (Superseded されても番号は維持)
+- 1 判断 = 1 ファイル
+
+## ステータス遷移
+
+```
+Proposed → Accepted → (Deprecated | Superseded by NNNN)
+```
+
+- **Proposed**: PR レビュー中、合意前
+- **Accepted**: main にマージ済、現行の判断
+- **Deprecated**: もう従わないが、置き換え判断はまだ無い (例: 関連機能を削除)
+- **Superseded by 00NN**: 別 ADR で上書きされた。元 ADR は削除せず status だけ書き換え、新 ADR の Context で経緯を引用
+
+## 書き方
+
+[`template.md`](template.md) をコピーして使う。Nygard 形式 (Title / Status / Context / Decision / Consequences)。
+
+**重要**: Decision は「**何をしたか**」、Consequences は「**良い面・悪い面・後で困るかもしれない面**」を率直に書く。
+
+## いつ書くか
+
+- 新機能 issue の AC に「ADR 追加」が入っているとき (型駆動 docs 戦略 #31 参照)
+- コード単体では理解困難な判断をしたとき (制約・前提・トレードオフが背景にある選択)
+- 過去の判断を覆すとき (新 ADR + 旧 ADR の Status を Superseded by NNNN に更新)
+
+書かなくて良い:
+- ライブラリの bug fix、依存更新、リファクタ
+- 「明らかな選択肢が 1 つしかない」もの

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,40 @@
+# NNNN. {判断のタイトル (動詞で始める、例: "Single Table Design を採用する")}
+
+- **Status**: Proposed | Accepted | Deprecated | Superseded by [ADR-NNNN](NNNN-...)
+- **Date**: YYYY-MM-DD
+- **Deciders**: {名前 / GitHub ユーザー名}
+
+## Context
+
+{この判断が必要になった背景。前提条件、制約 (技術的・組織的・予算的)、関連する過去の判断や issue を書く。
+
+ここで「**なぜ今これを決めるのか**」が読み手に伝わるかが ADR の価値の半分。}
+
+## Decision
+
+{採った選択肢を 1〜3 文で。何をやるか、どう実装するかではなく、**どの方針を採用したか**。
+
+例: "外部 API 仕様の正本として TypeScript 型 + Zod schema を採用する。OpenAPI は採用しない。"}
+
+## Consequences
+
+### Positive
+
+- {利点を 2-4 個}
+
+### Negative
+
+- {欠点・トレードオフを 2-4 個。「いつ困るか」も書くと将来 superseded する判断材料になる}
+
+### Neutral
+
+- {影響はあるが評価不能なもの}
+
+## Alternatives considered
+
+- **{案 A}**: {採らなかった理由を 1 文}
+- **{案 B}**: {採らなかった理由を 1 文}
+
+## References
+
+- {関連 issue / PR / 外部記事 / 公式ドキュメントへのリンク}

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,0 +1,123 @@
+# Use Cases
+
+resource-planner の主要ユースケースを **Mermaid sequence diagram** で記述する。
+SvelteKit form actions / `+page.server.ts` load の動的振る舞い (画面 → action → DB → redirect/render) を「設計仕様」として残す場所。
+
+## 書き方
+
+各ユースケースは:
+
+1. **見出し**: `## UC-NN: 短い動詞句` (例: `## UC-01: アサインを作成する`)
+2. **概要**: 1-2 文
+3. **アクター / 前提条件**: 誰が / どんな状態で発火するか
+4. **対応コード**: 該当する `+page.server.ts` / form action / load 関数へのリンク (実装後に追記)
+5. **Mermaid sequence**: 動作フロー
+6. **エラーケース**: 失敗パスを箇条書き
+
+## 一覧
+
+| # | Use case | 状態 |
+|---|---|---|
+| UC-01 | [アサインを作成する](#uc-01-アサインを作成する) | サンプル (CRUD 未実装) |
+
+> **Note**: 実機能 (Resource / Project / Assignment の CRUD) はまだ未実装のため、現時点のユースケースは設計仕様としてのサンプル 1 件のみ。
+> 実装 issue が起票されるたびに、その AC で本ファイルにユースケースを追記する運用とする ([#31](https://github.com/tommykey-apps/resource-planner/issues/31), [`docs/adr/0001-typescript-types-as-api-spec.md`](adr/0001-typescript-types-as-api-spec.md) 参照)。
+
+---
+
+## UC-01: アサインを作成する
+
+### 概要
+
+リソース (人) を案件 (Project) に期間 (startDate 〜 endDate) でアサインする。タイムライン UI から開始。
+
+### アクター / 前提条件
+
+- アクター: 認証済みユーザー (`@genech.co.jp` ドメイン制限を通過)
+- 前提条件:
+  - サインイン済 (Clerk session 有効)
+  - 対象 Resource と Project が同じ組織内に存在
+  - startDate ≤ endDate (実装側で検証)
+
+### 対応コード (実装後に追記)
+
+- 画面: `web/src/routes/timeline/+page.svelte` (TODO)
+- Action: `web/src/routes/timeline/+page.server.ts` の `actions.createAssignment` (TODO)
+- 検証 schema: `web/src/lib/schemas/assignment.ts` (Zod、TODO)
+- DB アクセス: `web/src/lib/db/assignment.ts` (TODO)
+
+### Mermaid sequence
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant SK as SvelteKit (browser)
+    participant Server as +page.server.ts<br/>(Lambda)
+    participant Clerk
+    participant DDB as DynamoDB
+
+    User->>SK: フォーム入力 (resourceId,<br/>projectId, startDate, endDate)
+    SK->>Server: POST ?/createAssignment<br/>(form data)
+    Server->>Clerk: getAuth() (JWT 検証)
+    Clerk-->>Server: { userId, orgId }
+
+    Server->>Server: Zod schema で input 検証
+    alt 検証失敗
+        Server-->>SK: ActionFailure(400, { errors })
+        SK-->>User: フィールド毎にエラー表示
+    else 検証成功
+        Server->>Server: id = ulid()<br/>sk = ASN#{startDate}#{id}
+        Server->>DDB: PutItem<br/>pk=ORG#{orgId}, sk=ASN#...,<br/>ConditionExpression: attribute_not_exists(sk)
+        alt SK 衝突 (極稀)
+            DDB-->>Server: ConditionalCheckFailedException
+            Server-->>SK: ActionFailure(409, "SK conflict, retry")
+        else 成功
+            DDB-->>Server: 200
+            Server-->>SK: redirect 303 → /timeline
+            SK-->>User: タイムラインに新アサイン表示
+        end
+    end
+```
+
+### エラーケース
+
+- 未認証: Clerk の `+layout.server.ts` で `redirect(303, "/sign-in")` (本 sequence の前段で処理済)
+- クロステナント: PK は **常に server-side で session の orgId から組み立てる** (HTTP body の orgId は信用しない)。詳細は [`db/access-patterns.md` の A1](db/access-patterns.md#a1-クロステナント混入防止) 参照
+- リソース / 案件不存在: FK 制約は DDB に無いため、app 層で先に `GetItem` で存在確認するか、整合性破壊を許容するかは実装時に判断 (UC レベルでは未定)
+
+---
+
+## ユースケース追加のテンプレ
+
+新規ユースケース追加時のコピペ用:
+
+```markdown
+## UC-NN: <短い動詞句>
+
+### 概要
+1-2 文。
+
+### アクター / 前提条件
+- アクター:
+- 前提条件:
+
+### 対応コード
+- 画面:
+- Action / Loader:
+- 検証 schema:
+- DB アクセス:
+
+### Mermaid sequence
+\`\`\`mermaid
+sequenceDiagram
+    actor User
+    participant SK as SvelteKit (browser)
+    participant Server
+    participant DDB as DynamoDB
+    User->>SK: ...
+    SK->>Server: ...
+\`\`\`
+
+### エラーケース
+- ...
+```


### PR DESCRIPTION
## Summary

OpenAPI を採用せず **TypeScript 型 + Zod schema を API 仕様の正本** とする方針を ADR で明文化し、判断記録 (ADR) と動的振る舞いの記述 (use-cases) の場所を整備する。CRUD 実装と並行で書き育てる運用を **issue 起票テンプレで AC 化** することで自動化する。

## 含むもの

### ADR (`docs/adr/`)
- `README.md` — 運用ポリシー (Nygard 形式、命名 `NNNN-kebab-title.md`、ステータス遷移 Proposed→Accepted→Deprecated/Superseded)
- `template.md` — 雛形
- `0001-typescript-types-as-api-spec.md` — 初の Accepted ADR
  - Decision: OpenAPI 不採用、TS 型 + Zod を仕様の正本に。4 種 docs (構造 / なぜ / どう動く / データ) の役割分担を明文化
  - Alternatives considered: OpenAPI 採用 / TypeDoc 主軸 / Schema-first
  - References: SvelteKit Discussion #9717 / tRPC / ADR + C4 解説記事

### Use Cases (`docs/use-cases.md`)
- 主要ユースケースを Mermaid sequence diagram で記録する場所
- 書き方ガイド + 一覧テーブル + サンプル UC-01 (アサインを作成する) を骨組みで掲載
- CRUD 未実装のため対応コード行は TODO、実装 PR で逐次補完する設計

### Issue テンプレ (`.github/ISSUE_TEMPLATE/`)
- `feature.yml` — 新機能起票フォーム。AC に以下のチェックボックスを内蔵:
  - TypeScript 型 / Zod schema で input/output 契約を定義
  - `docs/use-cases.md` に Mermaid sequence を追加
  - `docs/adr/NNNN-*.md` を必要に応じて追加 (Status=Accepted)
  - 関連 ADR を Superseded by N にした (該当時)
  - `docs/db/` を必要に応じて更新 (DB アクセス変更時)
  - \`pnpm check\` / \`pnpm lint\` / \`terraform validate\` 緑
- `config.yml` — blank issue 許容、docs/ への contact link

### README
- 「設計ドキュメントの読み方」セクション追加。4 種 docs の役割分担を表で示し、新機能起票時に feature.yml を使うことを誘導

## 含まないもの (別 issue / 後追い)

- 既存の決定事項 (Single Table、Clerk dev instance、form actions 採用 等) の遡及 ADR 化 → 必要になったとき (ADR 0001 References からの参照を必要としたとき) に書く
- `docs/use-cases.md` への実機能 UC 追加 → 各 CRUD 実装 issue で AC 化
- bug fix / hotfix 用の issue テンプレ → 別 issue (頻度が見えてから)

## 受け入れ基準

- [x] feature.yml で新規 issue 起票時 AC チェックボックスが自動展開される (テンプレ書式 valid)
- [x] docs/adr/0001-*.md が Accepted で merge される
- [x] docs/use-cases.md 骨組みあり、サンプル Mermaid 含む
- [x] README から adr/ と use-cases.md にリンク

## Test plan

- [ ] reviewer: feature.yml を使って test 起票してみる (作成しなくてもプレビューで AC 表示確認)
- [ ] GitHub UI 上で docs/use-cases.md の Mermaid sequence diagram が描画される
- [ ] docs/adr/0001-*.md の Markdown が崩れずレンダリング

Closes #31