### PR TITLE
chore: 基盤層整備 (DDB client + types + Zod + ULID + adapter + repository)

### DIFF
--- a/docs/adr/0002-id-generation-with-ulid.md
+++ b/docs/adr/0002-id-generation-with-ulid.md
@@ -1,0 +1,52 @@
+# 0002. ID 生成戦略を ULID に統一する
+
+- **Status**: Accepted
+- **Date**: 2026-05-08
+- **Deciders**: @tommykey0925
+
+## Context
+
+resource-planner の domain entity (Resource / Project / Assignment) は DynamoDB Single Table Design で管理する。各 entity に一意の `id` が必要だが、選択肢はいくつかある:
+
+- UUIDv4 (16 byte ランダム、辞書順 ≠ 時系列順)
+- ULID (16 byte: 48 bit timestamp + 80 bit ランダム、辞書順 = 時系列順)
+- nanoid (任意長 URL-safe ランダム、デフォルト 21 文字 = 126 bit エントロピー)
+
+検討事項:
+- Assignment SK は `ASN#{startDate}#{id}` で startDate を SK 先頭に置くため、id 自体の sortable 性は不要
+- Resource SK / Project SK は `RES#{id}` / `PRJ#{id}` で **id がそのまま辞書順で並ぶ** → sortable id だと List 時に作成順、debug 時に時刻情報が即わかる
+- TS 単一言語、依存サイズの差は小さい
+
+## Decision
+
+**全 entity の id 生成に ULID (`ulid` npm package) を使う。** `web/src/lib/id.ts` で `newId()` を export し、repository 層から呼び出す。
+
+## Consequences
+
+### Positive
+
+- Resource / Project の SK が **辞書順 = 作成時刻順** になり、debug / 管理画面でデータを眺めるときに直感的
+- Crockford Base32 で URL-safe、case-insensitive 衝突なし
+- 衝突確率は UUIDv4 同等 (80 bit ランダム部、誕生日攻撃まで 2^40 ≒ 10^12 件で 50%)
+- 26 文字固定長で sk のフォーマット幅が予測可能
+
+### Negative
+
+- nanoid (21 文字) より 5 文字長い → アイテムサイズが微増 (DynamoDB の RCU/WCU は 1KB / 4KB 単位なので実質影響なし)
+- 「タイムスタンプを id に含む」をプライバシー側面で問題にするユースケースがある (社内ツールなので非該当)
+
+### Neutral
+
+- ulid 生成は monotonic ではない (同一 ms 内で並び順が保証されない場合あり)。今回 SK で startDate / 作成時刻順を厳密に必要とする query は無いため OK
+
+## Alternatives considered
+
+- **UUIDv4**: 最も普及しているが時系列順で並ばない。debug 時の利便性が落ちる
+- **nanoid**: より短くシンプルだが時系列情報なし。Assignment は startDate が SK 先頭にあるため利点が活きない
+- **DynamoDB の autoincrement (counter item パターン)**: マルチテナント環境で counter がボトルネックになる、衝突なしのために strong consistent read が必要、複雑性に見合わない
+
+## References
+
+- [ulid spec](https://github.com/ulid/spec)
+- [ADR 0001](0001-typescript-types-as-api-spec.md) — 本リポジトリの ADR 初号
+- 関連 issue: [#35](https://github.com/tommykey-apps/resource-planner/issues/35)

--- a/docs/adr/0003-end-date-inclusive-storage.md
+++ b/docs/adr/0003-end-date-inclusive-storage.md
@@ -1,0 +1,58 @@
+# 0003. endDate は inclusive で保存し、ResourceTimeline 境界で adapter 変換する
+
+- **Status**: Accepted
+- **Date**: 2026-05-08
+- **Deciders**: @tommykey0925
+
+## Context
+
+Assignment には `startDate` / `endDate` がある (例: 「5/1 から 5/31 まで」)。
+ところが `@tommykey-apps/ui-components` の `ResourceTimeline` は **end-exclusive** を要求する (5/1〜5/31 表示なら `endDate = new Date(2026, 5, 1)` = 6/1)。
+
+検討すべき選択肢:
+
+- (A) DB / フォーム / docs を **inclusive 統一**、ResourceTimeline 境界で `±1 day` 変換する
+- (B) DB / フォーム / docs を **exclusive 統一** (timeline と一致)
+- (C) DB は duration (`startDate + days`) で持つ
+
+人間の自然な「5/1 から 5/31」入力を内部で sentinel value (6/1) に変換するのは混乱の温床。一方、timeline ライブラリの規約は変えられない。
+
+## Decision
+
+**全層 inclusive 統一**。`endDate = "2026-05-31"` が「5/31 を含む最後の日」を意味する。
+
+ResourceTimeline 境界 (`web/src/lib/timeline-adapter.ts`) で **2 箇所だけ** ±1 day 変換する:
+
+- `toTimelineAssignment(dbAssignment, project)`: DB → timeline 形式 (`endDate += 1 day`)
+- `fromTimelineAssignment(timelineAssignment, prev)`: timeline → DB 形式 (`endDate -= 1 day`)
+
+DB 保存: `YYYY-MM-DD` string (Asia/Tokyo の暦日)。`Date.toISOString().slice(0, 10)` は UTC ベースで JST と日付がずれる可能性があるため、`web/src/lib/timeline-adapter.ts` の `formatLocalDate(d)` で自前 zero-pad 実装する。
+
+## Consequences
+
+### Positive
+
+- フォーム / DB / docs / SK の `ASN#{startDate}#{id}` が **すべて同じ意味** で書ける (人間も SQL 風 query もそのまま読める)
+- 変換ロジックは 1 ファイル 2 関数に閉じ込まる (`timeline-adapter.ts`)
+- DB クエリ `BETWEEN "ASN#2026-05-01" AND "ASN#2026-05-31"` で「5 月開始の Assignment」が直感的に取れる
+
+### Negative
+
+- ResourceTimeline に渡すたび / 受け取るたびに変換が走る (CPU コストはほぼゼロだが認知コストはあり)
+- 変換忘れ (生 DB Assignment を timeline に渡してしまう) でズレるバグが出やすい → TS 型を意図的に **DbAssignment vs TimelineAssignment** で別物にして、コンパイラに気づかせる
+- adapter 関数が 2 個に増える → 将来 timeline ライブラリ仕様変更時の影響箇所だが、import path 1 つで済む
+
+### Neutral
+
+- 終了日 input フィールドの validation は inclusive 前提 (`startDate <= endDate`)。Zod schema の `refine` で表現
+
+## Alternatives considered
+
+- **(B) exclusive 統一**: DB に `2026-06-01` を保存して 5/31 終了を表現する。timeline 変換不要だが、フォームで `2026-06-01` を入れるか自動 +1 するか議論が起き、SK の `ASN#2026-06-01#...` も人間が読み解きにくい
+- **(C) duration 化**: `startDate + days` で持つ。range filter (`startDate BETWEEN ... AND ...`) は普通にできるが、`endDate` 主体の query (例: 「5 月末までに終わるもの」) は GSI かアプリ層で計算が必要。要件に対して overengineering
+
+## References
+
+- [ResourceTimeline API (調査結果、Plan ファイル参照)](#)
+- [ADR 0001](0001-typescript-types-as-api-spec.md)
+- 関連 issue: [#35](https://github.com/tommykey-apps/resource-planner/issues/35)

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,14 @@
+# Clerk
+CLERK_SECRET_KEY_PARAM=/resource-planner/clerk-secret-key
+PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx
+ALLOWED_DOMAIN=genech.co.jp
+
+# DynamoDB
+DYNAMODB_TABLE=resource-planner
+
+# Local dev only — DynamoDB Local の使用時のみ設定
+# AWS SDK v3 は AWS_ENDPOINT_URL を自動認識する (v3.385+)
+AWS_ENDPOINT_URL=http://localhost:8000
+AWS_ACCESS_KEY_ID=local
+AWS_SECRET_ACCESS_KEY=local
+AWS_REGION=ap-northeast-1

--- a/web/package.json
+++ b/web/package.json
@@ -39,12 +39,17 @@
 		"vite": "^8.0.7"
 	},
 	"dependencies": {
+		"@aws-sdk/client-dynamodb": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1042.0",
+		"@aws-sdk/lib-dynamodb": "^3.1045.0",
 		"@tommykey-apps/ui-components": "^0.4.0",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"svelte-clerk": "^1.1.5",
+		"svelte-sonner": "^1.1.1",
 		"tailwind-merge": "^3.5.0",
-		"tailwind-variants": "^3.2.2"
+		"tailwind-variants": "^3.2.2",
+		"ulid": "^3.0.2",
+		"zod": "^4.4.3"
 	}
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.1045.0
+        version: 3.1045.0
       '@aws-sdk/client-ssm':
         specifier: ^3.1042.0
         version: 3.1042.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.1045.0
+        version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
         specifier: ^0.4.0
         version: 0.4.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -23,12 +29,21 @@ importers:
       svelte-clerk:
         specifier: ^1.1.5
         version: 1.1.5(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+      svelte-sonner:
+        specifier: ^1.1.1
+        version: 1.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
       tailwind-variants:
         specifier: ^3.2.2
         version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.4)
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.4
@@ -115,6 +130,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-dynamodb@3.1045.0':
+    resolution: {integrity: sha512-TxZmhpziFxWD3pdXGbuwntKOX5OkW14yvCITYsRz+QDM5EUL4cIygu2xRGHiKDvKmb3QUOA4yKetAQcIMLe2zw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-ssm@3.1042.0':
     resolution: {integrity: sha512-FVX73f1jsms0Ay1DSmivV/jN+unUVI/pUjR2FtbbPoj3N9VA6JZd178xN62jLpfSIN+iBuNGD9gvk3uI3AR9nA==}
     engines: {node: '>=20.0.0'}
@@ -153,6 +172,24 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/dynamodb-codec@3.973.8':
+    resolution: {integrity: sha512-dYQ/cQqHZd23hcl8oEGwPphTqyGnmvf2HrVmz4J90Q5Bv89oJjlwcBcifiiTvApqsVpx7Pr0IebMpkYwWJvZlQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/endpoint-cache@3.972.5':
+    resolution: {integrity: sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-dynamodb@3.1045.0':
+    resolution: {integrity: sha512-U8PWWu3MGrsivZz8xMuRFnaP7ir9r/GvYRcrFRek8FhndiqB8OPQTCA2e+ki+ApLuPjj1foUs+3arTVptt1QGQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1045.0
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.11':
+    resolution: {integrity: sha512-vXARCZVFQHdsd6qPPZyC/hh+5x2XsCYKqUQDCqnUlpGpChMpDojOOacQWdLJ+FFXKN8X3cmLOGrtgx/zysCKqQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.972.10':
@@ -198,6 +235,12 @@ packages:
   '@aws-sdk/util-arn-parser@3.972.3':
     resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
     engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-dynamodb@3.996.2':
+    resolution: {integrity: sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1003.0
 
   '@aws-sdk/util-endpoints@3.996.8':
     resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
@@ -401,42 +444,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -534,79 +571,66 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -890,28 +914,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -1407,28 +1427,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1468,6 +1484,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -1486,6 +1505,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1658,6 +1680,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  runed@0.28.0:
+    resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   runed@0.35.1:
     resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
     peerDependencies:
@@ -1737,6 +1764,11 @@ packages:
       svelte:
         optional: true
 
+  svelte-sonner@1.1.1:
+    resolution: {integrity: sha512-5cd3p7wa4cq0NsqslMwdlPb7x1JglEZ/GKrLePWNr5bCxR1nagAVrY01FRFrXfUGs41miLt3C327+8XJo5BzZw==}
+    peerDependencies:
+      svelte: ^5.0.0
+
   svelte-toolbelt@0.10.6:
     resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
     engines: {node: '>=18', pnpm: '>=8.7.0'}
@@ -1804,6 +1836,10 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
     hasBin: true
 
   undici-types@6.21.0:
@@ -1886,6 +1922,9 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -1913,6 +1952,53 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+
+  '@aws-sdk/client-dynamodb@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/dynamodb-codec': 3.973.8
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.11
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/client-ssm@3.1042.0':
     dependencies:
@@ -2080,6 +2166,38 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/dynamodb-codec@3.973.8':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@smithy/core': 3.23.17
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@aws-sdk/endpoint-cache@3.972.5':
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-dynamodb@3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1045.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/util-dynamodb': 3.996.2(@aws-sdk/client-dynamodb@3.1045.0)
+      '@smithy/core': 3.23.17
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.11':
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.8
@@ -2209,6 +2327,11 @@ snapshots:
 
   '@aws-sdk/util-arn-parser@3.972.3':
     dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-dynamodb@3.996.2(@aws-sdk/client-dynamodb@3.1045.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1045.0
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -3435,6 +3558,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.5
 
+  mnemonist@0.38.3:
+    dependencies:
+      obliterator: 1.6.1
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -3444,6 +3571,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
+
+  obliterator@1.6.1: {}
 
   obug@2.1.1: {}
 
@@ -3588,6 +3717,11 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  runed@0.28.0(svelte@5.55.5(@typescript-eslint/types@8.59.1)):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+
   runed@0.35.1(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)):
     dependencies:
       dequal: 2.0.3
@@ -3670,6 +3804,11 @@ snapshots:
     optionalDependencies:
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
 
+  svelte-sonner@1.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1)):
+    dependencies:
+      runed: 0.28.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+
   svelte-toolbelt@0.10.6(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)):
     dependencies:
       clsx: 2.1.1
@@ -3746,6 +3885,8 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  ulid@3.0.2: {}
+
   undici-types@6.21.0: {}
 
   uri-js@4.4.1:
@@ -3781,3 +3922,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zimmerframe@1.1.4: {}
+
+  zod@4.4.3: {}

--- a/web/src/lib/db/client.ts
+++ b/web/src/lib/db/client.ts
@@ -1,0 +1,21 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { env } from '$env/dynamic/private';
+
+if (!env.DYNAMODB_TABLE) {
+	throw new Error('DYNAMODB_TABLE env not set');
+}
+
+// AWS SDK v3 は AWS_ENDPOINT_URL を自動認識する (v3.385+)。
+// 本番 (Lambda): IAM role + env なし → 本番 DynamoDB
+// 開発 (DynamoDB Local): AWS_ENDPOINT_URL=http://localhost:8000 を .env で渡す
+const client = new DynamoDBClient({});
+
+export const ddb = DynamoDBDocumentClient.from(client, {
+	marshallOptions: {
+		// undefined を attribute から落として、空 string も無視しない (DynamoDB は空 string OK)
+		removeUndefinedValues: true
+	}
+});
+
+export const TABLE = env.DYNAMODB_TABLE;

--- a/web/src/lib/id.ts
+++ b/web/src/lib/id.ts
@@ -1,0 +1,12 @@
+import { ulid } from 'ulid';
+
+/**
+ * 新規 entity の id 生成。
+ *
+ * ULID 採用理由 (ADR 0002):
+ * - 時系列 sortable (Crockford Base32、先頭 10 文字が timestamp)
+ * - URL-safe (英数のみ、case-insensitive)
+ * - 衝突確率は UUIDv4 同等 (80 bit ランダム部)
+ * - SK にそのまま埋めると debug 時に作成順がわかる
+ */
+export const newId = (): string => ulid();

--- a/web/src/lib/repository/assignment.ts
+++ b/web/src/lib/repository/assignment.ts
@@ -1,0 +1,100 @@
+import { PutCommand, DeleteCommand, TransactWriteCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb, TABLE } from '$lib/db/client';
+import { newId } from '$lib/id';
+import { pk, assignmentSk } from './keys';
+import type { Assignment } from '$lib/types';
+import type { AssignmentCreateInput, AssignmentUpdateInput } from '$lib/schemas';
+
+export async function createAssignment(
+	orgId: string,
+	input: AssignmentCreateInput
+): Promise<Assignment> {
+	const id = newId();
+	const item: Assignment = { id, ...input };
+	await ddb.send(
+		new PutCommand({
+			TableName: TABLE,
+			Item: { pk: pk(orgId), sk: assignmentSk(input.startDate, id), ...item },
+			ConditionExpression: 'attribute_not_exists(sk)'
+		})
+	);
+	return item;
+}
+
+/**
+ * Assignment の更新は startDate 変更があると SK が変わる (ASN#{startDate}#{id})。
+ * UpdateItem では SK を変更できないため、TransactWriteItems で旧 SK Delete + 新 SK Put を原子的に実行する。
+ *
+ * @param prevStartDate - 変更前の startDate (旧 SK 計算用)
+ */
+export async function updateAssignment(
+	orgId: string,
+	prevStartDate: string,
+	input: AssignmentUpdateInput
+): Promise<void> {
+	const oldSk = assignmentSk(prevStartDate, input.id);
+	const newSk = assignmentSk(input.startDate, input.id);
+
+	if (oldSk === newSk) {
+		// SK 変更なし → 通常 Put で上書き
+		await ddb.send(
+			new PutCommand({
+				TableName: TABLE,
+				Item: {
+					pk: pk(orgId),
+					sk: newSk,
+					id: input.id,
+					resourceId: input.resourceId,
+					projectId: input.projectId,
+					startDate: input.startDate,
+					endDate: input.endDate
+				},
+				ConditionExpression: 'attribute_exists(sk)'
+			})
+		);
+		return;
+	}
+
+	// SK 変更あり → 旧 Delete + 新 Put を原子的に
+	await ddb.send(
+		new TransactWriteCommand({
+			TransactItems: [
+				{
+					Delete: {
+						TableName: TABLE,
+						Key: { pk: pk(orgId), sk: oldSk },
+						ConditionExpression: 'attribute_exists(sk)'
+					}
+				},
+				{
+					Put: {
+						TableName: TABLE,
+						Item: {
+							pk: pk(orgId),
+							sk: newSk,
+							id: input.id,
+							resourceId: input.resourceId,
+							projectId: input.projectId,
+							startDate: input.startDate,
+							endDate: input.endDate
+						},
+						ConditionExpression: 'attribute_not_exists(sk)'
+					}
+				}
+			]
+		})
+	);
+}
+
+export async function deleteAssignment(
+	orgId: string,
+	startDate: string,
+	id: string
+): Promise<void> {
+	await ddb.send(
+		new DeleteCommand({
+			TableName: TABLE,
+			Key: { pk: pk(orgId), sk: assignmentSk(startDate, id) }
+		})
+	);
+}

--- a/web/src/lib/repository/index.ts
+++ b/web/src/lib/repository/index.ts
@@ -1,0 +1,55 @@
+import { QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb, TABLE } from '$lib/db/client';
+import { pk, SK_PREFIX } from './keys';
+import type { OrgData, Resource, Project, Assignment } from '$lib/types';
+
+export * from './resource';
+export * from './project';
+export * from './assignment';
+
+/**
+ * 組織内の全データ (Resource / Project / Assignment) を 1 query で取得する。
+ *
+ * Single Table Design のため `Query(pk = ORG#X)` だけで 3 entity が混在で返る。
+ * SK プレフィックスで振り分けて返す (access-patterns.md UC #1)。
+ */
+export async function queryAllByOrg(orgId: string): Promise<OrgData> {
+	const data: OrgData = { resources: [], projects: [], assignments: [] };
+	let lastKey: Record<string, unknown> | undefined;
+
+	do {
+		const out = await ddb.send(
+			new QueryCommand({
+				TableName: TABLE,
+				KeyConditionExpression: 'pk = :pk',
+				ExpressionAttributeValues: { ':pk': pk(orgId) },
+				ExclusiveStartKey: lastKey
+			})
+		);
+
+		for (const item of out.Items ?? []) {
+			const sk = item.sk as string;
+			if (sk.startsWith(SK_PREFIX.resource)) {
+				data.resources.push({ id: item.id, name: item.name } as Resource);
+			} else if (sk.startsWith(SK_PREFIX.project)) {
+				data.projects.push({
+					id: item.id,
+					name: item.name,
+					color: item.color
+				} as Project);
+			} else if (sk.startsWith(SK_PREFIX.assignment)) {
+				data.assignments.push({
+					id: item.id,
+					resourceId: item.resourceId,
+					projectId: item.projectId,
+					startDate: item.startDate,
+					endDate: item.endDate
+				} as Assignment);
+			}
+		}
+
+		lastKey = out.LastEvaluatedKey;
+	} while (lastKey);
+
+	return data;
+}

--- a/web/src/lib/repository/keys.ts
+++ b/web/src/lib/repository/keys.ts
@@ -1,0 +1,21 @@
+/**
+ * DynamoDB Single Table Design のキー組立 (entities.md / access-patterns.md 参照)。
+ *
+ * - pk: ORG#{orgId}
+ * - sk: RES#{id} | PRJ#{id} | ASN#{startDate}#{id}
+ *
+ * **必ず server side で組み立てる**。HTTP body の orgId を信用しない (クロステナント混入防止、
+ * docs/db/access-patterns.md A1 参照)。
+ */
+
+export const SK_PREFIX = {
+	resource: 'RES#',
+	project: 'PRJ#',
+	assignment: 'ASN#'
+} as const;
+
+export const pk = (orgId: string) => `ORG#${orgId}`;
+export const resourceSk = (id: string) => `${SK_PREFIX.resource}${id}`;
+export const projectSk = (id: string) => `${SK_PREFIX.project}${id}`;
+export const assignmentSk = (startDate: string, id: string) =>
+	`${SK_PREFIX.assignment}${startDate}#${id}`;

--- a/web/src/lib/repository/project.ts
+++ b/web/src/lib/repository/project.ts
@@ -1,0 +1,42 @@
+import { PutCommand, UpdateCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb, TABLE } from '$lib/db/client';
+import { newId } from '$lib/id';
+import { pk, projectSk } from './keys';
+import type { Project } from '$lib/types';
+import type { ProjectCreateInput, ProjectUpdateInput } from '$lib/schemas';
+
+export async function createProject(orgId: string, input: ProjectCreateInput): Promise<Project> {
+	const id = newId();
+	const item: Project = { id, name: input.name, color: input.color };
+	await ddb.send(
+		new PutCommand({
+			TableName: TABLE,
+			Item: { pk: pk(orgId), sk: projectSk(id), ...item },
+			ConditionExpression: 'attribute_not_exists(sk)'
+		})
+	);
+	return item;
+}
+
+export async function updateProject(orgId: string, input: ProjectUpdateInput): Promise<void> {
+	await ddb.send(
+		new UpdateCommand({
+			TableName: TABLE,
+			Key: { pk: pk(orgId), sk: projectSk(input.id) },
+			UpdateExpression: 'SET #name = :name, color = :color',
+			ExpressionAttributeNames: { '#name': 'name' },
+			ExpressionAttributeValues: { ':name': input.name, ':color': input.color },
+			ConditionExpression: 'attribute_exists(sk)'
+		})
+	);
+}
+
+export async function deleteProject(orgId: string, id: string): Promise<void> {
+	// 関連 Assignment の cascade は PR-H で実装。
+	await ddb.send(
+		new DeleteCommand({
+			TableName: TABLE,
+			Key: { pk: pk(orgId), sk: projectSk(id) }
+		})
+	);
+}

--- a/web/src/lib/repository/resource.ts
+++ b/web/src/lib/repository/resource.ts
@@ -1,0 +1,42 @@
+import { PutCommand, UpdateCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+import { ddb, TABLE } from '$lib/db/client';
+import { newId } from '$lib/id';
+import { pk, resourceSk } from './keys';
+import type { Resource } from '$lib/types';
+import type { ResourceCreateInput, ResourceUpdateInput } from '$lib/schemas';
+
+export async function createResource(orgId: string, input: ResourceCreateInput): Promise<Resource> {
+	const id = newId();
+	const item: Resource = { id, name: input.name };
+	await ddb.send(
+		new PutCommand({
+			TableName: TABLE,
+			Item: { pk: pk(orgId), sk: resourceSk(id), ...item },
+			ConditionExpression: 'attribute_not_exists(sk)'
+		})
+	);
+	return item;
+}
+
+export async function updateResource(orgId: string, input: ResourceUpdateInput): Promise<void> {
+	await ddb.send(
+		new UpdateCommand({
+			TableName: TABLE,
+			Key: { pk: pk(orgId), sk: resourceSk(input.id) },
+			UpdateExpression: 'SET #name = :name',
+			ExpressionAttributeNames: { '#name': 'name' },
+			ExpressionAttributeValues: { ':name': input.name },
+			ConditionExpression: 'attribute_exists(sk)'
+		})
+	);
+}
+
+export async function deleteResource(orgId: string, id: string): Promise<void> {
+	// 関連 Assignment の cascade は PR-H で実装。ここでは Resource 単体だけ削除。
+	await ddb.send(
+		new DeleteCommand({
+			TableName: TABLE,
+			Key: { pk: pk(orgId), sk: resourceSk(id) }
+		})
+	);
+}

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -1,0 +1,62 @@
+import { z } from 'zod';
+
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD 形式で入力してください');
+
+const colorString = z.string().regex(/^#[0-9a-fA-F]{6}$/, '#RRGGBB 形式で入力してください');
+
+// ── Resource ────────────────────────────────────────────────────────
+
+export const resourceCreateSchema = z.object({
+	name: z.string().min(1, '必須').max(100, '100 文字以内')
+});
+
+export const resourceUpdateSchema = resourceCreateSchema.extend({
+	id: z.string().min(1)
+});
+
+export type ResourceCreateInput = z.infer<typeof resourceCreateSchema>;
+export type ResourceUpdateInput = z.infer<typeof resourceUpdateSchema>;
+
+// ── Project ─────────────────────────────────────────────────────────
+
+export const projectCreateSchema = z.object({
+	name: z.string().min(1, '必須').max(100, '100 文字以内'),
+	color: colorString
+});
+
+export const projectUpdateSchema = projectCreateSchema.extend({
+	id: z.string().min(1)
+});
+
+export type ProjectCreateInput = z.infer<typeof projectCreateSchema>;
+export type ProjectUpdateInput = z.infer<typeof projectUpdateSchema>;
+
+// ── Assignment ──────────────────────────────────────────────────────
+
+export const assignmentCreateSchema = z
+	.object({
+		resourceId: z.string().min(1),
+		projectId: z.string().min(1),
+		startDate: dateString,
+		endDate: dateString
+	})
+	.refine((v) => v.startDate <= v.endDate, {
+		message: '終了日は開始日以降にしてください',
+		path: ['endDate']
+	});
+
+export const assignmentUpdateSchema = z
+	.object({
+		id: z.string().min(1),
+		resourceId: z.string().min(1),
+		projectId: z.string().min(1),
+		startDate: dateString,
+		endDate: dateString
+	})
+	.refine((v) => v.startDate <= v.endDate, {
+		message: '終了日は開始日以降にしてください',
+		path: ['endDate']
+	});
+
+export type AssignmentCreateInput = z.infer<typeof assignmentCreateSchema>;
+export type AssignmentUpdateInput = z.infer<typeof assignmentUpdateSchema>;

--- a/web/src/lib/timeline-adapter.ts
+++ b/web/src/lib/timeline-adapter.ts
@@ -1,0 +1,64 @@
+import type { Assignment as DbAssignment, DateString } from './types';
+import type { Assignment as TimelineAssignment } from '@tommykey-apps/ui-components';
+
+/**
+ * DB 保存形式 (inclusive YYYY-MM-DD) と ResourceTimeline 形式 (Date / end-exclusive) を相互変換する。
+ *
+ * ADR 0003 参照:
+ * - DB / フォーム / use-cases docs はすべて inclusive 統一
+ * - ResourceTimeline は end-exclusive ライブラリ規約 → 境界でのみ ±1 day 変換
+ */
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** YYYY-MM-DD (Asia/Tokyo) から、その日の 0:00 ローカルを表す Date を作る。 */
+export function parseLocalDate(s: DateString): Date {
+	const [y, m, d] = s.split('-').map(Number);
+	return new Date(y, m - 1, d);
+}
+
+/**
+ * Date を Asia/Tokyo の YYYY-MM-DD に変換する。
+ * `Date.toISOString().slice(0, 10)` は UTC ベースで JST と日付がずれることがあるため自前実装。
+ */
+export function formatLocalDate(d: Date): DateString {
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, '0');
+	const day = String(d.getDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}
+
+/**
+ * DB Assignment + 関連 Project の color/label を ResourceTimeline 用に compose。
+ * timeline は Project entity を知らないため、app 層で帯の見た目を決めて渡す。
+ */
+export function toTimelineAssignment(
+	a: DbAssignment,
+	project: { name: string; color: string } | undefined
+): TimelineAssignment {
+	const end = parseLocalDate(a.endDate);
+	end.setDate(end.getDate() + 1); // inclusive → end-exclusive
+	return {
+		id: a.id,
+		resourceId: a.resourceId,
+		startDate: parseLocalDate(a.startDate),
+		endDate: end,
+		label: project?.name,
+		color: project?.color
+	};
+}
+
+/**
+ * ResourceTimeline の onMove / onResize 引数を DB 形式に戻す。
+ * timeline は projectId を持たないため、変更前の DbAssignment と merge して projectId を保持する。
+ */
+export function fromTimelineAssignment(t: TimelineAssignment, prev: DbAssignment): DbAssignment {
+	const end = new Date(t.endDate);
+	end.setDate(end.getDate() - 1); // end-exclusive → inclusive
+	return {
+		...prev,
+		resourceId: t.resourceId,
+		startDate: formatLocalDate(t.startDate),
+		endDate: formatLocalDate(end)
+	};
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,0 +1,39 @@
+/**
+ * resource-planner の domain 型。
+ *
+ * - DB 保存形式: pk = ORG#{orgId}, sk = (RES|PRJ|ASN)#... + entity attribute。
+ * - endDate / startDate は **inclusive** な YYYY-MM-DD string (ADR 0003)。
+ * - id は ULID (ADR 0002)。
+ *
+ * ResourceTimeline 用の型は `@tommykey-apps/ui-components` から import し、
+ * 境界で `web/src/lib/timeline-adapter.ts` で変換する (DB 形式と timeline 形式を混ぜない)。
+ */
+
+/** YYYY-MM-DD (inclusive)。Asia/Tokyo の暦日。 */
+export type DateString = string;
+
+export interface Resource {
+	id: string;
+	name: string;
+}
+
+export interface Project {
+	id: string;
+	name: string;
+	color: string; // #RRGGBB
+}
+
+export interface Assignment {
+	id: string;
+	resourceId: string;
+	projectId: string;
+	startDate: DateString;
+	endDate: DateString; // inclusive
+}
+
+/** `+layout.server.ts` の load が返す形 (entity 別に振り分け済み)。 */
+export interface OrgData {
+	resources: Resource[];
+	projects: Project[];
+	assignments: Assignment[];
+}


### PR DESCRIPTION
## Summary

CRUD 実装フェーズの土台 (実機能 0、配線のみ)。後続 PR-B 〜 PR-H + Orphan PR はすべてこの基盤に乗る。
[実装プラン (`/home/tommykey0925/.claude/plans/issue-burnnote-url-shortener-velvety-koala.md`)](#) と [ADR 0001](https://github.com/tommykey-apps/resource-planner/blob/main/docs/adr/0001-typescript-types-as-api-spec.md) の方針 (型 + Zod = API 仕様の正本) に従う。

## 含むもの

### 依存追加
- `@aws-sdk/client-dynamodb`, `@aws-sdk/lib-dynamodb` (DynamoDBDocumentClient)
- `zod` (input validation)
- `ulid` (ID 生成、ADR 0002)
- `svelte-sonner` (PR-F の optimistic UI revert 通知用、本 PR では未使用だが先行追加)

### 新規ファイル
- `web/.env.example` — CLERK / DYNAMODB / AWS LOCAL を網羅
- `web/src/lib/db/client.ts` — DynamoDBDocumentClient シングルトン (AWS_ENDPOINT_URL 自動認識、`removeUndefinedValues: true`)
- `web/src/lib/types.ts` — Resource / Project / Assignment / OrgData (DB 形式 = inclusive endDate)
- `web/src/lib/schemas/index.ts` — Zod schema、`refine` で `startDate <= endDate` をバリデート
- `web/src/lib/id.ts` — `newId = ulid` (Resource / Project の SK 辞書順 = 作成順、ADR 0002)
- `web/src/lib/timeline-adapter.ts` — `to/fromTimelineAssignment` で inclusive ↔ exclusive ±1 day、`formatLocalDate` (Asia/Tokyo 自前実装で UTC ズレ回避)
- `web/src/lib/repository/keys.ts` — pk / sk 組立 (server-side 専用、HTTP body の orgId は信用しない)
- `web/src/lib/repository/{resource,project,assignment}.ts` — CRUD 関数
  - Assignment 更新は startDate 変更で SK が変わる → `TransactWriteCommand` で旧 Delete + 新 Put を原子的に
  - cascade delete は PR-H で実装
- `web/src/lib/repository/index.ts` — `queryAllByOrg(orgId)` で 1 query 全件取得 + SK プレフィックスで振り分け (pagination 対応)
- `docs/adr/0002-id-generation-with-ulid.md` — ULID 採用判断、Alternatives (UUIDv4 / nanoid / counter) 併記
- `docs/adr/0003-end-date-inclusive-storage.md` — inclusive 統一 + adapter 変換、Alternatives (exclusive / duration) 併記

## 含まないもの (別 PR)
- `+layout.server.ts` の load 改修 → PR-B
- shadcn-svelte の Dialog / Form / Sheet → PR-C で着手
- form actions / +server.ts ハンドラ → 各 UC PR で
- Clerk Org 必須 ON 切替 (Clerk dashboard 操作) → PR-B 着手前にユーザー手動

## 検証

- [x] `pnpm check` 緑 (1181 ファイル、0 errors / 0 warnings)
- [x] `pnpm build` 緑 (Lambda container bundle、SvelteKit adapter-node)
- [x] ADR 0002 / 0003 が Accepted ステータス
- [x] `web/.env.example` に必要な env 網羅
- [x] 既存 `+page.svelte` のモック表示は変更なし (regression なし)

## Test plan

- [ ] reviewer: `web/src/lib/repository/index.ts` の `queryAllByOrg` の SK プレフィックス振り分けロジック確認
- [ ] reviewer: ADR 0002 / 0003 の Decision / Consequences が妥当か
- [ ] CI: build-web / terraform-plan が緑

## Notes
- `pnpm format` が pre-existing ファイル (button.svelte 等) を整形するが Surgical Changes 原則で本 PR では含めず。別 issue 案件
- `pnpm lint` は `web/.gitignore` 不在で pre-existing エラー (CI の `pnpm check` には影響しない)。別 issue 案件

Closes #35