### PR TITLE
feat(layout): 組織内全データを +layout.server.ts で 1 query 取得

### DIFF
--- a/web/src/lib/db/client.ts
+++ b/web/src/lib/db/client.ts
@@ -1,8 +1,11 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { building } from '$app/environment';
 import { env } from '$env/dynamic/private';
 
-if (!env.DYNAMODB_TABLE) {
+// SvelteKit の `analyse` ステップ (postbuild) はサーバーモジュールを top-level 評価するため、
+// build 中は env チェックをスキップする (Lambda 実行時にのみ env が揃う)。
+if (!building && !env.DYNAMODB_TABLE) {
 	throw new Error('DYNAMODB_TABLE env not set');
 }
 
@@ -18,4 +21,4 @@ export const ddb = DynamoDBDocumentClient.from(client, {
 	}
 });
 
-export const TABLE = env.DYNAMODB_TABLE;
+export const TABLE = env.DYNAMODB_TABLE!;

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -1,6 +1,29 @@
+import { error } from '@sveltejs/kit';
 import { buildClerkProps } from 'svelte-clerk/server';
+import { queryAllByOrg } from '$lib/repository';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = ({ locals }) => {
-	return { ...buildClerkProps(locals.auth()) };
+export const load: LayoutServerLoad = async ({ locals }) => {
+	const auth = locals.auth();
+
+	// 未認証は +layout.svelte の <RedirectToSignIn /> で誘導されるため、ここでは
+	// orgId が無いケースのみハンドリング (ADR 0001 + plan ファイル UC 確定事項:
+	// Clerk Org 必須 ON 前提)。
+	if (auth.userId && !auth.orgId) {
+		// Org 未所属 / 未選択の場合。Clerk Account Portal で Org を作成 / 選択して再ログインさせる。
+		// メッセージは +error.svelte (Orphan PR) で UI 化予定。
+		error(
+			403,
+			'組織が選択されていません。Clerk の Account Portal から組織を作成または選択してください。'
+		);
+	}
+
+	const data = auth.orgId
+		? await queryAllByOrg(auth.orgId)
+		: { resources: [], projects: [], assignments: [] };
+
+	return {
+		...buildClerkProps(auth),
+		...data
+	};
 };

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -3,54 +3,41 @@
 		ResourceTimeline,
 		TimelineToolbar,
 		ZOOMS,
-		type Assignment,
-		type Resource
+		type Assignment as TimelineAssignment
 	} from '@tommykey-apps/ui-components';
+	import { toTimelineAssignment, fromTimelineAssignment } from '$lib/timeline-adapter';
+	import type { Assignment as DbAssignment } from '$lib/types';
+	import type { PageData } from './$types';
 
-	const resources: Resource[] = [
-		{ id: 'tanaka', name: '田中 太郎' },
-		{ id: 'suzuki', name: '鈴木 花子' },
-		{ id: 'sato', name: '佐藤 一郎' },
-		{ id: 'takahashi', name: '高橋 二郎' }
-	];
+	let { data }: { data: PageData } = $props();
 
-	let assignments = $state<Assignment[]>([
-		{
-			id: 'a1',
-			resourceId: 'tanaka',
-			startDate: new Date(2026, 4, 4),
-			endDate: new Date(2026, 4, 15),
-			label: 'A社 案件',
-			color: '#4f46e5'
-		},
-		{
-			id: 'a2',
-			resourceId: 'suzuki',
-			startDate: new Date(2026, 4, 4),
-			endDate: new Date(2026, 4, 22),
-			label: 'B社 PoC',
-			color: '#10b981'
-		},
-		{
-			id: 'a3',
-			resourceId: 'sato',
-			startDate: new Date(2026, 4, 11),
-			endDate: new Date(2026, 4, 25),
-			label: '社内ツール',
-			color: '#f59e0b'
-		},
-		{
-			id: 'a4',
-			resourceId: 'takahashi',
-			startDate: new Date(2026, 4, 4),
-			endDate: new Date(2026, 5, 8),
-			label: 'D社 長期',
-			color: '#ef4444'
-		}
-	]);
+	// DB 形式のアサインを source of truth として保持。
+	// timeline 形式 (end-exclusive Date) は $derived で都度 compose する。
+	// data.assignments は load 再実行 (invalidateAll 後など) で更新されるため $effect で再同期。
+	let dbAssignments = $state<DbAssignment[]>([]);
+	$effect(() => {
+		dbAssignments = data.assignments;
+	});
 
-	let viewportStart = $state(new Date(2026, 4, 4));
+	const resources = $derived(data.resources);
+	const projects = $derived(data.projects);
+	const projectMap = $derived(new Map(projects.map((p) => [p.id, p])));
+
+	const timelineAssignments = $derived(
+		dbAssignments.map((a) => toTimelineAssignment(a, projectMap.get(a.projectId)))
+	);
+
+	let viewportStart = $state(new Date());
 	let zoom = $state(ZOOMS.day);
+
+	function handleUpdate(updated: TimelineAssignment) {
+		// PR-F で +server.ts API への fetch + optimistic UI revert を追加予定。
+		// 現状は in-memory のみ (リロードで消える)。
+		const prev = dbAssignments.find((a) => a.id === updated.id);
+		if (!prev) return;
+		const next = fromTimelineAssignment(updated, prev);
+		dbAssignments = dbAssignments.map((a) => (a.id === next.id ? next : a));
+	}
 </script>
 
 <main>
@@ -74,15 +61,11 @@
 
 	<ResourceTimeline
 		{resources}
-		{assignments}
+		assignments={timelineAssignments}
 		bind:viewportStart
 		{zoom}
-		onMove={(updated) => {
-			assignments = assignments.map((a) => (a.id === updated.id ? updated : a));
-		}}
-		onResize={(updated) => {
-			assignments = assignments.map((a) => (a.id === updated.id ? updated : a));
-		}}
+		onMove={handleUpdate}
+		onResize={handleUpdate}
 	/>
 </main>
 


### PR DESCRIPTION
## Summary

- `+layout.server.ts`: `queryAllByOrg(orgId)` で Resource / Project / Assignment を 1 query 取得して `+page.svelte` に渡す
- `+page.svelte`: mock データを削除、`toTimelineAssignment` adapter で end-exclusive Date に変換 (ADR 0003)
- `db/client.ts`: SvelteKit `analyse` ステップ中の throw を `building` フラグで skip (Lambda 実行時のみ env 検証)

## サプライズ対処メモ

PR-A 時点では `+layout.server.ts` が `$lib/db/client.ts` を import していなかったため、`if (!env.DYNAMODB_TABLE) throw` が build (`analyse` step) で発火しなかった。PR-B で import チェーンが繋がって初めて発覚。`$app/environment` の `building` フラグで build 中はスキップ、Lambda 実行時のみ throw する標準パターンに修正。

> **Note**: `hooks.server.ts` も同パターンで throw しているが、SvelteKit の `analyse` は hooks を対象外にしているらしく現状 build は通る。Surgical changes 原則で本 PR では触らない (将来の SvelteKit 仕様変更で問題になったら別 PR で同様に `building` ガードを追加)。

## ⚠️ merge 前の手動作業

- [ ] **Clerk dashboard で Organizations 必須を ON に切り替える**
  - Settings > Organizations > "Organization required" を ON
  - 既存ユーザーが Org 未所属なら Account Portal で Org 作成案内が出る
- [ ] (任意) 自分のアカウント用に Org を 1 つ作っておく (動作確認用)

## 検証

- [x] `pnpm check` 緑 (1181 ファイル、0 errors / 0 warnings)
- [x] `pnpm build` 緑 (env 未設定でも analyse 通る)
- [x] regression なし (drag/resize で in-memory state は引き続き動く)
- [ ] (merge 後) サインイン済 + Org 設定済 → 空 timeline 表示 (CRUD 未実装のため資源 0 件、PR-C で人追加 → 行追加できるようになる)
- [ ] (merge 後) Org 未設定 → 403 ページ表示 (UI polish は Orphan PR で)

## Test plan

- [ ] CI: build-web / terraform-plan が緑
- [ ] reviewer: `+layout.server.ts` の orgId ガード + repository 呼び出し確認
- [ ] reviewer: `+page.svelte` の `$effect` で data → dbAssignments 再同期パターンが Svelte 5 流儀として OK か

Closes #37