### PR TITLE
fix(ci): pnpm.ignoredBuiltDependencies で @clerk/shared を許容、CD の Docker build 失敗を解消

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -51,5 +51,10 @@
 		"tailwind-variants": "^3.2.2",
 		"ulid": "^3.0.2",
 		"zod": "^4.4.3"
+	},
+	"pnpm": {
+		"ignoredBuiltDependencies": [
+			"@clerk/shared"
+		]
 	}
 }


### PR DESCRIPTION
## Summary

CD (`.github/workflows/cd.yaml` の `deploy-web`) が **直近 7 回連続失敗** していた問題を解消。原因は **pnpm 10 のデフォルト挙動 + 非 TTY (Docker) 環境** で `[ERR_PNPM_IGNORED_BUILDS]` が fatal error になることだった。

## 根本原因

- pnpm v10 から build scripts はデフォルト無効 (セキュリティ理由)
- `Ignored build scripts` メッセージは:
  - **Interactive (TTY)**: warning (継続)
  - **Non-interactive (CI / Docker)**: fatal error (exit 1)
- `@clerk/shared@4.8.3` (svelte-clerk の transitive dep) に build script があり未承認のため、Docker `prod-deps` stage で `pnpm install --frozen-lockfile --prod` が exit 1 で失敗

CI (`build-web`) は `pnpm check` / `pnpm build` を直接走らせる構成で Dockerfile を経由しないため、PR 段階では検知できていなかった (CI 緑のまま CD だけ赤)。

## 修正内容

`web/package.json` に追加:

```json
"pnpm": {
  "ignoredBuiltDependencies": ["@clerk/shared"]
}
```

`@clerk/shared` の postinstall script は本アプリでは不要 (svelte-clerk のランタイム動作・ビルドには影響なし)。

## 検証

- [x] ローカル `pnpm install`: warning なしで完了
- [x] 隔離環境で `pnpm install --frozen-lockfile --prod` (Docker `prod-deps` stage と同じ条件) 実行、`[ERR_PNPM_IGNORED_BUILDS]` なしで成功
- [x] `pnpm check` 緑 (1658 ファイル、0 errors / 0 warnings)
- [ ] (merge 後) CD `deploy-web` ジョブが成功し Lambda update 完走する

## 副次対策 (別 issue 候補)

PR 段階で CD 失敗を検知できるよう、CI に Docker build smoke test を追加する案 (Buildx で Dockerfile を実ビルドして失敗検知のみ、push しない)。本 PR では対象外。

## なぜ早く気付かなかったか

- CI の `build-web` ジョブは Dockerfile を経由しない構成だった
- merge queue は CI 通過のみで判定、CD は post-merge 実行
- CD 失敗 → 通知設定なし → 気付かず累積 7 回失敗

→ 「PR 段階で Docker build を smoke test に含める」改善は別 issue 化推奨。

Closes #49