### PR TITLE
fix(ci): packageManager pin + onlyBuiltDependencies で CD の Docker build を再修正

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
+	"packageManager": "pnpm@10.13.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",
@@ -53,7 +54,7 @@
 		"zod": "^4.4.3"
 	},
 	"pnpm": {
-		"ignoredBuiltDependencies": [
+		"onlyBuiltDependencies": [
 			"@clerk/shared"
 		]
 	}


### PR DESCRIPTION
## Summary

PR #50 (`ignoredBuiltDependencies` 追加) でも CD が失敗継続していた問題の **再修正**。

## 原因

調査の結果:
- `pnpm view pnpm version` で確認すると **最新は v11.0.8** (npm registry の `latest` tag)
- ローカル env は v10.13.1
- CD の Docker は `corepack enable pnpm` で **最新版を pickup → 内部的に v11 系**
- v11 では `ignoredBuiltDependencies` の挙動が変わった可能性、ERR_PNPM_IGNORED_BUILDS が解消せず
- そもそも PR #50 のローカルテストは v10.13.1 で行ったため通っていた

## 修正

`web/package.json`:

1. **`"packageManager": "pnpm@10.13.1"`** を追加
   - corepack が必ず v10.13.1 を使用 (Docker でもローカルでも同じ)
2. **`ignoredBuiltDependencies` → `onlyBuiltDependencies: ["@clerk/shared"]`** に変更
   - pnpm 公式 docs に明示記載 (whitelist 形式)
   - `@clerk/shared` の postinstall script (`node ./scripts/postinstall.mjs`) を許容して実行
   - postinstall は害のない script (TypeScript 型生成等) で、走らせる方が本来の挙動に近い

## 検証

- [x] ローカル `pnpm install` 緑 (v10.13.1)
- [x] 隔離環境 `pnpm install --frozen-lockfile --prod` 緑 (Docker と同じ条件)
- [x] `pnpm check` 緑
- [ ] (merge 後) CD `deploy-web` 成功

## 副次対策 (今回の教訓)

- `pnpm view pnpm version` が npm registry を直接見るので、ローカル v10.13.1 と registry latest v11 のずれを確認できた。今後 CD 失敗時はまず両方確認
- `packageManager` field を pin したので、今後 corepack 経由のバージョン違いは発生しない
- 将来 pnpm v11 系に移行する判断は別途 ADR で

Refs #49