### PR TITLE
fix(docs): head-custom.html のコメントから Liquid タグ風記述を完全除去

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,16 +1,17 @@
 <!--
   Mermaid render for GitHub Pages.
 
-  jekyll-theme-cayman の `_layouts/default.html` が `{% include head-custom.html %}` を hook するため、
-  ここに <script> を inject すれば全ページの <head> に挿入される。
+  jekyll-theme-cayman の _layouts/default.html が head-custom.html を include する hook を
+  持っているため、ここに script を inject すれば全ページの <head> に挿入される。
 
-  ` ```mermaid ` で書かれた markdown コードブロックは kramdown により
-  `<pre><code class="language-mermaid">...</code></pre>` に変換される。
-  これを `<div class="mermaid">` に置換した上で `mermaid.run()` で SVG 描画。
+  Markdown のコードブロック (3 backtick + mermaid 言語指定) は kramdown により
+  pre > code.language-mermaid に変換される。これを div.mermaid に置換した上で
+  mermaid.run() で SVG 描画。
 
-  注: script 全体を `{% raw %}` `{% endraw %}` で囲むこと。JavaScript の `{`/`}` を Liquid に
-  Liquid タグと誤認させないため (誤認すると _layouts/default.html で
-  `Liquid Exception: stack level too deep` エラーになる)。
+  重要: このコメント内には Liquid タグ風の記述 (波括弧 + パーセント) を一切書かないこと。
+  Liquid は HTML コメントを認識しないため、コメント内の Liquid タグも実行される。
+  特に include 文をコメント内に書くと自分自身を recursive include して
+  「stack level too deep」または「raw tag was never closed」エラーになる。
 -->
 {%- raw -%}
 <script type="module">


### PR DESCRIPTION
PR #60 で Pages build 失敗継続。原因: head-custom.html 内のコメントに書いた `{% include head-custom.html %}` 等が **Liquid に実 タグとして実行され**、自分自身を recursive include していた。

Liquid は HTML コメントを認識しないため、コメント内のテンプレートタグも普通にパース / 実行される。

修正:
- コメントから Liquid タグ風記述 (波括弧パーセント) を全削除
- raw タグペアは script を囲む 1 ペアのみに限定
- 「コメント内に Liquid タグを書くな」警告を本文として追記

Refs #57