### PR TITLE
test: 純粋関数 backfill (schemas / timeline-adapter)

### DIFF
--- a/web/src/lib/schemas/index.test.ts
+++ b/web/src/lib/schemas/index.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import {
+	assignmentApiUpdateSchema,
+	assignmentCreateSchema,
+	assignmentUpdateSchema,
+	projectCreateSchema,
+	projectUpdateSchema,
+	resourceCreateSchema,
+	resourceUpdateSchema
+} from './index';
+
+describe('resourceCreateSchema', () => {
+	it('accepts a valid name', () => {
+		expect(resourceCreateSchema.safeParse({ name: 'Alice' }).success).toBe(true);
+	});
+
+	it('rejects empty name', () => {
+		const r = resourceCreateSchema.safeParse({ name: '' });
+		expect(r.success).toBe(false);
+	});
+
+	it('rejects name longer than 100 chars', () => {
+		const r = resourceCreateSchema.safeParse({ name: 'a'.repeat(101) });
+		expect(r.success).toBe(false);
+	});
+
+	it('accepts name of exactly 100 chars', () => {
+		expect(resourceCreateSchema.safeParse({ name: 'a'.repeat(100) }).success).toBe(true);
+	});
+});
+
+describe('resourceUpdateSchema', () => {
+	it('requires id in addition to name', () => {
+		expect(resourceUpdateSchema.safeParse({ name: 'Alice' }).success).toBe(false);
+		expect(resourceUpdateSchema.safeParse({ id: 'r1', name: 'Alice' }).success).toBe(true);
+	});
+
+	it('rejects empty id', () => {
+		expect(resourceUpdateSchema.safeParse({ id: '', name: 'Alice' }).success).toBe(false);
+	});
+});
+
+describe('projectCreateSchema', () => {
+	it('accepts a valid name + color', () => {
+		expect(projectCreateSchema.safeParse({ name: 'P1', color: '#abcdef' }).success).toBe(true);
+		expect(projectCreateSchema.safeParse({ name: 'P1', color: '#ABCDEF' }).success).toBe(true);
+		expect(projectCreateSchema.safeParse({ name: 'P1', color: '#000000' }).success).toBe(true);
+	});
+
+	it('rejects color without leading #', () => {
+		expect(projectCreateSchema.safeParse({ name: 'P1', color: 'abcdef' }).success).toBe(false);
+	});
+
+	it('rejects color with shorthand 3-digit form', () => {
+		expect(projectCreateSchema.safeParse({ name: 'P1', color: '#abc' }).success).toBe(false);
+	});
+
+	it('rejects color with non-hex characters', () => {
+		expect(projectCreateSchema.safeParse({ name: 'P1', color: '#zzzzzz' }).success).toBe(false);
+	});
+});
+
+describe('projectUpdateSchema', () => {
+	it('requires id', () => {
+		expect(projectUpdateSchema.safeParse({ name: 'P1', color: '#abcdef' }).success).toBe(false);
+		expect(projectUpdateSchema.safeParse({ id: 'p1', name: 'P1', color: '#abcdef' }).success).toBe(
+			true
+		);
+	});
+});
+
+describe('assignmentCreateSchema', () => {
+	const valid = {
+		resourceId: 'r1',
+		projectId: 'p1',
+		startDate: '2026-05-01',
+		endDate: '2026-05-31'
+	};
+
+	it('transforms inclusive endDate to exclusive endDateExclusive (+1 day)', () => {
+		const r = assignmentCreateSchema.safeParse(valid);
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data).toEqual({
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+	});
+
+	it('transforms across month boundary correctly', () => {
+		const r = assignmentCreateSchema.safeParse({
+			...valid,
+			startDate: '2026-01-01',
+			endDate: '2026-01-31'
+		});
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data.endDateExclusive).toBe('2026-02-01');
+	});
+
+	it('accepts startDate == endDate (single-day assignment)', () => {
+		const r = assignmentCreateSchema.safeParse({
+			...valid,
+			startDate: '2026-05-01',
+			endDate: '2026-05-01'
+		});
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data.endDateExclusive).toBe('2026-05-02');
+	});
+
+	it('rejects startDate > endDate with path = ["endDate"]', () => {
+		const r = assignmentCreateSchema.safeParse({
+			...valid,
+			startDate: '2026-05-31',
+			endDate: '2026-05-01'
+		});
+		expect(r.success).toBe(false);
+		if (r.success) return;
+		expect(r.error.issues[0].path).toEqual(['endDate']);
+	});
+
+	it('rejects malformed startDate (not YYYY-MM-DD)', () => {
+		expect(assignmentCreateSchema.safeParse({ ...valid, startDate: '2026/5/1' }).success).toBe(
+			false
+		);
+	});
+
+	it('rejects empty resourceId / projectId', () => {
+		expect(assignmentCreateSchema.safeParse({ ...valid, resourceId: '' }).success).toBe(false);
+		expect(assignmentCreateSchema.safeParse({ ...valid, projectId: '' }).success).toBe(false);
+	});
+});
+
+describe('assignmentUpdateSchema', () => {
+	it('requires id and applies the same +1-day transform', () => {
+		const r = assignmentUpdateSchema.safeParse({
+			id: 'a1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDate: '2026-05-31'
+		});
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data).toEqual({
+			id: 'a1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+	});
+
+	it('rejects missing id', () => {
+		expect(
+			assignmentUpdateSchema.safeParse({
+				resourceId: 'r1',
+				projectId: 'p1',
+				startDate: '2026-05-01',
+				endDate: '2026-05-31'
+			}).success
+		).toBe(false);
+	});
+});
+
+describe('assignmentApiUpdateSchema', () => {
+	const valid = {
+		prevStartDate: '2026-05-01',
+		resourceId: 'r1',
+		projectId: 'p1',
+		startDate: '2026-05-01',
+		endDateExclusive: '2026-06-01'
+	};
+
+	it('accepts strict half-open interval (startDate < endDateExclusive)', () => {
+		expect(assignmentApiUpdateSchema.safeParse(valid).success).toBe(true);
+	});
+
+	it('rejects startDate == endDateExclusive (would be empty interval)', () => {
+		const r = assignmentApiUpdateSchema.safeParse({
+			...valid,
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-05-01'
+		});
+		expect(r.success).toBe(false);
+		if (r.success) return;
+		expect(r.error.issues[0].path).toEqual(['endDateExclusive']);
+	});
+
+	it('rejects startDate > endDateExclusive', () => {
+		expect(
+			assignmentApiUpdateSchema.safeParse({
+				...valid,
+				startDate: '2026-06-01',
+				endDateExclusive: '2026-05-01'
+			}).success
+		).toBe(false);
+	});
+
+	it('rejects malformed dates', () => {
+		expect(assignmentApiUpdateSchema.safeParse({ ...valid, startDate: 'yesterday' }).success).toBe(
+			false
+		);
+	});
+});

--- a/web/src/lib/timeline-adapter.test.ts
+++ b/web/src/lib/timeline-adapter.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import type { Assignment as DbAssignment } from './types';
+import { fromTimelineAssignment, toTimelineAssignment } from './timeline-adapter';
+
+const sampleDb: DbAssignment = {
+	id: 'a1',
+	resourceId: 'r1',
+	projectId: 'p1',
+	startDate: '2026-05-01',
+	endDateExclusive: '2026-06-01'
+};
+
+describe('toTimelineAssignment', () => {
+	it('composes label + color from project, parses dates', () => {
+		const t = toTimelineAssignment(sampleDb, { name: 'Project One', color: '#ff0000' });
+		expect(t.id).toBe('a1');
+		expect(t.resourceId).toBe('r1');
+		expect(t.label).toBe('Project One');
+		expect(t.color).toBe('#ff0000');
+		expect(t.startDate).toBeInstanceOf(Date);
+		expect(t.endDate).toBeInstanceOf(Date);
+		expect(t.startDate.getFullYear()).toBe(2026);
+		expect(t.startDate.getMonth()).toBe(4); // 0-indexed: May
+		expect(t.startDate.getDate()).toBe(1);
+		expect(t.endDate.getMonth()).toBe(5); // 0-indexed: June
+		expect(t.endDate.getDate()).toBe(1);
+	});
+
+	it('falls back to undefined label/color when project is missing', () => {
+		const t = toTimelineAssignment(sampleDb, undefined);
+		expect(t.label).toBeUndefined();
+		expect(t.color).toBeUndefined();
+		expect(t.id).toBe('a1');
+	});
+});
+
+describe('fromTimelineAssignment', () => {
+	it('formats Date back to YYYY-MM-DD and preserves projectId from prev', () => {
+		const t = {
+			id: 'a1',
+			resourceId: 'r2',
+			startDate: new Date(2026, 5, 15), // 2026-06-15
+			endDate: new Date(2026, 6, 1) // 2026-07-01
+		};
+		const result = fromTimelineAssignment(t, sampleDb);
+		expect(result).toEqual({
+			id: 'a1',
+			resourceId: 'r2',
+			projectId: 'p1', // preserved from prev (timeline has no projectId)
+			startDate: '2026-06-15',
+			endDateExclusive: '2026-07-01'
+		});
+	});
+
+	it('survives a roundtrip (db -> timeline -> db) without drift', () => {
+		const project = { name: 'P', color: '#000000' };
+		const t = toTimelineAssignment(sampleDb, project);
+		const back = fromTimelineAssignment(t, sampleDb);
+		expect(back).toEqual(sampleDb);
+	});
+});


### PR DESCRIPTION
PR-T1 (#70) の Vitest 基盤上に、移行で挙動保証したい純粋関数のテストを追加。
詳細は #71 参照。

## 追加
- `web/src/lib/schemas/index.test.ts` (27 ケース):
  - resource/project create/update validation
  - `assignmentCreateSchema`: `.transform()` (endDate → endDateExclusive +1day)、`.refine()` (`startDate <= endDate`、path=['endDate'])
  - `assignmentApiUpdateSchema`: strict `startDate < endDateExclusive`
- `web/src/lib/timeline-adapter.test.ts` (3 ケース):
  - `toTimelineAssignment` with/without project
  - `fromTimelineAssignment` で `projectId` を prev から保持
  - db → timeline → db roundtrip

## 検証
- `pnpm test` 緑 (35/35、duration ~190ms)
- `pnpm test:coverage` で 3 ファイル 100% covered (stmts 25/25、funcs 10/10)
- `pnpm check` 緑 (1718 files / 0 errors)

新規 ADR は無し (PR-T1 ADR 0007 の枠で実行のみ)。

## 含まないもの
- PR-T3: repository 層 + DDB Local 統合
- PR-T4: CI 統合
- PR-T5: Playwright

Closes #71