### PR TITLE
test: repository 層 unit tests (aws-sdk-client-mock)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,6 +27,8 @@
 		"@tailwindcss/vite": "^4.2.2",
 		"@types/node": "^22",
 		"@vitest/coverage-v8": "^4.1.5",
+		"aws-sdk-client-mock": "^4.1.0",
+		"aws-sdk-client-mock-vitest": "^7.0.1",
 		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.17.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -72,6 +72,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
+      aws-sdk-client-mock:
+        specifier: ^4.1.0
+        version: 4.1.0
+      aws-sdk-client-mock-vitest:
+        specifier: ^7.0.1
+        version: 7.0.1(@smithy/types@4.14.1)(aws-sdk-client-mock@4.1.0)(vitest@4.1.5)
       eslint:
         specifier: ^10.2.0
         version: 10.3.0(jiti@2.6.1)
@@ -689,6 +695,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinonjs/commons@3.0.1':
+    resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
+
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
   '@smithy/config-resolver@4.4.17':
     resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
     engines: {node: '>=18.0.0'}
@@ -1028,6 +1046,12 @@ packages:
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
@@ -1152,6 +1176,17 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  aws-sdk-client-mock-vitest@7.0.1:
+    resolution: {integrity: sha512-uvMZKOT6i7dDxdHM/8ksZ7Z3m27ZZNRNm8r+zzFTT0cXmW2xG5/ttUtQDEImthZ5QARA325ll1wMCBGQ0+8WrQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      '@smithy/types': '>=3.5.0'
+      aws-sdk-client-mock: '>=2.2.0'
+      vitest: '>=3.2.0'
+
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -1234,6 +1269,10 @@ packages:
 
   devalue@5.8.0:
     resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+
+  diff@5.2.2:
+    resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
+    engines: {node: '>=0.3.1'}
 
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
@@ -1492,6 +1531,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1627,6 +1669,9 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  nise@6.1.5:
+    resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
+
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
@@ -1659,6 +1704,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1841,6 +1889,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1973,6 +2024,14 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-detect@4.0.8:
+    resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
+    engines: {node: '>=4'}
 
   typescript-eslint@8.59.1:
     resolution: {integrity: sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==}
@@ -2880,6 +2939,23 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@sinonjs/commons@3.0.1':
+    dependencies:
+      type-detect: 4.0.8
+
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
   '@smithy/config-resolver@4.4.17':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
@@ -3305,6 +3381,12 @@ snapshots:
 
   '@types/resolve@1.20.2': {}
 
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
+
   '@types/trusted-types@2.0.7': {}
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)':
@@ -3476,6 +3558,19 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  aws-sdk-client-mock-vitest@7.0.1(@smithy/types@4.14.1)(aws-sdk-client-mock@4.1.0)(vitest@4.1.5):
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@vitest/expect': 4.1.5
+      aws-sdk-client-mock: 4.1.0
+      vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
+
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
+
   axobject-query@4.1.0: {}
 
   balanced-match@4.0.4: {}
@@ -3536,6 +3631,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   devalue@5.8.0: {}
+
+  diff@5.2.2: {}
 
   enhanced-resolve@5.21.0:
     dependencies:
@@ -3784,6 +3881,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  just-extend@6.2.0: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3888,6 +3987,13 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  nise@6.1.5:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.4.0
+      just-extend: 6.2.0
+      path-to-regexp: 8.4.2
+
   obliterator@1.6.1: {}
 
   obug@2.1.1: {}
@@ -3916,6 +4022,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -4065,6 +4173,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.2
+      nise: 6.1.5
+      supports-color: 7.2.0
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -4205,6 +4322,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
 
   typescript-eslint@8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3):
     dependencies:

--- a/web/src/lib/repository/assignment.test.ts
+++ b/web/src/lib/repository/assignment.test.ts
@@ -1,0 +1,125 @@
+import {
+	DeleteCommand,
+	DynamoDBDocumentClient,
+	PutCommand,
+	TransactWriteCommand
+} from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createAssignment, deleteAssignment, updateAssignment } from './assignment';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ORG = 'org-test';
+const TABLE = 'resource-planner-test';
+
+beforeEach(() => {
+	ddbMock.reset();
+});
+
+describe('createAssignment', () => {
+	it('uses SK = ASN#{startDate}#{id} and stores half-open interval', async () => {
+		ddbMock.on(PutCommand).resolves({});
+
+		const result = await createAssignment(ORG, {
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+
+		expect(result).toMatchObject({
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+		const input = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+		expect(input.Item).toMatchObject({
+			pk: `ORG#${ORG}`,
+			sk: `ASN#2026-05-01#${result.id}`,
+			id: result.id,
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+		expect(input.ConditionExpression).toBe('attribute_not_exists(sk)');
+	});
+});
+
+describe('updateAssignment (SK aware)', () => {
+	const baseInput = {
+		id: 'a1',
+		resourceId: 'r1',
+		projectId: 'p1',
+		startDate: '2026-05-01',
+		endDateExclusive: '2026-06-01'
+	};
+
+	it('SK unchanged → uses PutCommand with attribute_exists guard', async () => {
+		ddbMock.on(PutCommand).resolves({});
+
+		await updateAssignment(ORG, '2026-05-01', baseInput);
+
+		const calls = ddbMock.commandCalls(PutCommand);
+		expect(calls).toHaveLength(1);
+		expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+
+		const input = calls[0].args[0].input;
+		expect(input.Item).toMatchObject({
+			pk: `ORG#${ORG}`,
+			sk: 'ASN#2026-05-01#a1',
+			id: 'a1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+		expect(input.ConditionExpression).toBe('attribute_exists(sk)');
+	});
+
+	it('SK changed (startDate moved) → TransactWriteCommand: old Delete + new Put atomic', async () => {
+		ddbMock.on(TransactWriteCommand).resolves({});
+
+		const moved = { ...baseInput, startDate: '2026-05-15' };
+		await updateAssignment(ORG, '2026-05-01', moved);
+
+		expect(ddbMock.commandCalls(PutCommand)).toHaveLength(0);
+		const txCalls = ddbMock.commandCalls(TransactWriteCommand);
+		expect(txCalls).toHaveLength(1);
+
+		const items = txCalls[0].args[0].input.TransactItems;
+		expect(items).toHaveLength(2);
+
+		// Old SK delete (with attribute_exists guard)
+		expect(items?.[0].Delete).toMatchObject({
+			TableName: TABLE,
+			Key: { pk: `ORG#${ORG}`, sk: 'ASN#2026-05-01#a1' },
+			ConditionExpression: 'attribute_exists(sk)'
+		});
+
+		// New SK put (with attribute_not_exists guard)
+		expect(items?.[1].Put).toMatchObject({
+			TableName: TABLE,
+			ConditionExpression: 'attribute_not_exists(sk)'
+		});
+		expect(items?.[1].Put?.Item).toMatchObject({
+			pk: `ORG#${ORG}`,
+			sk: 'ASN#2026-05-15#a1',
+			startDate: '2026-05-15',
+			endDateExclusive: '2026-06-01'
+		});
+	});
+});
+
+describe('deleteAssignment', () => {
+	it('sends DeleteCommand with composite SK', async () => {
+		ddbMock.on(DeleteCommand).resolves({});
+
+		await deleteAssignment(ORG, '2026-05-01', 'a1');
+
+		const input = ddbMock.commandCalls(DeleteCommand)[0].args[0].input;
+		expect(input.Key).toEqual({ pk: `ORG#${ORG}`, sk: 'ASN#2026-05-01#a1' });
+	});
+});

--- a/web/src/lib/repository/index.test.ts
+++ b/web/src/lib/repository/index.test.ts
@@ -1,0 +1,95 @@
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { queryAllByOrg } from './index';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ORG = 'org-test';
+
+beforeEach(() => {
+	ddbMock.reset();
+});
+
+describe('queryAllByOrg', () => {
+	it('partitions returned items by SK prefix into resources/projects/assignments', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [
+				{ sk: 'RES#r1', id: 'r1', name: 'Alice' },
+				{ sk: 'RES#r2', id: 'r2', name: 'Bob' },
+				{ sk: 'PRJ#p1', id: 'p1', name: 'Project A', color: '#ff0000' },
+				{
+					sk: 'ASN#2026-05-01#a1',
+					id: 'a1',
+					resourceId: 'r1',
+					projectId: 'p1',
+					startDate: '2026-05-01',
+					endDateExclusive: '2026-06-01'
+				}
+			]
+		});
+
+		const data = await queryAllByOrg(ORG);
+
+		expect(data.resources).toEqual([
+			{ id: 'r1', name: 'Alice' },
+			{ id: 'r2', name: 'Bob' }
+		]);
+		expect(data.projects).toEqual([{ id: 'p1', name: 'Project A', color: '#ff0000' }]);
+		expect(data.assignments).toEqual([
+			{
+				id: 'a1',
+				resourceId: 'r1',
+				projectId: 'p1',
+				startDate: '2026-05-01',
+				endDateExclusive: '2026-06-01'
+			}
+		]);
+
+		const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+		expect(input.KeyConditionExpression).toBe('pk = :pk');
+		expect(input.ExpressionAttributeValues).toEqual({ ':pk': `ORG#${ORG}` });
+	});
+
+	it('paginates via LastEvaluatedKey until exhausted', async () => {
+		ddbMock
+			.on(QueryCommand)
+			.resolvesOnce({
+				Items: [{ sk: 'RES#r1', id: 'r1', name: 'Alice' }],
+				LastEvaluatedKey: { pk: `ORG#${ORG}`, sk: 'RES#r1' }
+			})
+			.resolvesOnce({
+				Items: [{ sk: 'RES#r2', id: 'r2', name: 'Bob' }]
+			});
+
+		const data = await queryAllByOrg(ORG);
+
+		expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(2);
+		expect(data.resources).toEqual([
+			{ id: 'r1', name: 'Alice' },
+			{ id: 'r2', name: 'Bob' }
+		]);
+	});
+
+	it('returns empty arrays when no items exist', async () => {
+		ddbMock.on(QueryCommand).resolves({ Items: [] });
+
+		const data = await queryAllByOrg(ORG);
+
+		expect(data).toEqual({ resources: [], projects: [], assignments: [] });
+	});
+
+	it('ignores items with unknown SK prefix', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [
+				{ sk: 'RES#r1', id: 'r1', name: 'Alice' },
+				{ sk: 'UNKNOWN#x', id: 'x' }
+			]
+		});
+
+		const data = await queryAllByOrg(ORG);
+		expect(data.resources).toHaveLength(1);
+		expect(data.projects).toHaveLength(0);
+		expect(data.assignments).toHaveLength(0);
+	});
+});

--- a/web/src/lib/repository/project.test.ts
+++ b/web/src/lib/repository/project.test.ts
@@ -1,0 +1,91 @@
+import {
+	DynamoDBDocumentClient,
+	PutCommand,
+	QueryCommand,
+	TransactWriteCommand,
+	UpdateCommand
+} from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createProject, deleteProject, updateProject } from './project';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ORG = 'org-test';
+const TABLE = 'resource-planner-test';
+
+beforeEach(() => {
+	ddbMock.reset();
+});
+
+describe('createProject', () => {
+	it('sends PutCommand with id/name/color and attribute_not_exists guard', async () => {
+		ddbMock.on(PutCommand).resolves({});
+
+		const result = await createProject(ORG, { name: 'Project A', color: '#ff0000' });
+
+		expect(result).toMatchObject({ name: 'Project A', color: '#ff0000' });
+		const input = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+		expect(input.TableName).toBe(TABLE);
+		expect(input.ConditionExpression).toBe('attribute_not_exists(sk)');
+		expect(input.Item).toMatchObject({
+			pk: `ORG#${ORG}`,
+			sk: `PRJ#${result.id}`,
+			id: result.id,
+			name: 'Project A',
+			color: '#ff0000'
+		});
+	});
+});
+
+describe('updateProject', () => {
+	it('sends UpdateCommand with #name + color in SET, attribute_exists guard', async () => {
+		ddbMock.on(UpdateCommand).resolves({});
+
+		await updateProject(ORG, { id: 'prj-1', name: 'Renamed', color: '#00ff00' });
+
+		const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+		expect(input.Key).toEqual({ pk: `ORG#${ORG}`, sk: 'PRJ#prj-1' });
+		expect(input.UpdateExpression).toBe('SET #name = :name, color = :color');
+		expect(input.ExpressionAttributeNames).toEqual({ '#name': 'name' });
+		expect(input.ExpressionAttributeValues).toEqual({
+			':name': 'Renamed',
+			':color': '#00ff00'
+		});
+		expect(input.ConditionExpression).toBe('attribute_exists(sk)');
+	});
+});
+
+describe('deleteProject (cascade)', () => {
+	it('queries by projectId then transact-deletes project + assignments atomically', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [{ sk: 'ASN#2026-05-01#a1' }, { sk: 'ASN#2026-05-10#a2' }]
+		});
+		ddbMock.on(TransactWriteCommand).resolves({});
+
+		await deleteProject(ORG, 'prj-1');
+
+		const qInput = ddbMock.commandCalls(QueryCommand)[0].args[0].input;
+		expect(qInput.FilterExpression).toBe('projectId = :pid');
+		expect(qInput.ExpressionAttributeValues).toMatchObject({
+			':pk': `ORG#${ORG}`,
+			':asn': 'ASN#',
+			':pid': 'prj-1'
+		});
+
+		const txInput = ddbMock.commandCalls(TransactWriteCommand)[0].args[0].input;
+		expect(txInput.TransactItems).toEqual([
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'PRJ#prj-1' } } },
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'ASN#2026-05-01#a1' } } },
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'ASN#2026-05-10#a2' } } }
+		]);
+	});
+
+	it('throws when cascade exceeds 100 items', async () => {
+		const items = Array.from({ length: 100 }, (_, i) => ({ sk: `ASN#2026-05-01#a${i}` }));
+		ddbMock.on(QueryCommand).resolves({ Items: items });
+
+		await expect(deleteProject(ORG, 'prj-1')).rejects.toThrow(/exceeds 100 items/);
+		expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+	});
+});

--- a/web/src/lib/repository/resource.test.ts
+++ b/web/src/lib/repository/resource.test.ts
@@ -1,0 +1,146 @@
+import {
+	DeleteCommand,
+	DynamoDBDocumentClient,
+	PutCommand,
+	QueryCommand,
+	TransactWriteCommand,
+	UpdateCommand
+} from '@aws-sdk/lib-dynamodb';
+import { mockClient } from 'aws-sdk-client-mock';
+import 'aws-sdk-client-mock-vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createResource, deleteResource, updateResource } from './resource';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+const ORG = 'org-test';
+const TABLE = 'resource-planner-test';
+
+beforeEach(() => {
+	ddbMock.reset();
+});
+
+afterEach(() => {
+	ddbMock.reset();
+});
+
+describe('createResource', () => {
+	it('sends PutCommand with pk/sk/id/name and attribute_not_exists guard', async () => {
+		ddbMock.on(PutCommand).resolves({});
+
+		const result = await createResource(ORG, { name: 'Alice' });
+
+		expect(result.name).toBe('Alice');
+		expect(typeof result.id).toBe('string');
+		expect(result.id.length).toBeGreaterThan(0);
+
+		const calls = ddbMock.commandCalls(PutCommand);
+		expect(calls).toHaveLength(1);
+		const input = calls[0].args[0].input;
+		expect(input.TableName).toBe(TABLE);
+		expect(input.ConditionExpression).toBe('attribute_not_exists(sk)');
+		expect(input.Item).toMatchObject({
+			pk: `ORG#${ORG}`,
+			sk: `RES#${result.id}`,
+			id: result.id,
+			name: 'Alice'
+		});
+	});
+});
+
+describe('updateResource', () => {
+	it('sends UpdateCommand with #name placeholder + attribute_exists guard', async () => {
+		ddbMock.on(UpdateCommand).resolves({});
+
+		await updateResource(ORG, { id: 'res-1', name: 'Bob' });
+
+		const calls = ddbMock.commandCalls(UpdateCommand);
+		expect(calls).toHaveLength(1);
+		const input = calls[0].args[0].input;
+		expect(input.TableName).toBe(TABLE);
+		expect(input.Key).toEqual({ pk: `ORG#${ORG}`, sk: 'RES#res-1' });
+		expect(input.UpdateExpression).toBe('SET #name = :name');
+		expect(input.ExpressionAttributeNames).toEqual({ '#name': 'name' });
+		expect(input.ExpressionAttributeValues).toEqual({ ':name': 'Bob' });
+		expect(input.ConditionExpression).toBe('attribute_exists(sk)');
+	});
+});
+
+describe('deleteResource (cascade)', () => {
+	it('queries related assignments then transact-deletes resource + assignments atomically', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [{ sk: 'ASN#2026-05-01#a1' }, { sk: 'ASN#2026-05-10#a2' }]
+		});
+		ddbMock.on(TransactWriteCommand).resolves({});
+
+		await deleteResource(ORG, 'res-1');
+
+		const queryCalls = ddbMock.commandCalls(QueryCommand);
+		expect(queryCalls).toHaveLength(1);
+		const qInput = queryCalls[0].args[0].input;
+		expect(qInput.KeyConditionExpression).toBe('pk = :pk AND begins_with(sk, :asn)');
+		expect(qInput.FilterExpression).toBe('resourceId = :rid');
+		expect(qInput.ExpressionAttributeValues).toMatchObject({
+			':pk': `ORG#${ORG}`,
+			':asn': 'ASN#',
+			':rid': 'res-1'
+		});
+
+		const txCalls = ddbMock.commandCalls(TransactWriteCommand);
+		expect(txCalls).toHaveLength(1);
+		const txInput = txCalls[0].args[0].input;
+		expect(txInput.TransactItems).toEqual([
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'RES#res-1' } } },
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'ASN#2026-05-01#a1' } } },
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'ASN#2026-05-10#a2' } } }
+		]);
+	});
+
+	it('paginates Query when LastEvaluatedKey is returned', async () => {
+		ddbMock
+			.on(QueryCommand)
+			.resolvesOnce({
+				Items: [{ sk: 'ASN#2026-05-01#a1' }],
+				LastEvaluatedKey: { pk: `ORG#${ORG}`, sk: 'ASN#2026-05-01#a1' }
+			})
+			.resolvesOnce({
+				Items: [{ sk: 'ASN#2026-05-10#a2' }]
+			});
+		ddbMock.on(TransactWriteCommand).resolves({});
+
+		await deleteResource(ORG, 'res-1');
+
+		expect(ddbMock.commandCalls(QueryCommand)).toHaveLength(2);
+		const txInput = ddbMock.commandCalls(TransactWriteCommand)[0].args[0].input;
+		expect(txInput.TransactItems).toHaveLength(3); // resource + 2 assignments
+	});
+
+	it('throws when cascade exceeds 100 items', async () => {
+		const items = Array.from({ length: 100 }, (_, i) => ({
+			sk: `ASN#2026-05-01#a${i}`
+		}));
+		ddbMock.on(QueryCommand).resolves({ Items: items });
+
+		await expect(deleteResource(ORG, 'res-1')).rejects.toThrow(/exceeds 100 items/);
+		expect(ddbMock.commandCalls(TransactWriteCommand)).toHaveLength(0);
+	});
+
+	it('handles resource with no related assignments (transact-deletes only the resource)', async () => {
+		ddbMock.on(QueryCommand).resolves({ Items: [] });
+		ddbMock.on(TransactWriteCommand).resolves({});
+
+		await deleteResource(ORG, 'res-1');
+
+		const txInput = ddbMock.commandCalls(TransactWriteCommand)[0].args[0].input;
+		expect(txInput.TransactItems).toEqual([
+			{ Delete: { TableName: TABLE, Key: { pk: `ORG#${ORG}`, sk: 'RES#res-1' } } }
+		]);
+	});
+});
+
+// Sanity: unrelated DeleteCommand should never be sent by these functions
+it('does not send raw DeleteCommand (delete is via TransactWrite)', async () => {
+	ddbMock.on(QueryCommand).resolves({ Items: [] });
+	ddbMock.on(TransactWriteCommand).resolves({});
+	await deleteResource(ORG, 'res-1');
+	expect(ddbMock.commandCalls(DeleteCommand)).toHaveLength(0);
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -3,6 +3,12 @@ import tailwindcss from '@tailwindcss/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+// SvelteKit の `$env/dynamic/private` は plugin 初期化時に process.env を snapshot するため、
+// vitest 起動時には既に固定されている。test 専用のダミー値を SvelteKit plugin より先に注入する。
+if (process.env.VITEST) {
+	process.env.DYNAMODB_TABLE = process.env.DYNAMODB_TABLE ?? 'resource-planner-test';
+}
+
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit()],
 	test: {


### PR DESCRIPTION
PR-T1 (#70) / PR-T2 (#72) に続き、repository 層を mocked DynamoDBDocumentClient で固める。詳細は #73 参照。

DDB Local 統合は CI service container と一緒のほうが自然なため PR-T4 に集約。本 PR は unit (mocked) only。

## 依存追加
- `aws-sdk-client-mock@^4` / `aws-sdk-client-mock-vitest@^4`

## 設定
- `web/vite.config.ts`: `VITEST` 検出時に `process.env.DYNAMODB_TABLE` を inject (`$env/dynamic/private` は plugin 起動時 snapshot のため `setupFiles` では遅い)

## 追加テスト (4 ファイル、19 ケース)
- `repository/resource.test.ts`: create / update / cascade delete (Query → TransactWrite atomic、pagination、100 items 上限)
- `repository/project.test.ts`: 同パターン (color フィールド含む)
- `repository/assignment.test.ts`: SK aware update (SK 不変=Put、SK 変化=TransactWrite で旧 Delete + 新 Put)
- `repository/index.test.ts`: `queryAllByOrg` の SK 振り分け、pagination、unknown prefix 無視

## 検証
- `pnpm test` 緑 (54/54、duration ~360ms)
- `pnpm test:coverage` で repository 100% line / 100% function、全体 99% line
- `pnpm check` 緑 (1729 files / 0 errors)

## 含まないもの
- DDB Local 統合 (PR-T4 で CI service container と一緒に)
- E2E (PR-T5)

新規 ADR は無し (PR-T1 ADR 0007 の枠で実行のみ)。

Closes #73