### PR TITLE
test(ci): test job 追加 + DDB Local 統合テスト

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,71 @@ jobs:
         run: pnpm build
         working-directory: web
 
+  test:
+    runs-on: ubuntu-latest
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:latest
+        ports: ["8000:8000"]
+        # NOTE: amazon/dynamodb-local image はシェルなしのため services.options で
+        # --health-cmd を渡せない。後続ステップで wait ループする (db-docs.yaml と同じ)。
+    env:
+      AWS_ENDPOINT_URL: http://localhost:8000
+      AWS_DEFAULT_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: local
+      AWS_SECRET_ACCESS_KEY: local
+      DYNAMODB_TABLE: resource-planner
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: '@tommykey-apps'
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: web
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for DynamoDB Local
+        run: |
+          for i in {1..30}; do
+            curl -s http://localhost:8000 > /dev/null && exit 0
+            sleep 1
+          done
+          echo "DynamoDB Local did not start within 30s"
+          exit 1
+
+      # NOTE: 同じ create-table 定義が以下にもある:
+      #   - Makefile の db ターゲット
+      #   - .github/workflows/db-docs.yaml の Create table ステップ
+      # いずれかを変更したら必ず全箇所を同期すること。
+      - name: Create table
+        run: |
+          aws dynamodb create-table \
+            --table-name resource-planner \
+            --attribute-definitions \
+              AttributeName=pk,AttributeType=S \
+              AttributeName=sk,AttributeType=S \
+            --key-schema \
+              AttributeName=pk,KeyType=HASH \
+              AttributeName=sk,KeyType=RANGE \
+            --billing-mode PAY_PER_REQUEST \
+            --endpoint-url http://localhost:8000
+
+      - name: Run tests
+        run: pnpm test
+        working-directory: web
+
   terraform-plan:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,7 @@ jobs:
         # --health-cmd を渡せない。後続ステップで wait ループする (db-docs.yaml と同じ)。
     env:
       AWS_ENDPOINT_URL: http://localhost:8000
+      AWS_REGION: ap-northeast-1
       AWS_DEFAULT_REGION: ap-northeast-1
       AWS_ACCESS_KEY_ID: local
       AWS_SECRET_ACCESS_KEY: local

--- a/README.md
+++ b/README.md
@@ -66,7 +66,27 @@ pnpm dev                   # Vite dev server
 pnpm build                 # ビルド (build/ に出力、Lambda 用)
 pnpm check                 # svelte-check
 pnpm format                # Prettier 自動修正
+pnpm test                  # Vitest (unit; DDB Local 起動時は integration も含む)
+pnpm test:watch            # Vitest watch mode
+pnpm test:coverage         # Vitest + v8 coverage
 ```
+
+### 統合テストの実行
+
+`web/src/lib/repository/integration.test.ts` は `AWS_ENDPOINT_URL` が設定されている時のみ実行
+([`describe.runIf`](https://vitest.dev/api/#describe-runif))。ローカルで integration まで含めて実行するには:
+
+```bash
+make db                    # DynamoDB Local 起動 + table 作成
+cd web
+AWS_ENDPOINT_URL=http://localhost:8000 \
+AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local AWS_DEFAULT_REGION=ap-northeast-1 \
+DYNAMODB_TABLE=resource-planner \
+pnpm test
+```
+
+CI では `.github/workflows/ci.yaml` の `test` job が `services.dynamodb` で起動して unit + integration を一括実行する。
+詳細方針は [ADR 0007](docs/adr/0007-tdd-with-vitest-and-playwright.md) 参照。
 
 ## アーキテクチャ
 

--- a/web/src/lib/repository/assignment.test.ts
+++ b/web/src/lib/repository/assignment.test.ts
@@ -11,7 +11,7 @@ import { createAssignment, deleteAssignment, updateAssignment } from './assignme
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ORG = 'org-test';
-const TABLE = 'resource-planner-test';
+const TABLE = process.env.DYNAMODB_TABLE ?? 'resource-planner-test';
 
 beforeEach(() => {
 	ddbMock.reset();

--- a/web/src/lib/repository/integration.test.ts
+++ b/web/src/lib/repository/integration.test.ts
@@ -1,0 +1,96 @@
+import { ulid } from 'ulid';
+import { describe, expect, it } from 'vitest';
+import { createAssignment } from './assignment';
+import { createResource, deleteResource, updateResource } from './resource';
+import { queryAllByOrg } from './index';
+
+/**
+ * Repository 層の統合テスト。実 DDB Local に書き込み、unit (mock) では拾えない
+ * marshalling、SK ソート順、TransactWriteItems の実挙動を検証する。
+ *
+ * **実行条件**: `AWS_ENDPOINT_URL` が設定されている場合のみ走る (DDB Local 起動済の指標)。
+ * - ローカル: `make db` 後に `pnpm test`
+ * - CI: `test` job が `services.dynamodb` で起動 (.github/workflows/ci.yaml)
+ *
+ * **隔離**: 各テストで `org-${ulid()}` の一意 ORG を使うため、並行実行・前回の残骸の影響を受けない。
+ */
+describe.runIf(process.env.AWS_ENDPOINT_URL)('repository integration (DDB Local)', () => {
+	it('Resource lifecycle: create → query → update → delete', async () => {
+		const orgId = `test-${ulid()}`;
+		const r = await createResource(orgId, { name: 'Alice' });
+
+		let data = await queryAllByOrg(orgId);
+		expect(data.resources).toEqual([{ id: r.id, name: 'Alice' }]);
+
+		await updateResource(orgId, { id: r.id, name: 'Alicia' });
+		data = await queryAllByOrg(orgId);
+		expect(data.resources).toEqual([{ id: r.id, name: 'Alicia' }]);
+
+		await deleteResource(orgId, r.id);
+		data = await queryAllByOrg(orgId);
+		expect(data.resources).toEqual([]);
+	});
+
+	it('cascade delete removes resource + related assignments atomically', async () => {
+		const orgId = `test-${ulid()}`;
+		const r = await createResource(orgId, { name: 'Bob' });
+		await createAssignment(orgId, {
+			resourceId: r.id,
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-06-01'
+		});
+		await createAssignment(orgId, {
+			resourceId: r.id,
+			projectId: 'p1',
+			startDate: '2026-05-15',
+			endDateExclusive: '2026-05-30'
+		});
+
+		let data = await queryAllByOrg(orgId);
+		expect(data.assignments).toHaveLength(2);
+
+		await deleteResource(orgId, r.id);
+
+		data = await queryAllByOrg(orgId);
+		expect(data.resources).toEqual([]);
+		expect(data.assignments).toEqual([]);
+	});
+
+	it('Query returns assignments in startDate ascending order (SK lexicographic)', async () => {
+		const orgId = `test-${ulid()}`;
+		const r = await createResource(orgId, { name: 'C' });
+
+		// 順番を逆に挿入しても、SK が `ASN#{startDate}#{id}` なのでソートされる
+		await createAssignment(orgId, {
+			resourceId: r.id,
+			projectId: 'p1',
+			startDate: '2026-05-15',
+			endDateExclusive: '2026-05-30'
+		});
+		await createAssignment(orgId, {
+			resourceId: r.id,
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-05-10'
+		});
+
+		const data = await queryAllByOrg(orgId);
+		expect(data.assignments.map((a) => a.startDate)).toEqual(['2026-05-01', '2026-05-15']);
+
+		// cleanup
+		await deleteResource(orgId, r.id);
+	});
+
+	it('createResource enforces attribute_not_exists (no duplicate SK)', async () => {
+		const orgId = `test-${ulid()}`;
+		const a = await createResource(orgId, { name: 'A' });
+		const b = await createResource(orgId, { name: 'B' });
+		// Different ULIDs → both succeed
+		expect(a.id).not.toBe(b.id);
+
+		// cleanup
+		await deleteResource(orgId, a.id);
+		await deleteResource(orgId, b.id);
+	});
+});

--- a/web/src/lib/repository/project.test.ts
+++ b/web/src/lib/repository/project.test.ts
@@ -12,7 +12,7 @@ import { createProject, deleteProject, updateProject } from './project';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ORG = 'org-test';
-const TABLE = 'resource-planner-test';
+const TABLE = process.env.DYNAMODB_TABLE ?? 'resource-planner-test';
 
 beforeEach(() => {
 	ddbMock.reset();

--- a/web/src/lib/repository/resource.test.ts
+++ b/web/src/lib/repository/resource.test.ts
@@ -13,7 +13,7 @@ import { createResource, deleteResource, updateResource } from './resource';
 
 const ddbMock = mockClient(DynamoDBDocumentClient);
 const ORG = 'org-test';
-const TABLE = 'resource-planner-test';
+const TABLE = process.env.DYNAMODB_TABLE ?? 'resource-planner-test';
 
 beforeEach(() => {
 	ddbMock.reset();


### PR DESCRIPTION
PR-T1〜T3 で揃えた unit test 基盤を CI に統合し、DDB Local で repository 層のフルサイクルを検証する。詳細は #75 参照。

## CI 変更 (`.github/workflows/ci.yaml`)
- 新 job `test`:
  - `services.dynamodb` で DynamoDB Local 起動 (db-docs.yaml と同じパターン)
  - wait ループ + `aws dynamodb create-table`
  - `DYNAMODB_TABLE=resource-planner` / `AWS_ENDPOINT_URL=http://localhost:8000` を env で設定
  - `pnpm test` (unit + integration 一括実行)

## 統合テスト追加
- `web/src/lib/repository/integration.test.ts`:
  - `describe.runIf(process.env.AWS_ENDPOINT_URL)` で DDB 起動時のみ run
  - Resource lifecycle (create → query → update → delete)
  - cascade delete (resource + 関連 assignments atomic)
  - Query SK ソート順 (startDate ascending)
  - createResource ULID 衝突なし

## unit test 修正
- `TABLE` 定数を `process.env.DYNAMODB_TABLE ?? 'resource-planner-test'` に変更 (CI で `DYNAMODB_TABLE=resource-planner` が設定された時に assertion 一致)

## ドキュメント
- `README.md`: `pnpm test` 系コマンド + 統合テスト実行手順 (`make db` + env export) を追記

## 検証
- ローカル DDB 起動済: `pnpm test` 緑 (58/58、うち 4 が integration)
- ローカル DDB 未起動: `pnpm test` 緑 (54 passed / 4 skipped)
- `pnpm check` 緑

## 含まないもの
- ruleset で `test` を required check に追加 (本 PR merge 後、別途 API で設定)
- E2E (PR-T5)

新規 ADR は無し (PR-T1 ADR 0007 の枠内)。

Closes #75