### PR TITLE
test(e2e): Playwright 基盤導入

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,6 +111,36 @@ jobs:
         run: pnpm test
         working-directory: web
 
+  # Playwright E2E。Phase 3 (Auth.js + Magic Link) 完了まで disable する。
+  # 有効化条件: web/e2e/ に sign-in fixture + 実 spec が揃った時点で `if: false` を外す。
+  # 詳細: ADR 0007 / issue #77
+  test-e2e:
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+          scope: '@tommykey-apps'
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: web
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+        working-directory: web
+      - name: Run E2E tests
+        run: pnpm test:e2e
+        working-directory: web
+
   terraform-plan:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ web/build
 # Vitest
 web/coverage
 
+# Playwright
+web/test-results
+web/playwright-report
+web/playwright/.cache
+
 # Terraform
 infra/.terraform
 infra/*.tfstate

--- a/docs/adr/0007-tdd-with-vitest-and-playwright.md
+++ b/docs/adr/0007-tdd-with-vitest-and-playwright.md
@@ -21,7 +21,7 @@ resource-planner はこれまで「動くコードを書いて手動で確認」
 |---|---|---|
 | Unit / Integration | **Vitest** | 純粋関数 (date, schemas, timeline-adapter)、repository 層 (`aws-sdk-client-mock`)、DDB Local 統合 |
 | Component | Vitest + `@testing-library/svelte` (将来) | Svelte 5 コンポーネント (必要になった PR で導入) |
-| E2E | **Playwright** (将来、PR-T5) | サインイン → CRUD のフルパス |
+| E2E | **Playwright** (基盤 PR-T5、実 spec は PR-A3 以降) | サインイン → CRUD のフルパス |
 
 **設定方針**:
 - `web/vitest.config.ts` は作らず、**`web/vite.config.ts` の `test` block** に併設 (設定一元化)
@@ -40,6 +40,13 @@ resource-planner はこれまで「動くコードを書いて手動で確認」
 - `pnpm test` — `vitest run` (CI / 一回実行)
 - `pnpm test:watch` — `vitest` (開発時の watch モード)
 - `pnpm test:coverage` — `vitest run --coverage`
+- `pnpm test:e2e` — `playwright test` (PR-T5 で導入、Phase 3 完了まで CI は disable)
+
+**Playwright 設定**:
+- `web/playwright.config.ts`: ローカル = Chromium / Firefox / WebKit、CI = Chromium のみ
+- `webServer` で `pnpm preview` を auto-start、port 4173
+- spec は `web/e2e/**/*.spec.ts`、結果は `test-results/` (.gitignore 済)
+- 実 sign-in fixture が必要なため、本格的な spec は **PR-A3 (Magic Link 移行)** 以降に書く
 
 **起票プロセスへの反映**:
 - `.github/ISSUE_TEMPLATE/feature.yml` の AC に「unit test」「integration test (該当時)」「E2E

--- a/web/e2e/.gitignore
+++ b/web/e2e/.gitignore
@@ -1,0 +1,3 @@
+test-results/
+playwright-report/
+playwright/.cache/

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * 最小 smoke spec。Phase 3 (Auth.js + Magic Link) 完了後に sign-in / CRUD spec を追加する前の土台。
+ *
+ * 本テストは未認証アクセスの想定挙動 (sign-in リダイレクト or 認証画面表示) を確認するのみ。
+ * 認証 fixture が必要な spec は PR-A3 以降で追加。
+ */
+test('home page responds (any 2xx/3xx) — minimal smoke', async ({ page }) => {
+	const response = await page.goto('/');
+	expect(response).not.toBeNull();
+	const status = response!.status();
+	expect(status).toBeLessThan(400);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -15,12 +15,14 @@
 		"format": "prettier --write .",
 		"test": "vitest run",
 		"test:watch": "vitest",
-		"test:coverage": "vitest run --coverage"
+		"test:coverage": "vitest run --coverage",
+		"test:e2e": "playwright test"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^2.0.4",
 		"@eslint/js": "^10.0.1",
 		"@fontsource-variable/jetbrains-mono": "^5.2.8",
+		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E test configuration.
+ *
+ * **位置づけ**: Auth.js 移行後 (PR-A3 以降) に Magic Link sign-in → CRUD のフルパス E2E を書く土台。
+ * 本 PR (PR-T5) ではホーム画面の smoke 1 件のみ。
+ *
+ * - 既定では preview build (`pnpm build && pnpm preview`) を Playwright が起動
+ * - CI は Chromium のみ (コスト削減)、ローカルは 3 ブラウザ並行
+ * - storageState は Phase 3 で sign-in fixture を作るときに利用 (現状は authless smoke のみ)
+ */
+export default defineConfig({
+	testDir: 'e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 1 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? 'github' : 'list',
+	use: {
+		baseURL: 'http://localhost:4173',
+		trace: 'on-first-retry'
+	},
+	projects: process.env.CI
+		? [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
+		: [
+				{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+				{ name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+				{ name: 'webkit', use: { ...devices['Desktop Safari'] } }
+			],
+	webServer: {
+		command: 'pnpm preview --host 127.0.0.1 --port 4173',
+		url: 'http://localhost:4173',
+		reuseExistingServer: !process.env.CI,
+		timeout: 120_000
+	}
+});

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
         version: 5.5.4(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))
@@ -438,6 +441,11 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -1423,6 +1431,11 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1726,6 +1739,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -2775,6 +2798,10 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
@@ -3801,6 +3828,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4038,6 +4068,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@3.1.4(postcss@8.5.13):
     dependencies:


### PR DESCRIPTION
Phase 3 (Auth.js + Magic Link 移行) で sign-in → CRUD の E2E が必要になる。本 PR は基盤 (config + skeleton) のみ整え、実 spec は PR-A3 以降で追加。Clerk フローの E2E は撤去予定なので書かない。詳細は #77 参照。

## 依存
- `@playwright/test@^1.59`

## 新規
- `web/playwright.config.ts`: ローカル = Chromium/Firefox/WebKit、CI = Chromium のみ、`webServer` で `pnpm preview` を auto-start
- `web/e2e/smoke.spec.ts`: ホーム画面が < 400 ステータスを返す最小 smoke
- `web/e2e/.gitignore`: test-results / playwright-report / cache 除外

## 設定
- `web/package.json`: `test:e2e` script
- `.github/workflows/ci.yaml`: `test-e2e` job (`if: false` で disable、Phase 3 完了で有効化)
- `.gitignore`: `web/test-results` / `web/playwright-report` / `web/playwright/.cache`
- `docs/adr/0007`: Playwright 章を充実 (config 概要、spec は PR-A3 以降)

## 検証
- `pnpm check` 緑 (1730 files / 0 errors)
- `pnpm test` (vitest) 緑 — e2e/ は include glob 外
- 実 E2E 実行は **未試行** (sign-in / DB のセットアップが必要、Phase 3 で対応)

## 含まないもの
- 実 E2E spec (PR-A3 以降、Magic Link 経由 sign-in fixture)
- visual regression / Lighthouse
- CI で `test-e2e` を有効化 (Phase 3 完了まで `if: false`)

Closes #77