### PR TITLE
feat(auth): Auth.js 基盤 + lib/auth.ts abstraction

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,9 +1,15 @@
-# Clerk
+# Clerk (PR-A5 で撤去予定)
 CLERK_SECRET_KEY_PARAM=/resource-planner/clerk-secret-key
 PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx
 # IMPORTANT: 実値は git に commit しないこと。`.env.local` (.gitignore) で実ドメインを設定し、
 # 本番は SSM Parameter Store / GitHub Secrets で渡す。
 ALLOWED_DOMAIN=your-company.example.com
+
+# Auth.js (#65、PR-A1 で配線、PR-A3 から実利用)
+# AUTH_SECRET は `openssl rand -hex 32` で生成、git に commit しない (.env.local 経由)。
+# 本番は SSM SecureString (PR-A4 で配備)。
+AUTH_SECRET=replace-with-openssl-rand-hex-32
+AUTH_TRUST_HOST=true
 
 # DynamoDB
 DYNAMODB_TABLE=resource-planner

--- a/web/package.json
+++ b/web/package.json
@@ -49,6 +49,7 @@
 		"vitest": "^4.1.5"
 	},
 	"dependencies": {
+		"@auth/sveltekit": "^1.11.2",
 		"@aws-sdk/client-dynamodb": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1042.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@auth/sveltekit':
+        specifier: ^1.11.2
+        version: 1.11.2(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1045.0
         version: 3.1045.0
@@ -131,6 +134,36 @@ importers:
         version: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
 
 packages:
+
+  '@auth/core@0.41.2':
+    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/sveltekit@1.11.2':
+    resolution: {integrity: sha512-3Ifc1McYor3OHNChhOTcnJ2bQWWiVlSXxHe15vaVqhoUM//9MhbP6sSO2ChKuoocXVNQWATBCfkkxMAw1Z7QPw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.3
+      '@sveltejs/kit': ^1.0.0 || ^2.0.0
+      nodemailer: ^7.0.7
+      svelte: ^3.54.0 || ^4.0.0 || ^5.0.0-0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
 
   '@aws-crypto/sha256-browser@5.2.0':
     resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
@@ -441,6 +474,9 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@playwright/test@1.59.1':
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
@@ -1528,6 +1564,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -1685,6 +1724,9 @@ packages:
   nise@6.1.5:
     resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
 
+  oauth4webapi@3.8.6:
+    resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
+
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
 
@@ -1781,6 +1823,14 @@ packages:
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1897,6 +1947,9 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -2202,6 +2255,21 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@auth/core@0.41.2':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.2.3
+      oauth4webapi: 3.8.6
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/sveltekit@1.11.2(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+    dependencies:
+      '@auth/core': 0.41.2
+      '@sveltejs/kit': 2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
+      set-cookie-parser: 2.7.2
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -2797,6 +2865,8 @@ snapshots:
   '@nodable/entities@2.1.0': {}
 
   '@oxc-project/types@0.127.0': {}
+
+  '@panva/hkdf@1.2.1': {}
 
   '@playwright/test@1.59.1':
     dependencies:
@@ -3901,6 +3971,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   js-cookie@3.0.5: {}
 
   js-tokens@10.0.0: {}
@@ -4024,6 +4096,8 @@ snapshots:
       just-extend: 6.2.0
       path-to-regexp: 8.4.2
 
+  oauth4webapi@3.8.6: {}
+
   obliterator@1.6.1: {}
 
   obug@2.1.1: {}
@@ -4102,6 +4176,12 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 
@@ -4200,6 +4280,8 @@ snapshots:
       mri: 1.2.0
 
   semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   set-cookie-parser@3.1.0: {}
 

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -1,0 +1,18 @@
+/**
+ * Auth.js 設定の入り口 (#65 / #79)。
+ *
+ * 本ファイル (PR-A1) の役割は **構造の用意のみ**。Clerk と並行稼働させ、移行を段階的に進める:
+ * - PR-A2: DynamoDB adapter + GSI1 を追加 (DB schema 拡張とセット)
+ * - PR-A3: Nodemailer (Magic Link) provider 追加 + sign-in UI
+ * - PR-A4: Infra (SES + SSM AUTH_SECRET)
+ * - PR-A5: Clerk 完全撤去 + ADR 0008/0009
+ *
+ * 本 PR 時点では providers が空のため Auth.js 経由の sign-in は実行できない。
+ * 既存 Clerk サインインフローはそのまま動作する (hooks.server.ts で sequence)。
+ */
+import { SvelteKitAuth } from '@auth/sveltekit';
+
+export const { handle, signIn, signOut } = SvelteKitAuth({
+	providers: [],
+	trustHost: true
+});

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -3,6 +3,7 @@ import { error, type Handle } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { withClerkHandler, createClerkClient } from 'svelte-clerk/server';
+import { handle as authjsHandle } from './auth';
 
 if (!env.CLERK_SECRET_KEY_PARAM) {
 	throw new Error('CLERK_SECRET_KEY_PARAM env not set');
@@ -52,4 +53,7 @@ const domainCheck: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
-export const handle = sequence(clerkHandler, domainCheck);
+// Auth.js を sequence の **先頭** に置く: locals.auth は最終的に Clerk のもので上書きされ、
+// 既存 Clerk 動作は維持される。Auth.js は providers が空なので no-op だが、`/auth/*` ルート
+// (PR-A3 以降の sign-in flow) を予約する目的で配線しておく。
+export const handle = sequence(authjsHandle, clerkHandler, domainCheck);

--- a/web/src/lib/auth.test.ts
+++ b/web/src/lib/auth.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { RequestEvent } from '@sveltejs/kit';
+import { requireSession } from './auth';
+
+function mockEvent(authReturn: unknown): RequestEvent {
+	return {
+		locals: {
+			auth: () => authReturn
+		}
+	} as unknown as RequestEvent;
+}
+
+interface HttpErrorLike {
+	status: number;
+	body: { message: string };
+}
+
+function expectHttpError(fn: () => unknown, status: number, messageRegex: RegExp): void {
+	try {
+		fn();
+		throw new Error('expected requireSession to throw, but it did not');
+	} catch (e) {
+		const err = e as HttpErrorLike;
+		expect(err.status).toBe(status);
+		expect(err.body.message).toMatch(messageRegex);
+	}
+}
+
+describe('requireSession', () => {
+	it('returns AppSession when Clerk session has userId + primaryEmail', () => {
+		const event = mockEvent({
+			userId: 'user_abc',
+			sessionClaims: { primaryEmail: 'alice@example.com' }
+		});
+
+		const session = requireSession(event);
+
+		expect(session).toEqual({
+			userId: 'user_abc',
+			email: 'alice@example.com',
+			name: undefined,
+			teamId: 'team_default'
+		});
+	});
+
+	it('falls back to sessionClaims.email when primaryEmail is missing', () => {
+		const event = mockEvent({
+			userId: 'user_abc',
+			sessionClaims: { email: 'fallback@example.com' }
+		});
+
+		expect(requireSession(event).email).toBe('fallback@example.com');
+	});
+
+	it('throws 401 when locals.auth is not a function (no auth handler installed)', () => {
+		const event = { locals: {} } as unknown as RequestEvent;
+		expectHttpError(() => requireSession(event), 401, /認証/);
+	});
+
+	it('throws 401 when userId is null (Clerk: signed out)', () => {
+		const event = mockEvent({ userId: null });
+		expectHttpError(() => requireSession(event), 401, /認証/);
+	});
+
+	it('throws 401 when locals.auth() returns a Promise (Auth.js without providers, no session)', () => {
+		// Auth.js の locals.auth は Promise<Session | null> を返す。Clerk 上書きが効いていない
+		// 状況のシミュレーション。Clerk 同居中は Promise が返ってくる時点で認証なし扱い。
+		const event = mockEvent(Promise.resolve(null));
+		expectHttpError(() => requireSession(event), 401, /認証/);
+	});
+
+	it('throws 401 when sessionClaims has no email at all', () => {
+		const event = mockEvent({
+			userId: 'user_abc',
+			sessionClaims: {}
+		});
+		expectHttpError(() => requireSession(event), 401, /メールアドレス/);
+	});
+});

--- a/web/src/lib/auth.ts
+++ b/web/src/lib/auth.ts
@@ -1,0 +1,66 @@
+/**
+ * Provider 非依存の認証セッション抽象 (#65 / #79)。
+ *
+ * Clerk → Auth.js への段階移行中、`+page.server.ts` の form action / `+layout.server.ts` の
+ * load から呼ばれる「現在のユーザーを取得する」入り口を 1 箇所に集約する。
+ *
+ * **PR-A1 時点の挙動**: hooks.server.ts の `sequence(authHandle, clerkHandler, ...)` 順により
+ * `event.locals.auth` は最終的に **Clerk のもの** で上書きされる (Auth.js は providers 空なので
+ * 実質 no-op)。本関数は Clerk session を読み出して `AppSession` 形に整形する。
+ *
+ * - PR-A2: `teamId` を Team モデル (DDB GSI1) 経由で取得
+ * - PR-A3: Auth.js Magic Link 経由の session も読めるように
+ * - PR-A5: Clerk fallback を削除、Auth.js 専用に簡素化
+ */
+import { error, type RequestEvent } from '@sveltejs/kit';
+
+export interface AppSession {
+	userId: string;
+	email: string;
+	name?: string;
+	/** 現在の active team。本 PR では `'team_default'` 固定、将来は last-used / URL ベース。 */
+	teamId: string;
+}
+
+const DEFAULT_TEAM_ID = 'team_default';
+
+interface ClerkLikeAuth {
+	userId: string | null;
+	sessionClaims?: Record<string, unknown>;
+}
+
+/**
+ * 認証済セッションを取得する。未認証なら 401 を throw する。
+ * 現状は Clerk session 由来。PR-A3 以降で Auth.js session も併読する。
+ */
+export function requireSession(event: RequestEvent): AppSession {
+	const authFn = event.locals.auth as unknown;
+	if (typeof authFn !== 'function') {
+		error(401, '認証が必要です');
+	}
+
+	const result = (authFn as () => unknown)();
+	// Auth.js は Promise を返す (PR-A3 以降に await で扱う)。Clerk は同期 object を返す。
+	if (!result || typeof result !== 'object' || result instanceof Promise) {
+		error(401, '認証が必要です');
+	}
+
+	const clerk = result as ClerkLikeAuth;
+	if (!clerk.userId) {
+		error(401, '認証が必要です');
+	}
+
+	const email = (clerk.sessionClaims?.primaryEmail ?? clerk.sessionClaims?.email) as
+		| string
+		| undefined;
+	if (!email) {
+		error(401, 'メールアドレスがセッションに含まれていません');
+	}
+
+	return {
+		userId: clerk.userId,
+		email,
+		name: undefined,
+		teamId: DEFAULT_TEAM_ID
+	};
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,6 +7,7 @@ import { defineConfig } from 'vite';
 // vitest 起動時には既に固定されている。test 専用のダミー値を SvelteKit plugin より先に注入する。
 if (process.env.VITEST) {
 	process.env.DYNAMODB_TABLE = process.env.DYNAMODB_TABLE ?? 'resource-planner-test';
+	process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'test-secret-not-for-production';
 }
 
 export default defineConfig({


### PR DESCRIPTION
#65 (auth migration epic) Phase 3 着手。本 PR は **構造のみ**: Clerk と Auth.js を両方同居させ、段階移行の最初のステップ。詳細は #79 参照。

## 依存追加
- `@auth/sveltekit@^1.11.2` (公式 docs 確認済、Svelte 5 対応、experimental flag あり、版固定)

## 新規
- `web/src/auth.ts`: `SvelteKitAuth({ providers: [], trustHost: true })` の最小設定 (adapter は PR-A2、Nodemailer は PR-A3)
- `web/src/lib/auth.ts`:
  - `AppSession` interface (`userId`, `email`, `name?`, `teamId`)
  - `requireSession(event)` — `hooks.server.ts` の sequence 順で `locals.auth` は Clerk が最終上書き、本 PR では Clerk session を読み出して AppSession に整形
  - `teamId` は `'team_default'` 固定 (PR-A2 で Team モデル経由に切替)
- `web/src/lib/auth.test.ts`: 6 ケース (成功 / 401 / Promise return / no email)

## 変更
- `web/src/hooks.server.ts`: `sequence(authjsHandle, clerkHandler, domainCheck)` で Auth.js handle を先頭に追加 (Clerk 動作維持、`/auth/*` ルート予約)
- `web/vite.config.ts`: `VITEST` 検出時に `AUTH_SECRET` ダミーも inject
- `web/.env.example`: `AUTH_SECRET` / `AUTH_TRUST_HOST` placeholder 追加

## 検証
- `pnpm test` 緑 (60 passing / 4 skipped、unit + integration on DDB Local)
- `pnpm check` 緑 (1759 files / 0 errors)
- `pnpm build` 緑 (adapter-node)

## 含まないもの
- DynamoDB adapter (PR-A2 で GSI1 schema 拡張とセット)
- Magic Link provider + sign-in UI (PR-A3)
- Infra (SES + SSM AUTH_SECRET) (PR-A4)
- Clerk 撤去 (PR-A5)
- ADR 0008 (PR-A5 で完成形を書く)

## 既存挙動への影響
**無し**。Auth.js は providers が空なので handle は no-op、既存 Clerk サインインフロー / 既存 form action / `+layout.server.ts` はそのまま動作する。

Closes #79