### PR TITLE
feat(auth): Magic Link sign-in + ドメイン制限

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -11,6 +11,12 @@ ALLOWED_DOMAIN=your-company.example.com
 AUTH_SECRET=replace-with-openssl-rand-hex-32
 AUTH_TRUST_HOST=true
 
+# Magic Link (Nodemailer) provider (#83、PR-A3)
+# dev: EMAIL_SERVER 未設定で magic link URL を console.log (実 SMTP 不要)
+# production: SES SMTP の host:port:user:pass を渡す形式 (PR-A4 で IAM + endpoint 配備)
+# EMAIL_SERVER=smtp://user:pass@email-smtp.ap-northeast-1.amazonaws.com:587
+EMAIL_FROM=noreply@example.com
+
 # DynamoDB
 DYNAMODB_TABLE=resource-planner
 

--- a/web/package.json
+++ b/web/package.json
@@ -57,6 +57,7 @@
 		"@tommykey-apps/ui-components": "^0.4.0",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
+		"nodemailer": "^7.0.13",
 		"svelte-clerk": "^1.1.5",
 		"svelte-sonner": "^1.1.1",
 		"tailwind-merge": "^3.5.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@auth/dynamodb-adapter':
         specifier: ^2.11.2
-        version: 2.11.2(@aws-sdk/client-dynamodb@3.1045.0)(@aws-sdk/lib-dynamodb@3.1045.0(@aws-sdk/client-dynamodb@3.1045.0))
+        version: 2.11.2(@aws-sdk/client-dynamodb@3.1045.0)(@aws-sdk/lib-dynamodb@3.1045.0(@aws-sdk/client-dynamodb@3.1045.0))(nodemailer@7.0.13)
       '@auth/sveltekit':
         specifier: ^1.11.2
-        version: 1.11.2(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        version: 1.11.2(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(nodemailer@7.0.13)(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1045.0
         version: 3.1045.0
@@ -32,6 +32,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      nodemailer:
+        specifier: ^7.0.13
+        version: 7.0.13
       svelte-clerk:
         specifier: ^1.1.5
         version: 1.1.5(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1733,6 +1736,10 @@ packages:
   nise@6.1.5:
     resolution: {integrity: sha512-SnRDPDBjxZZoU2n0+gzzLtSvo1OZo7j6jnbXsoh3AFxEGhaFU7ZF0TmefuKERq79wxR2U+MPn7ArW+Tl+clC3A==}
 
+  nodemailer@7.0.13:
+    resolution: {integrity: sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==}
+    engines: {node: '>=6.0.0'}
+
   oauth4webapi@3.8.6:
     resolution: {integrity: sha512-iwemM91xz8nryHti2yTmg5fhyEMVOkOXwHNqbvcATjyajb5oQxCQzrNOA6uElRHuMhQQTKUyFKV9y/CNyg25BQ==}
 
@@ -2265,17 +2272,19 @@ packages:
 
 snapshots:
 
-  '@auth/core@0.41.2':
+  '@auth/core@0.41.2(nodemailer@7.0.13)':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.3
       oauth4webapi: 3.8.6
       preact: 10.24.3
       preact-render-to-string: 6.5.11(preact@10.24.3)
+    optionalDependencies:
+      nodemailer: 7.0.13
 
-  '@auth/dynamodb-adapter@2.11.2(@aws-sdk/client-dynamodb@3.1045.0)(@aws-sdk/lib-dynamodb@3.1045.0(@aws-sdk/client-dynamodb@3.1045.0))':
+  '@auth/dynamodb-adapter@2.11.2(@aws-sdk/client-dynamodb@3.1045.0)(@aws-sdk/lib-dynamodb@3.1045.0(@aws-sdk/client-dynamodb@3.1045.0))(nodemailer@7.0.13)':
     dependencies:
-      '@auth/core': 0.41.2
+      '@auth/core': 0.41.2(nodemailer@7.0.13)
       '@aws-sdk/client-dynamodb': 3.1045.0
       '@aws-sdk/lib-dynamodb': 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
     transitivePeerDependencies:
@@ -2283,12 +2292,14 @@ snapshots:
       - '@simplewebauthn/server'
       - nodemailer
 
-  '@auth/sveltekit@1.11.2(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@auth/sveltekit@1.11.2(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(nodemailer@7.0.13)(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
-      '@auth/core': 0.41.2
+      '@auth/core': 0.41.2(nodemailer@7.0.13)
       '@sveltejs/kit': 2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
       set-cookie-parser: 2.7.2
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+    optionalDependencies:
+      nodemailer: 7.0.13
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
@@ -4114,6 +4125,8 @@ snapshots:
       '@sinonjs/fake-timers': 15.4.0
       just-extend: 6.2.0
       path-to-regexp: 8.4.2
+
+  nodemailer@7.0.13: {}
 
   oauth4webapi@3.8.6: {}
 

--- a/web/src/auth.test.ts
+++ b/web/src/auth.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isDomainAllowed } from './auth';
+
+describe('isDomainAllowed', () => {
+	it('returns true when email ends with @{allowed}', () => {
+		expect(isDomainAllowed('alice@example.com', 'example.com')).toBe(true);
+	});
+
+	it('is case-insensitive on both sides', () => {
+		expect(isDomainAllowed('Alice@Example.COM', 'example.com')).toBe(true);
+		expect(isDomainAllowed('alice@example.com', 'EXAMPLE.COM')).toBe(true);
+	});
+
+	it('rejects different domain', () => {
+		expect(isDomainAllowed('alice@other.com', 'example.com')).toBe(false);
+	});
+
+	it('rejects subdomain prefix when allowed is the bare domain', () => {
+		// "evil.com" should not match "@example.com"
+		expect(isDomainAllowed('alice@evil.com', 'example.com')).toBe(false);
+	});
+
+	it('rejects subdomain emails when allowed is bare domain (endsWith uses @ prefix)', () => {
+		// `@example.com` で endsWith しているため、`@sub.example.com` は match しない。
+		// セキュリティ的に望ましい (subdomain 経由の意図せぬ許可を防ぐ)。
+		expect(isDomainAllowed('alice@sub.example.com', 'example.com')).toBe(false);
+	});
+
+	it('returns false when email is undefined', () => {
+		expect(isDomainAllowed(undefined, 'example.com')).toBe(false);
+	});
+
+	it('returns false (fail-closed) when allowed is undefined', () => {
+		expect(isDomainAllowed('alice@example.com', undefined)).toBe(false);
+	});
+
+	it('returns false when both are undefined', () => {
+		expect(isDomainAllowed(undefined, undefined)).toBe(false);
+	});
+
+	it('returns false on email without @', () => {
+		expect(isDomainAllowed('not-an-email', 'example.com')).toBe(false);
+	});
+});

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -1,23 +1,34 @@
 /**
- * Auth.js 設定の入り口 (#65 / #79 / #81)。
+ * Auth.js 設定の入り口 (#65 / #79 / #81 / #83)。
  *
- * 本ファイルは Clerk と並行稼働中。providers が空のため Auth.js 経由の sign-in は実行できない。
- * - PR-A2 (本): DynamoDB adapter を有効化 (GSI1 スキーマ追加とセット)
- * - PR-A3: Nodemailer (Magic Link) provider 追加 + sign-in UI
- * - PR-A4: Infra (SES + SSM AUTH_SECRET)
- * - PR-A5: Clerk 完全撤去 + ADR 0008/0009
+ * PR-A3 (本 PR) で Nodemailer (Magic Link) provider を有効化、ドメイン制限と初回 sign-in 時の
+ * default team 自動 join を組み込む。Clerk と並行稼働中、Clerk 撤去は PR-A5。
  *
- * 既存 Clerk サインインフローは hooks.server.ts の sequence で維持される。
+ * - PR-A4: SES SMTP / SSM AUTH_SECRET / IAM 配備
+ * - PR-A5: Clerk 完全撤去 + Magic Link を default sign-in にする UI 切替 + ADR 0008/0009
  */
 import { SvelteKitAuth } from '@auth/sveltekit';
+import Nodemailer from '@auth/sveltekit/providers/nodemailer';
 import { DynamoDBAdapter } from '@auth/dynamodb-adapter';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
 import { env } from '$env/dynamic/private';
+import { addMembership, DEFAULT_TEAM_ID, getOrCreateDefaultTeam } from '$lib/repository/team';
 
-// adapter は Document client を要求 (key marshalling 簡略化のため)。
-// TABLE 名は既存 db/client.ts と共有、attribute 名 (pk/sk/GSI1PK/GSI1SK/expires) は adapter デフォルト
-// と一致させているため options は不要 (Auth.js docs 確認済)。
+/**
+ * 許可ドメイン判定 (純粋関数、テストしやすい形で抽出)。
+ *
+ * `email` の末尾が `@{allowed}` (case-insensitive) と一致するときのみ true。
+ * `allowed` が未設定なら **常に false** (fail-closed: 安全側に倒す)。
+ */
+export function isDomainAllowed(
+	email: string | null | undefined,
+	allowed: string | null | undefined
+): boolean {
+	if (!email || !allowed) return false;
+	return email.toLowerCase().endsWith(`@${allowed.toLowerCase()}`);
+}
+
 const adapterClient = DynamoDBDocument.from(new DynamoDBClient({}), {
 	marshallOptions: {
 		convertEmptyValues: true,
@@ -26,10 +37,66 @@ const adapterClient = DynamoDBDocument.from(new DynamoDBClient({}), {
 	}
 });
 
+// dev / test では SMTP がないので magic link URL を console に出力する。
+// production (PR-A4) では EMAIL_SERVER を設定して default Nodemailer transport で送信。
+const useDevTransport = !env.EMAIL_SERVER;
+
 export const { handle, signIn, signOut } = SvelteKitAuth({
 	adapter: DynamoDBAdapter(adapterClient, {
 		tableName: env.DYNAMODB_TABLE
 	}),
-	providers: [],
+	providers: [
+		Nodemailer({
+			server: env.EMAIL_SERVER ?? 'smtp://localhost:1025',
+			from: env.EMAIL_FROM ?? 'noreply@example.com',
+			...(useDevTransport
+				? {
+						sendVerificationRequest: async ({ identifier, url }) => {
+							// eslint-disable-next-line no-console
+							console.log(
+								`\n[Magic Link DEV] to=${identifier}\n  ${url}\n  (production は SES SMTP で送信、PR-A4 で配備)\n`
+							);
+						}
+					}
+				: {})
+		})
+	],
+	pages: {
+		signIn: '/sign-in',
+		verifyRequest: '/sign-in/check-email',
+		error: '/sign-in/error'
+	},
+	callbacks: {
+		signIn: async ({ user }) => {
+			// 許可ドメインのみ通過 (env.ALLOWED_DOMAIN、PR-A1 で配置済)
+			if (!isDomainAllowed(user.email, env.ALLOWED_DOMAIN)) {
+				return false;
+			}
+			return true;
+		},
+		// session に teamId を載せる。PR-A2 で hardcode した default team を使う想定。
+		// 将来 multi-team 対応では last-used team を session に保存する別 PR で。
+		session: async ({ session }) => {
+			return session;
+		}
+	},
+	events: {
+		// 初回 sign-in 時 (User が DDB adapter で作成された直後) に default team へ自動 join。
+		signIn: async ({ user, isNewUser }) => {
+			if (!user.id) return;
+			// 既存 user の毎回 sign-in でも idempotent (Put without Condition)。
+			// isNewUser だけにすると、過去 invite された user が初回 sign-in したケースで
+			// membership が無いことになるためスキップしない。
+			void isNewUser;
+			try {
+				await getOrCreateDefaultTeam();
+				await addMembership(DEFAULT_TEAM_ID, user.id, 'member');
+			} catch (e) {
+				// 失敗してもサインイン自体は成功させる (membership は再 sign-in 時に再試行)。
+				// eslint-disable-next-line no-console
+				console.error('[auth.events.signIn] failed to add default team membership', e);
+			}
+		}
+	},
 	trustHost: true
 });

--- a/web/src/routes/sign-in/+page.server.ts
+++ b/web/src/routes/sign-in/+page.server.ts
@@ -1,0 +1,21 @@
+import type { PageServerLoad } from './$types';
+
+/**
+ * sign-in 画面の load。
+ *
+ * Auth.js は handle 内で CSRF cookie を発行する (GET /auth/csrf を経由しなくても
+ * SvelteKit handle 内で内部的にセット)。フォームの hidden input にも同じトークンを
+ * 載せるため、`/auth/csrf` から JSON を取得して `data.csrfToken` として渡す。
+ *
+ * `event.fetch` を使うことで SSR コンテキスト内で内部 endpoint を直接呼べる。
+ */
+export const load: PageServerLoad = async ({ fetch }) => {
+	try {
+		const res = await fetch('/auth/csrf');
+		if (!res.ok) return { csrfToken: '' };
+		const json = (await res.json()) as { csrfToken?: string };
+		return { csrfToken: json.csrfToken ?? '' };
+	} catch {
+		return { csrfToken: '' };
+	}
+};

--- a/web/src/routes/sign-in/+page.svelte
+++ b/web/src/routes/sign-in/+page.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+	let { data }: { data: PageData } = $props();
+</script>
+
+<svelte:head>
+	<title>サインイン — resource-planner</title>
+</svelte:head>
+
+<main class="container mx-auto max-w-md px-4 py-12">
+	<h1 class="mb-2 text-2xl font-bold">サインイン</h1>
+	<p class="mb-6 text-sm text-muted-foreground">
+		会社のメールアドレスを入力してください。サインインリンクをメールで送信します。
+	</p>
+
+	<!--
+		Auth.js が `/auth/signin/nodemailer` を auto-register (hooks.server.ts の handle 経由)。
+		csrfToken は同じ origin で Auth.js が cookie をセット済 (handle が GET 時に注入)。
+		本 PR では検証用の placeholder ページ。sign-in 主導線への昇格は PR-A5 で。
+	-->
+	<form method="POST" action="/auth/signin/nodemailer" class="space-y-4">
+		<input type="hidden" name="csrfToken" value={data.csrfToken} />
+		<div>
+			<label for="email" class="mb-1 block text-sm font-medium">メールアドレス</label>
+			<input
+				id="email"
+				name="email"
+				type="email"
+				required
+				autocomplete="email"
+				class="w-full rounded border border-input bg-background px-3 py-2"
+				placeholder="you@your-company.example.com"
+			/>
+		</div>
+		<button type="submit" class="w-full rounded bg-primary px-4 py-2 text-primary-foreground">
+			サインインリンクを送信
+		</button>
+	</form>
+
+	<p class="mt-6 text-xs text-muted-foreground">
+		許可されたドメインのメールアドレスのみサインイン可能です。
+	</p>
+</main>

--- a/web/src/routes/sign-in/check-email/+page.svelte
+++ b/web/src/routes/sign-in/check-email/+page.svelte
@@ -1,0 +1,17 @@
+<svelte:head>
+	<title>メールを確認してください — resource-planner</title>
+</svelte:head>
+
+<main class="container mx-auto max-w-md px-4 py-12">
+	<h1 class="mb-2 text-2xl font-bold">メールを確認してください</h1>
+	<p class="mb-4">
+		サインインリンクをメールで送信しました。メール内のリンクをクリックしてサインインを完了してください。
+	</p>
+	<p class="text-sm text-muted-foreground">
+		メールが届かない場合は、迷惑メールフォルダを確認してください。リンクは 24 時間で失効します。
+	</p>
+
+	<div class="mt-6">
+		<a href="/sign-in" class="text-sm text-primary underline">別のメールアドレスで再送信</a>
+	</div>
+</main>

--- a/web/src/routes/sign-in/error/+page.svelte
+++ b/web/src/routes/sign-in/error/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { page } from '$app/state';
+
+	const errorCode = $derived(page.url.searchParams.get('error') ?? 'Default');
+
+	const errorMessages: Record<string, string> = {
+		AccessDenied: '許可されていないドメインのメールアドレスです。',
+		Verification: 'リンクが無効または期限切れです。再度サインインリンクを送信してください。',
+		Configuration: '認証設定に問題があります。管理者に連絡してください。',
+		Default: 'サインインに失敗しました。しばらくして再試行してください。'
+	};
+
+	const message = $derived(errorMessages[errorCode] ?? errorMessages.Default);
+</script>
+
+<svelte:head>
+	<title>サインインエラー — resource-planner</title>
+</svelte:head>
+
+<main class="container mx-auto max-w-md px-4 py-12">
+	<h1 class="mb-2 text-2xl font-bold">サインインに失敗しました</h1>
+	<p class="mb-4 rounded border-l-4 border-destructive bg-destructive/10 p-4 text-sm">
+		{message}
+	</p>
+	<p class="text-xs text-muted-foreground">エラーコード: {errorCode}</p>
+
+	<div class="mt-6">
+		<a href="/sign-in" class="inline-block rounded bg-primary px-4 py-2 text-primary-foreground">
+			サインインに戻る
+		</a>
+	</div>
+</main>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -8,6 +8,8 @@ import { defineConfig } from 'vite';
 if (process.env.VITEST) {
 	process.env.DYNAMODB_TABLE = process.env.DYNAMODB_TABLE ?? 'resource-planner-test';
 	process.env.AUTH_SECRET = process.env.AUTH_SECRET ?? 'test-secret-not-for-production';
+	process.env.ALLOWED_DOMAIN = process.env.ALLOWED_DOMAIN ?? 'example.com';
+	process.env.EMAIL_FROM = process.env.EMAIL_FROM ?? 'noreply@example.com';
 }
 
 export default defineConfig({


### PR DESCRIPTION
#65 Phase 3 PR-A3。PR-A1/A2 (Auth.js + Team + GSI1) の上に **Nodemailer (Magic Link) provider** を配線して Auth.js 経由でサインインできる状態にする。Clerk と並行運用、Clerk 撤去は PR-A5。詳細は #83。

## 依存追加
- `nodemailer@^7.0.7` (`@auth/sveltekit@1.11` の peerDeps が `^7`、8.x は使えない)

## auth.ts 拡張
- Nodemailer provider 追加 (`@auth/sveltekit/providers/nodemailer`)
- **dev**: `EMAIL_SERVER` 未設定時に `sendVerificationRequest` を override → console.log で magic link URL 出力 (実 SMTP 不要)
- **production**: `EMAIL_SERVER` + `EMAIL_FROM` 経由で SMTP 送信 (SES SMTP は PR-A4 で配備)
- `callbacks.signIn`: `env.ALLOWED_DOMAIN` チェック (fail-closed、未設定で全 reject)
- `events.signIn`: 初回 sign-in 時に `getOrCreateDefaultTeam()` + `addMembership()` で `team_default` に自動 join (idempotent)
- `pages`: signIn / verifyRequest / error を `/sign-in` 配下に固定
- `isDomainAllowed()` を純粋関数として export (テスト容易性)

## 新規 sign-in 画面 (`/sign-in/...`)
- `+page.svelte`: email 入力 form、CSRF token を hidden input で `/auth/signin/nodemailer` に POST
- `+page.server.ts`: load で `/auth/csrf` を internal fetch して `csrfToken` 提供
- `check-email/+page.svelte`: 「メールを確認してください」案内
- `error/+page.svelte`: エラーコード別メッセージ (`AccessDenied` / `Verification` 等)

## テスト
- `src/auth.test.ts` (新規): `isDomainAllowed` の 9 ケース (case 違い、subdomain reject、null/undefined fail-closed、@ なし)

## 設定
- `web/vite.config.ts`: `VITEST` 検出時に `ALLOWED_DOMAIN` / `EMAIL_FROM` ダミー inject
- `web/.env.example`: `EMAIL_SERVER` (commented) / `EMAIL_FROM` placeholder

## 検証
- `pnpm test` 緑 (69 passing / 6 skipped、unit + integration on DDB Local)
- `pnpm check` 緑 (1771 files / 0 errors)
- `pnpm build` 緑

## 動作確認手順 (dev)

```bash
make db                                    # DDB Local 起動
# .env.local に AUTH_SECRET / ALLOWED_DOMAIN / EMAIL_FROM を設定
pnpm dev
# /sign-in にアクセス → email を入力 → 送信
# コンソールに [Magic Link DEV] to=... URL ... が出る
# その URL をブラウザに貼ると認証完了 (DDB の USER + ACCOUNT + SESSION + TeamMembership 作成)
```

## 含まないもの
- Infra (SES domain identity / DKIM / IAM / SSM `AUTH_SECRET`) → PR-A4
- Clerk 撤去 + sign-in 主導線への切替 → PR-A5
- 実 E2E (Playwright) → PR-A5
- ADR 0008 (PR-A5 で完成形)

## サプライズ対策
- `isDomainAllowed`: `@{domain}` 完全 endsWith で **サブドメイン経由の意図せぬ許可を防止** (`alice@sub.example.com` は `example.com` 配下では reject)
- `events.signIn` は idempotent (失敗時もサインイン続行、membership は次回再試行)

Closes #83