### PR TITLE
infra(auth): SES + AUTH_SECRET SSM + Lambda IAM/env (PR-A4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ OpenAPI は使わず、TypeScript 型 + Zod schema を API 仕様の正本とし
 | [0004](docs/adr/0004-end-date-exclusive-with-form-transform.md) | endDate は exclusive 半開区間 + Zod transform | Accepted |
 | [0005](docs/adr/0005-assignment-drag-resize-transport.md) | Assignment ドラッグ / リサイズは `+server.ts` API + Optimistic UI | Accepted |
 | [0006](docs/adr/0006-cascade-delete-strategy.md) | Resource / Project の削除は cascade (TransactWriteItems) | Accepted |
+| [0007](docs/adr/0007-tdd-with-vitest-and-playwright.md) | TDD で開発する: Vitest + Playwright | Accepted |
 
 ### Use Cases
 
@@ -135,6 +136,33 @@ OpenAPI は使わず、TypeScript 型 + Zod schema を API 仕様の正本とし
 
 新機能を追加するときは [`.github/ISSUE_TEMPLATE/feature.yml`](.github/ISSUE_TEMPLATE/feature.yml) を使う。
 ADR / use-case / 型定義の追加が AC に含まれる。
+
+## 本番投入手順 (Auth.js infra、PR-A4)
+
+`infra/` を `terraform apply` した後、以下を **手動で 1 度だけ** 実行する:
+
+```bash
+# 1. AUTH_SECRET を生成して SSM SecureString に投入 (terraform state には残さない)
+SECRET=$(openssl rand -hex 32)
+aws ssm put-parameter \
+  --name /resource-planner/auth-secret \
+  --value "$SECRET" \
+  --type SecureString \
+  --overwrite \
+  --region ap-northeast-1
+
+# 2. SES domain identity の verified 状態を確認 (DKIM CNAME 反映に最大 15 分)
+aws sesv2 get-email-identity \
+  --email-identity tommykeyapp.com \
+  --region ap-northeast-1
+# VerifiedForSendingStatus が true、DkimAttributes.Status が SUCCESS ならOK
+
+# 3. SES Sandbox 解除を申請 (本番ユーザーへの送信を有効化、24-48 時間)
+# AWS Console → SES → Account dashboard → Request production access
+# `ALLOWED_DOMAIN` 配下の社内ユーザーのみに送信する旨を理由に記載
+```
+
+その後 `gh secret set` で CD 用の env を本番用に揃える (`AUTH_SECRET` は SSM 経由で Lambda 起動時に取得するため、CD には不要)。
 
 ## 関連リポジトリ
 

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -56,14 +56,38 @@ resource "aws_iam_role_policy" "lambda_ssm" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = ["ssm:GetParameter"]
-        Resource = [aws_ssm_parameter.clerk_secret_key.arn]
+        Effect = "Allow"
+        Action = ["ssm:GetParameter"]
+        Resource = [
+          aws_ssm_parameter.clerk_secret_key.arn,
+          aws_ssm_parameter.auth_secret.arn
+        ]
       },
       {
         Effect   = "Allow"
         Action   = ["kms:Decrypt"]
         Resource = "arn:aws:kms:${var.region}:${data.aws_caller_identity.current.account_id}:alias/aws/ssm"
+      }
+    ]
+  })
+}
+
+# SES SendEmail 権限 (#85): Auth.js Magic Link を SESv2 SDK 経由で送信する。
+# domain identity (tommykeyapp.com) からの送信のみ許可。
+resource "aws_iam_role_policy" "lambda_ses" {
+  name = "${var.project}-ses-policy"
+  role = aws_iam_role.lambda.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ]
+        Resource = aws_ses_domain_identity.main.arn
       }
     ]
   })
@@ -85,6 +109,9 @@ resource "aws_lambda_function" "app" {
       CLERK_SECRET_KEY_PARAM       = aws_ssm_parameter.clerk_secret_key.name
       PUBLIC_CLERK_PUBLISHABLE_KEY = var.clerk_publishable_key
       ALLOWED_DOMAIN               = var.allowed_domain
+      AUTH_SECRET_PARAM            = aws_ssm_parameter.auth_secret.name
+      AUTH_TRUST_HOST              = "true"
+      EMAIL_FROM                   = var.email_from
     }
   }
 

--- a/infra/ses.tf
+++ b/infra/ses.tf
@@ -1,0 +1,42 @@
+/**
+ * SES (Simple Email Service) for Auth.js Magic Link sign-in (#65 / #85).
+ *
+ * - domain identity: tommykeyapp.com 配下の任意 from address (`noreply@...` 等) で送信可能
+ * - DKIM: domain identity 検証 + 受信側スパム判定対策で必須
+ * - SES sandbox: 本番 access 申請まで verified email にしか送信できない
+ *   → README に「本番投入前に AWS console で sandbox 解除申請」と明記
+ *
+ * SMTP credentials (`aws_iam_user` + `aws_iam_access_key`) は **発行しない**。
+ * Auth.js の sendVerificationRequest を SES SDK (SESv2) で実装するため、
+ * Lambda IAM role に `ses:SendEmail` 権限を付与する方針 (lambda.tf 参照)。
+ */
+resource "aws_ses_domain_identity" "main" {
+  domain = "tommykeyapp.com"
+}
+
+resource "aws_ses_domain_dkim" "main" {
+  domain = aws_ses_domain_identity.main.domain
+}
+
+resource "aws_route53_record" "ses_dkim" {
+  count   = 3
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "${aws_ses_domain_dkim.main.dkim_tokens[count.index]}._domainkey.${aws_ses_domain_identity.main.domain}"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.main.dkim_tokens[count.index]}.dkim.amazonses.com"]
+}
+
+# domain identity verify を Route53 TXT で完了させる (sandbox 内でも必須)
+resource "aws_route53_record" "ses_verification" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "_amazonses.${aws_ses_domain_identity.main.domain}"
+  type    = "TXT"
+  ttl     = 600
+  records = [aws_ses_domain_identity.main.verification_token]
+}
+
+resource "aws_ses_domain_identity_verification" "main" {
+  domain     = aws_ses_domain_identity.main.id
+  depends_on = [aws_route53_record.ses_verification]
+}

--- a/infra/ssm.tf
+++ b/infra/ssm.tf
@@ -22,3 +22,17 @@ resource "aws_ssm_parameter" "clerk_secret_key" {
   value = var.clerk_secret_key
   tier  = "Standard"
 }
+
+# Auth.js JWT secret (#85)。`openssl rand -hex 32` で生成し、terraform apply 後に
+# `aws ssm put-parameter --name /resource-planner/auth-secret --value <secret> --type SecureString --overwrite`
+# で投入する。terraform state に secret 値が残らないよう lifecycle.ignore_changes を設定。
+resource "aws_ssm_parameter" "auth_secret" {
+  name  = "/${var.project}/auth-secret"
+  type  = "SecureString"
+  value = "PLACEHOLDER_REPLACE_VIA_AWS_CLI"
+  tier  = "Standard"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -30,3 +30,9 @@ variable "allowed_domain" {
   description = "Email domain allowed to sign in (set via TF_VAR_allowed_domain or GitHub Secret, never commit literal value)"
   sensitive   = true
 }
+
+variable "email_from" {
+  type        = string
+  description = "Auth.js Magic Link sender (must be on aws_ses_domain_identity.main.domain)"
+  default     = "noreply@tommykeyapp.com"
+}

--- a/web/package.json
+++ b/web/package.json
@@ -52,6 +52,7 @@
 		"@auth/dynamodb-adapter": "^2.11.2",
 		"@auth/sveltekit": "^1.11.2",
 		"@aws-sdk/client-dynamodb": "^3.1045.0",
+		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1042.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
 		"@tommykey-apps/ui-components": "^0.4.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.1045.0
         version: 3.1045.0
+      '@aws-sdk/client-sesv2':
+        specifier: ^3.1045.0
+        version: 3.1045.0
       '@aws-sdk/client-ssm':
         specifier: ^3.1042.0
         version: 3.1042.0
@@ -192,6 +195,10 @@ packages:
 
   '@aws-sdk/client-dynamodb@3.1045.0':
     resolution: {integrity: sha512-TxZmhpziFxWD3pdXGbuwntKOX5OkW14yvCITYsRz+QDM5EUL4cIygu2xRGHiKDvKmb3QUOA4yKetAQcIMLe2zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sesv2@3.1045.0':
+    resolution: {integrity: sha512-Ae6oKWTod06687mIdKPnHPG5tolx/g68tqIbySMoWCs56OmRqn+7JiS3pOlpQeqjhbJlukfrXbsTMgZcXO9cSQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-ssm@3.1042.0':
@@ -2370,6 +2377,51 @@ snapshots:
       '@smithy/util-retry': 4.3.8
       '@smithy/util-utf8': 4.2.2
       '@smithy/util-waiter': 4.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sesv2@3.1045.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -1,17 +1,20 @@
 /**
- * Auth.js 設定の入り口 (#65 / #79 / #81 / #83)。
+ * Auth.js 設定の入り口 (#65 / #79 / #81 / #83 / #85)。
  *
- * PR-A3 (本 PR) で Nodemailer (Magic Link) provider を有効化、ドメイン制限と初回 sign-in 時の
- * default team 自動 join を組み込む。Clerk と並行稼働中、Clerk 撤去は PR-A5。
+ * PR-A4 (本 PR) で **production infra** (SSM AUTH_SECRET + SES SDK 経由送信) を実装。
+ * Clerk と並行稼働中、Clerk 撤去は PR-A5。
  *
- * - PR-A4: SES SMTP / SSM AUTH_SECRET / IAM 配備
- * - PR-A5: Clerk 完全撤去 + Magic Link を default sign-in にする UI 切替 + ADR 0008/0009
+ * - dev / test: env から AUTH_SECRET 直接 / sendVerificationRequest を console.log
+ * - production (Lambda): env.AUTH_SECRET 未設定 + env.AUTH_SECRET_PARAM 設定
+ *   → SSM SecureString から resolve、sendVerificationRequest を SES SDK で送信
  */
 import { SvelteKitAuth } from '@auth/sveltekit';
 import Nodemailer from '@auth/sveltekit/providers/nodemailer';
 import { DynamoDBAdapter } from '@auth/dynamodb-adapter';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
 import { env } from '$env/dynamic/private';
 import { addMembership, DEFAULT_TEAM_ID, getOrCreateDefaultTeam } from '$lib/repository/team';
 
@@ -29,6 +32,21 @@ export function isDomainAllowed(
 	return email.toLowerCase().endsWith(`@${allowed.toLowerCase()}`);
 }
 
+// ── AUTH_SECRET resolution ──
+// production: env.AUTH_SECRET_PARAM (SSM SecureString) を top-level await で fetch。
+// dev / test:  env.AUTH_SECRET をそのまま使う (vite.config.ts で test 用ダミー注入済)。
+let resolvedAuthSecret = env.AUTH_SECRET;
+if (!resolvedAuthSecret && env.AUTH_SECRET_PARAM) {
+	const ssm = new SSMClient({});
+	const out = await ssm.send(
+		new GetParameterCommand({ Name: env.AUTH_SECRET_PARAM, WithDecryption: true })
+	);
+	resolvedAuthSecret = out.Parameter?.Value;
+	if (!resolvedAuthSecret) {
+		throw new Error(`AUTH_SECRET could not be resolved from SSM param ${env.AUTH_SECRET_PARAM}`);
+	}
+}
+
 const adapterClient = DynamoDBDocument.from(new DynamoDBClient({}), {
 	marshallOptions: {
 		convertEmptyValues: true,
@@ -37,28 +55,60 @@ const adapterClient = DynamoDBDocument.from(new DynamoDBClient({}), {
 	}
 });
 
-// dev / test では SMTP がないので magic link URL を console に出力する。
-// production (PR-A4) では EMAIL_SERVER を設定して default Nodemailer transport で送信。
-const useDevTransport = !env.EMAIL_SERVER;
+// transport 選択:
+// - dev / test (`!env.EMAIL_SERVER` かつ `!env.EMAIL_FROM` が tommykeyapp.com 形式でない):
+//   sendVerificationRequest を console.log で stub
+// - production (Lambda):
+//   env.EMAIL_FROM が tommykeyapp.com 形式 + AWS region 解決可 → SES SDK 経由
+const isProductionTransport =
+	!!env.EMAIL_FROM && env.EMAIL_FROM.endsWith('@tommykeyapp.com') && !env.EMAIL_SERVER;
+
+const sesClient = isProductionTransport ? new SESv2Client({}) : null;
+
+async function sendMagicLinkViaSES(params: { identifier: string; url: string }): Promise<void> {
+	if (!sesClient) throw new Error('SES client not initialized');
+	const subject = 'サインインリンク - resource-planner';
+	const text = `resource-planner にサインインするには以下のリンクをクリックしてください:\n\n${params.url}\n\nこのリンクは 24 時間で失効します。\n身に覚えがない場合は無視してください。\n`;
+	const html = `<p>resource-planner にサインインするには以下のリンクをクリックしてください:</p>
+<p><a href="${params.url}">${params.url}</a></p>
+<p style="font-size:12px;color:#666;">このリンクは 24 時間で失効します。<br>身に覚えがない場合は無視してください。</p>`;
+
+	await sesClient.send(
+		new SendEmailCommand({
+			FromEmailAddress: env.EMAIL_FROM,
+			Destination: { ToAddresses: [params.identifier] },
+			Content: {
+				Simple: {
+					Subject: { Data: subject, Charset: 'UTF-8' },
+					Body: {
+						Text: { Data: text, Charset: 'UTF-8' },
+						Html: { Data: html, Charset: 'UTF-8' }
+					}
+				}
+			}
+		})
+	);
+}
 
 export const { handle, signIn, signOut } = SvelteKitAuth({
+	secret: resolvedAuthSecret,
 	adapter: DynamoDBAdapter(adapterClient, {
 		tableName: env.DYNAMODB_TABLE
 	}),
 	providers: [
 		Nodemailer({
-			server: env.EMAIL_SERVER ?? 'smtp://localhost:1025',
+			// SMTP server 設定は production では SES SDK 経由で send するため未使用。
+			// Auth.js が provider 初期化時に server 値を要求するため dummy を渡す。
+			server: env.EMAIL_SERVER ?? 'smtp://placeholder:25',
 			from: env.EMAIL_FROM ?? 'noreply@example.com',
-			...(useDevTransport
-				? {
-						sendVerificationRequest: async ({ identifier, url }) => {
-							// eslint-disable-next-line no-console
-							console.log(
-								`\n[Magic Link DEV] to=${identifier}\n  ${url}\n  (production は SES SMTP で送信、PR-A4 で配備)\n`
-							);
-						}
+			sendVerificationRequest: isProductionTransport
+				? sendMagicLinkViaSES
+				: async ({ identifier, url }) => {
+						// eslint-disable-next-line no-console
+						console.log(
+							`\n[Magic Link DEV] to=${identifier}\n  ${url}\n  (production は SES SDK で送信)\n`
+						);
 					}
-				: {})
 		})
 	],
 	pages: {
@@ -74,8 +124,6 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 			}
 			return true;
 		},
-		// session に teamId を載せる。PR-A2 で hardcode した default team を使う想定。
-		// 将来 multi-team 対応では last-used team を session に保存する別 PR で。
 		session: async ({ session }) => {
 			return session;
 		}
@@ -85,8 +133,8 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 		signIn: async ({ user, isNewUser }) => {
 			if (!user.id) return;
 			// 既存 user の毎回 sign-in でも idempotent (Put without Condition)。
-			// isNewUser だけにすると、過去 invite された user が初回 sign-in したケースで
-			// membership が無いことになるためスキップしない。
+			// isNewUser だけに絞ると、過去 invite された user の初回 sign-in でメンバーシップ
+			// が抜けるリスクがあるため毎回試行する。
 			void isNewUser;
 			try {
 				await getOrCreateDefaultTeam();


### PR DESCRIPTION
#65 Phase 3 PR-A4。PR-A3 で auth.ts を Magic Link 対応にしたので、本 PR で production infra を整えて Lambda から実際に SES で magic link を送れる状態にする。Clerk 撤去は PR-A5。詳細は #85。

## Terraform (`infra/`)
- `ses.tf` (新規): `aws_ses_domain_identity` + DKIM 3 record + verification TXT
- `ssm.tf` 拡張: `aws_ssm_parameter "auth_secret"` (SecureString、`lifecycle.ignore_changes=[value]`) — apply 後に `aws ssm put-parameter` で投入
- `lambda.tf` 拡張:
  - IAM: `ssm:GetParameter` を auth_secret に拡張
  - IAM (新): `ses:SendEmail` を domain identity scope で
  - env (新): `AUTH_SECRET_PARAM` / `AUTH_TRUST_HOST=true` / `EMAIL_FROM`
  - **既存 Clerk env は維持** (撤去は PR-A5)
- `variables.tf`: `email_from` (default `noreply@tommykeyapp.com`)

## App (`web/src/auth.ts`)
- `AUTH_SECRET` resolve: `env.AUTH_SECRET` 優先 → 未設定なら `AUTH_SECRET_PARAM` 経由で SSM から top-level await fetch (Clerk と同パターン)
- `sendVerificationRequest`:
  - **dev** (`EMAIL_FROM` が `tommykeyapp.com` 形式でない or `EMAIL_SERVER` 設定): console.log
  - **production** (`EMAIL_FROM=...@tommykeyapp.com` かつ `EMAIL_SERVER` 未設定): **SESv2 SDK** で送信 (HTML + Text)

## 依存追加
- `@aws-sdk/client-sesv2`

## Docs
- `README.md`: 「本番投入手順 (Auth.js infra)」section
  - AUTH_SECRET の `openssl rand -hex 32` + `aws ssm put-parameter` 手順
  - SES domain verified 確認コマンド
  - SES Sandbox 解除申請手順

## 検証
- `pnpm test` 緑 (69 passing / 6 skipped)
- `pnpm check` 緑 (1917 files / 0 errors)
- `pnpm build` 緑
- `terraform plan` は CI で検証

## 含まないもの
- Clerk env / SSM の削除 (PR-A5)
- SES Sandbox 解除申請 (本番投入直前に AWS Console から手動)
- ADR 0008 (PR-A5)

## サプライズ対策
- `aws_ssm_parameter.auth_secret` は `lifecycle.ignore_changes=[value]` で state に secret 値を残さない
- DKIM CNAME 反映は数分〜15 分 (apply 直後は verified にならない)
- SES Sandbox 中は ALLOWED_DOMAIN 内 user のみ送信可
- Lambda 起動時 SSM fetch で cold start +50-100ms 程度

Closes #85