### PR TITLE
fix(infra): SES IAM policy を Resource="*" + ses:FromAddress condition に修正

### DIFF
--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -69,8 +69,18 @@ resource "aws_iam_role_policy" "lambda_ssm" {
   })
 }
 
-# SES SendEmail 権限 (#85): Auth.js Magic Link を SESv2 SDK 経由で送信する。
-# domain identity (tommykeyapp.com) からの送信のみ許可。
+# SES SendEmail 権限 (#85, refined #89): Auth.js Magic Link を SESv2 SDK 経由で送信。
+#
+# Resource = "*" + ses:FromAddress condition が AWS docs 推奨パターン:
+# - SES は SendEmail の IAM 認可を sender identity ARN に対して評価する
+# - **Sandbox モードでは recipient identity ARN にも追加 IAM チェックが走る**
+#   ため、Resource を sender 1 件に絞ると recipient で AccessDenied になる
+# - Resource = "*" に広げ、from address を ses:FromAddress condition で固定
+#   することで「from は固定、to は誰でも (sandbox の verify 強制は SES 側で別途)」
+# - ses:ApiVersion=2 で SESv1 経由の悪用も防止 (defense in depth)
+# - ses:SendRawEmail は SESv2 SDK では呼ばれないので不要
+#
+# 参考: https://docs.aws.amazon.com/ses/latest/dg/control-user-access.html
 resource "aws_iam_role_policy" "lambda_ses" {
   name = "${var.project}-ses-policy"
   role = aws_iam_role.lambda.id
@@ -79,12 +89,16 @@ resource "aws_iam_role_policy" "lambda_ses" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = [
-          "ses:SendEmail",
-          "ses:SendRawEmail"
-        ]
-        Resource = aws_ses_domain_identity.main.arn
+        Sid      = "SendMagicLinkEmail"
+        Effect   = "Allow"
+        Action   = ["ses:SendEmail"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "ses:FromAddress" = var.email_from
+            "ses:ApiVersion"  = "2"
+          }
+        }
       }
     ]
   })


### PR DESCRIPTION
PR-A4 (#86) で配備した `lambda_ses` policy が Sandbox 中の Magic Link 送信で `AccessDeniedException` を出す問題の修正。詳細は #89。

## 原因

- SES は `SendEmail` の IAM 認可を **sender identity ARN** で評価する
- ただし **Sandbox モードでは recipient identity ARN にも追加 IAM チェックが走る**
- 旧 policy は `Resource = aws_ses_domain_identity.main.arn` (sender 1 件) に scope していたため、recipient identity ARN で deny されて sign-in が失敗 → UI で "Configuration エラー"

## 修正 (AWS docs 推奨、2026 時点最新)

```hcl
{
  Sid      = "SendMagicLinkEmail"
  Effect   = "Allow"
  Action   = ["ses:SendEmail"]
  Resource = "*"
  Condition = {
    StringEquals = {
      "ses:FromAddress" = var.email_from   # noreply@tommykeyapp.com
      "ses:ApiVersion"  = "2"               # SESv1 経由の悪用 防止
    }
  }
}
```

- `Resource = "*"` で recipient ARN trap を回避 (Sandbox 中も production 後も動く)
- `ses:FromAddress` condition で **from address を固定** (Lambda は `noreply@tommykeyapp.com` 以外から送れない、least-privilege 維持)
- `ses:SendRawEmail` 削除 (SESv2 SDK の `SendEmailCommand` は v1 raw 経路を使わない)
- `ses:ApiVersion=2` condition で defense in depth

## 検証

- `terraform plan` は CI で検証 (ローカル terraform 未インストール)
- merge 後、CD で `aws_iam_role_policy.lambda_ses` が更新される
- 動作確認: 手元で `/sign-in` → magic link 受信 → click → ホーム到達

## 参考
- [AWS docs: Restricting the From address](https://docs.aws.amazon.com/ses/latest/dg/control-user-access.html#iam-and-ses-examples-from-address)
- [Service Authorization Reference: SES v2](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonsimpleemailservicev2.html)

Closes #89