### PR TITLE
chore(claude-code): TDD 強制セットアップ — /tdd skill + warn hook

### DIFF
--- a/.claude/hooks/warn-untested.sh
+++ b/.claude/hooks/warn-untested.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit / Write on web/src code (#92).
+#
+# AI / 人間が `web/src/**.{ts,svelte}` を編集する前に、対応する `*.test.ts` を
+# staging area に置いたかを確認する。staging されていなければ
+# `permissionDecision: "ask"` で確認 prompt を出す (deny ではなく ask、
+# iterative work を阻害しないため)。
+#
+# Trigger 対象外:
+# - test ファイル本体 (`*.test.ts` / `*.spec.ts`)
+# - 拡張子が ts / svelte 以外
+# - web/src 配下以外
+#
+# 参考: https://code.claude.com/docs/en/hooks.md
+set -euo pipefail
+
+# stdin から hook input JSON を読む
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+# Edit / Write 以外、または file_path が空ならスキップ
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+# 拡張子チェック
+case "$file_path" in
+  *.ts|*.svelte) ;;
+  *) exit 0 ;;
+esac
+
+# test / spec ファイル本体は除外
+case "$file_path" in
+  *.test.ts|*.test.svelte|*.spec.ts|*.spec.svelte) exit 0 ;;
+esac
+
+# web/src 配下以外は対象外
+case "$file_path" in
+  *web/src/*) ;;
+  *) exit 0 ;;
+esac
+
+# repo root を解決 (Claude Code の cwd ではなく、編集対象ファイルの dir から逆算)
+file_dir=$(dirname "$file_path")
+repo_root=$(git -C "$file_dir" rev-parse --show-toplevel 2>/dev/null || true)
+if [ -z "$repo_root" ]; then
+  exit 0
+fi
+
+# 対応する test ファイルを推測 (foo.ts → foo.test.ts、foo.svelte → foo.svelte.test.ts)
+case "$file_path" in
+  *.svelte) test_file="${file_path%.svelte}.svelte.test.ts" ;;
+  *) test_file="${file_path%.*}.test.ts" ;;
+esac
+
+rel_test_file="${test_file#$repo_root/}"
+
+# staging area に対応 test が乗っているか確認
+if git -C "$repo_root" diff --cached --name-only | grep -Fxq "$rel_test_file"; then
+  exit 0
+fi
+
+# どこかで test が触られているか (untracked / unstaged 含む) も見る
+if git -C "$repo_root" status --porcelain "$rel_test_file" 2>/dev/null | grep -q .; then
+  # 触っているが staged ではない → やや弱めの警告
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "additionalContext": "対応 test ($rel_test_file) は変更中ですが staged されていません。TDD では先に test を書いて git add してから実装を編集してください (ADR 0007)。"
+  }
+}
+EOF
+  exit 0
+fi
+
+# test ファイルがそもそも存在しない / 触られてもいない → 強めの警告
+cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "additionalContext": "対応 test ($rel_test_file) が staged されていません。TDD では先に失敗するテストを書いてから実装してください (ADR 0007、/tdd skill 参照)。"
+  }
+}
+EOF
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://code.claude.com/settings.schema.json",
+	"hooks": {
+		"PreToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": ".claude/hooks/warn-untested.sh"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: tdd
+description: ADR 0007 に沿って TDD で進めるための workflow guide。`/tdd <task の説明>` で起動。
+disable-model-invocation: true
+allowed-tools: Bash(pnpm *) Bash(git *) Read Edit Write Grep Glob
+---
+
+# TDD workflow (resource-planner、ADR 0007)
+
+## Current test status
+
+```
+!`cd web && pnpm test 2>&1 | tail -30`
+```
+
+## Currently staged files
+
+```
+!`git diff --cached --name-only`
+```
+
+## このセッションで既に変更したファイル (uncommitted)
+
+```
+!`git diff --name-only`
+```
+
+---
+
+## 進め方 (ユーザーから依頼された task: `$ARGUMENTS`)
+
+1. **失敗するテストを先に書く** (RED)
+   - 該当する `*.test.ts` を新規作成 / 既存に追加。`web/src/lib/**/*.test.ts` は unit、`web/src/lib/repository/integration.test.ts` は DDB Local。
+   - `pnpm test` を実行して **新しいテストが fail することを確認**。fail メッセージが期待した assertion に一致しているか確認。
+   - 「テストが書けない」「テストが pass してしまう」 場合は、依頼内容が曖昧 / 既存挙動と一致 を疑い、ユーザーに確認。
+
+2. **最小限の実装で pass させる** (GREEN)
+   - テストを通す **最小コード**だけ書く。speculative な機能 / 未使用の引数 / 抽象化は禁止 (ADR 0007 / CLAUDE.md "Simplicity First")。
+   - `pnpm test` で全 test 緑を確認。
+
+3. **必要なら refactor** (REFACTOR)
+   - テストが緑のまま実装を整える。リファクタの内容は別 commit に分けるとレビューしやすい。
+
+4. **commit / PR**
+   - test ファイルと実装ファイルは **同じ commit** に入れる (TDD discipline の証跡)。
+   - hook (`.claude/hooks/warn-untested.sh`) が「対応する `*.test.ts` が staged されていない」 と警告したら、test を先に `git add` して staged してから Edit。
+
+## 注意点
+
+- **境界 / 例外 / null / 0 件 / 100 件超** を最低限カバー (ADR 0007 命名規約)
+- repository 層は `aws-sdk-client-mock` で unit test、DDB Local 統合は `*.integration.test.ts` で `describe.runIf(process.env.AWS_ENDPOINT_URL)` gate
+- Svelte コンポーネントテストはまだ jsdom + `@testing-library/svelte` を導入していないため、必要になった時に同 PR で `pnpm add -D` してから書く
+- Playwright E2E は `web/e2e/*.spec.ts` (未充実、Phase 3 完了後の TODO)
+- coverage を **下げない**: `pnpm test:coverage` で line/func 割合を確認、減ったら新規実装側に test 追加
+
+## 参考
+
+- ADR 0007: `docs/adr/0007-tdd-with-vitest-and-playwright.md`
+- CLAUDE.md: `### Simplicity First` `### Goal-Driven Execution`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,15 @@ Single Table Design (詳細: `docs/db/entities.md`、`docs/db/access-patterns.md
    - infra 変更時: terraform apply
    - web: docker build → ECR push → Lambda update
 
+## TDD 運用 (ADR 0007 / #92)
+
+Claude Code session 内で本 repo を編集する際は **必ず先にテストを書く**。
+
+- `/tdd <task>` skill で workflow ガイド (`.claude/skills/tdd/SKILL.md`)
+- `web/src/**.{ts,svelte}` の Edit / Write 前に、対応 `*.test.ts` が `git diff --cached` に出るか **PreToolUse hook** が確認 (`.claude/hooks/warn-untested.sh`)
+- staged されていなければ `permissionDecision: "ask"` で確認 prompt (deny ではなく ask、iterative work を阻害しない)
+- AI / 人間共通の discipline。RED → GREEN → REFACTOR で進める
+
 ## 関連リポジトリ
 
 - [tommykey-apps/ui-components](https://github.com/tommykey-apps/ui-components) — ResourceTimeline コンポーネント


### PR DESCRIPTION
ADR 0007 (TDD with Vitest + Playwright) を運用面で補強し、AI / 人間共通の discipline で TDD を半強制する Claude Code 設定を repo にコミット。詳細は #92。

## 採用方針

`permissionDecision: "deny"` での hard block は iterative work を阻害するため不採用。代わりに:

| 構成 | 配置 | 効果 |
|---|---|---|
| `/tdd` Skill (manual) | `.claude/skills/tdd/SKILL.md` | `/tdd <task>` で「失敗テスト → 実装 → green」を walkthrough。動的コンテキストで最新 `pnpm test` 結果を skill 起動時に注入 |
| PreToolUse warn hook | `.claude/hooks/warn-untested.sh` + `.claude/settings.json` | `web/src/**.{ts,svelte}` Edit / Write 前に対応 `*.test.ts` が `git diff --cached` に出るかを `permissionDecision: "ask"` で確認 |

## 含むもの
- `.claude/skills/tdd/SKILL.md`: `disable-model-invocation: true` 手動起動のみ、3 ステップ ガイド
- `.claude/hooks/warn-untested.sh`: 拡張子 / test 本体 / web/src 配下のフィルタ + `git -C` で repo root を file_path から解決
- `.claude/settings.json`: hooks 設定
- `CLAUDE.md`: 「TDD 運用」 section 追加

## 検証
- `bash -n` 構文 OK
- Smoke tests:
  - test ファイル本体 → exit 0 (素通り)
  - `infra/lambda.tf` 等 web/src 外 → exit 0
  - `web/src/lib/foo.ts` (test 未 staged) → `permissionDecision: "ask"` JSON 出力 ✓

## 含まないもの
- 既存テストの拡充 (UX 改修 PR で per-feature TDD 実施)
- hard block (deny)
- pre-commit (git 側、別途検討)
- CI coverage threshold gate (ADR 0007 で「段階的」と決定済)

## サプライズ対策
- `git diff --cached` で見るので「test 先 → `git add web/src/foo.test.ts`」 の習慣が必要 → SKILL.md と CLAUDE.md で案内
- 慣れるまで ask prompt がうるさい可能性 (deny より OK だが頻度が高い)
- 本 repo 固有の `.claude/` 設定 (commit 済) なので burnnote 等他 repo には影響しない

## 参考
- https://code.claude.com/docs/en/hooks.md
- https://code.claude.com/docs/en/skills.md

Closes #92