### PR TITLE
fix(ui): モバイル/タブレットでヘッダが横スクロール (Avatar Dropdown 化 + sticky + flex-wrap)

### DIFF
--- a/web/src/lib/components/AssignmentCreator.svelte
+++ b/web/src/lib/components/AssignmentCreator.svelte
@@ -73,7 +73,7 @@
 	disabled={!canCreate}
 	title={canCreate ? '' : '人と案件を 1 件以上登録してから作成できます'}
 >
-	+ アサインを追加
+	+<span class="hidden sm:ml-1 sm:inline">アサインを追加</span>
 </Button>
 
 <Dialog bind:open title="アサインを追加" description="人を案件に期間でアサインする">

--- a/web/src/lib/components/AssignmentCreator.svelte.test.ts
+++ b/web/src/lib/components/AssignmentCreator.svelte.test.ts
@@ -10,4 +10,13 @@ describe('AssignmentCreator (smoke)', () => {
 		});
 		expect(getByRole('button', { name: /アサイン/ })).toBeInTheDocument();
 	});
+
+	it('shows + icon always, wraps text label in sm:inline span (mobile responsive、#96)', () => {
+		const { getByRole } = render(AssignmentCreator, {
+			props: { resources: [], projects: [] }
+		});
+		const trigger = getByRole('button');
+		expect(trigger.textContent).toMatch(/\+/);
+		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/アサインを追加/);
+	});
 });

--- a/web/src/lib/components/AssignmentManager.svelte
+++ b/web/src/lib/components/AssignmentManager.svelte
@@ -41,7 +41,7 @@
 </script>
 
 <Button variant="outline" onclick={() => (open = true)}>
-	📋 アサイン一覧 ({assignments.length})
+	📋<span class="hidden sm:ml-1 sm:inline">アサイン一覧 ({assignments.length})</span>
 </Button>
 
 <Dialog bind:open title="アサイン一覧" description="登録済みアサインの一覧と削除">

--- a/web/src/lib/components/AssignmentManager.svelte.test.ts
+++ b/web/src/lib/components/AssignmentManager.svelte.test.ts
@@ -10,4 +10,13 @@ describe('AssignmentManager (smoke)', () => {
 		});
 		expect(getByRole('button', { name: /アサイン一覧/ })).toBeInTheDocument();
 	});
+
+	it('emoji icon visible + text label wrapped in sm:inline span (mobile responsive、#96)', () => {
+		const { getByRole } = render(AssignmentManager, {
+			props: { assignments: [], resources: [], projects: [] }
+		});
+		const trigger = getByRole('button', { name: /アサイン一覧/ });
+		expect(trigger.textContent).toMatch(/📋/);
+		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/アサイン一覧/);
+	});
 });

--- a/web/src/lib/components/AvatarDropdown.svelte
+++ b/web/src/lib/components/AvatarDropdown.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import { DropdownMenu } from 'bits-ui';
+
+	let { email = '' }: { email?: string } = $props();
+
+	const initial = $derived(email.length > 0 ? email[0].toUpperCase() : '?');
+	const ariaLabel = $derived(email.length > 0 ? `ユーザーメニュー (${email})` : 'ユーザーメニュー');
+</script>
+
+<DropdownMenu.Root>
+	<DropdownMenu.Trigger
+		class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-background text-sm font-semibold transition-colors hover:bg-accent"
+		aria-label={ariaLabel}
+		title={ariaLabel}
+	>
+		{initial}
+	</DropdownMenu.Trigger>
+	<DropdownMenu.Portal>
+		<DropdownMenu.Content
+			class="z-50 min-w-[12rem] rounded-md border border-border bg-background p-1 shadow-lg"
+			sideOffset={6}
+			align="end"
+		>
+			{#if email}
+				<DropdownMenu.Item
+					class="pointer-events-none px-2 py-1.5 text-xs text-muted-foreground"
+					disabled
+				>
+					{email}
+				</DropdownMenu.Item>
+				<DropdownMenu.Separator class="my-1 h-px bg-border" />
+			{/if}
+			<form method="POST" action="/auth/signout">
+				<DropdownMenu.Item
+					class="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent"
+				>
+					<button type="submit" class="flex-1 text-left">サインアウト</button>
+				</DropdownMenu.Item>
+			</form>
+		</DropdownMenu.Content>
+	</DropdownMenu.Portal>
+</DropdownMenu.Root>

--- a/web/src/lib/components/AvatarDropdown.svelte.test.ts
+++ b/web/src/lib/components/AvatarDropdown.svelte.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import AvatarDropdown from './AvatarDropdown.svelte';
+
+/**
+ * AvatarDropdown smoke test (#96)。
+ *
+ * Trigger button が email から生成した initial を表示し、aria-label でメニュー目的を
+ * screen reader に伝える。実際のメニュー展開挙動は bits-ui DropdownMenu に依存するため
+ * 本 test では trigger のレンダリングと a11y 属性のみ確認 (実展開は Playwright で smoke)。
+ */
+describe('AvatarDropdown (smoke)', () => {
+	it('renders trigger with email initial when user.email is provided', () => {
+		const { getByRole } = render(AvatarDropdown, {
+			props: { email: 'alice@example.com' }
+		});
+		const trigger = getByRole('button', { name: /ユーザーメニュー|account|menu/i });
+		expect(trigger).toBeInTheDocument();
+		// initial は email の先頭 1 文字 (uppercase)
+		expect(trigger.textContent).toMatch(/A/);
+	});
+
+	it('uses aria-label that mentions the email for screen readers', () => {
+		const { getByRole } = render(AvatarDropdown, {
+			props: { email: 'bob@example.com' }
+		});
+		const trigger = getByRole('button');
+		const label = trigger.getAttribute('aria-label') ?? '';
+		expect(label.toLowerCase()).toContain('bob@example.com'.toLowerCase());
+	});
+
+	it('falls back to "?" initial when email is empty/undefined', () => {
+		const { getByRole } = render(AvatarDropdown, {
+			props: { email: '' }
+		});
+		const trigger = getByRole('button');
+		expect(trigger.textContent).toMatch(/\?/);
+	});
+});

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -69,9 +69,9 @@
 	const deleteSubmit: SubmitFunction = deleteSubmitState.wrap();
 </script>
 
-<Button variant="outline" onclick={() => (listOpen = true)}
-	>📁 案件を管理 ({projects.length})</Button
->
+<Button variant="outline" onclick={() => (listOpen = true)}>
+	📁<span class="hidden sm:ml-1 sm:inline">案件を管理 ({projects.length})</span>
+</Button>
 
 <Dialog
 	bind:open={listOpen}

--- a/web/src/lib/components/ProjectManager.svelte.test.ts
+++ b/web/src/lib/components/ProjectManager.svelte.test.ts
@@ -20,4 +20,13 @@ describe('ProjectManager (smoke)', () => {
 		});
 		expect(getByRole('button', { name: /\(1\)/ })).toBeInTheDocument();
 	});
+
+	it('emoji icon visible + text label wrapped in sm:inline span (mobile responsive、#96)', () => {
+		const { getByRole } = render(ProjectManager, {
+			props: { projects: [], assignments: [] }
+		});
+		const trigger = getByRole('button', { name: /案件を管理/ });
+		expect(trigger.textContent).toMatch(/📁/);
+		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/案件を管理/);
+	});
 });

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -64,8 +64,9 @@
 	const deleteSubmit: SubmitFunction = deleteSubmitState.wrap();
 </script>
 
-<Button variant="outline" onclick={() => (listOpen = true)}>👥 人を管理 ({resources.length})</Button
->
+<Button variant="outline" onclick={() => (listOpen = true)}>
+	👥<span class="hidden sm:ml-1 sm:inline">人を管理 ({resources.length})</span>
+</Button>
 
 <Dialog bind:open={listOpen} title="人を管理" description="リソース (人) の追加・編集・削除">
 	<div class="flex flex-col gap-3">

--- a/web/src/lib/components/ResourceManager.svelte.test.ts
+++ b/web/src/lib/components/ResourceManager.svelte.test.ts
@@ -31,4 +31,13 @@ describe('ResourceManager (smoke)', () => {
 		});
 		expect(getByRole('button', { name: /\(2\)/ })).toBeInTheDocument();
 	});
+
+	it('keeps the emoji icon visible while wrapping the text label in a sm:inline span (mobile responsive、#96)', () => {
+		const { getByRole } = render(ResourceManager, {
+			props: { resources: [], assignments: [] }
+		});
+		const trigger = getByRole('button', { name: /人を管理/ });
+		expect(trigger.textContent).toMatch(/👥/);
+		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/人を管理/);
+	});
 });

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -11,6 +11,7 @@
 	import ProjectManager from '$lib/components/ProjectManager.svelte';
 	import AssignmentCreator from '$lib/components/AssignmentCreator.svelte';
 	import AssignmentManager from '$lib/components/AssignmentManager.svelte';
+	import AvatarDropdown from '$lib/components/AvatarDropdown.svelte';
 	import type { Assignment as DbAssignment } from '$lib/types';
 	import type { PageData } from './$types';
 
@@ -76,22 +77,20 @@
 	}
 </script>
 
-<main>
-	<header>
-		<h1>resource-planner</h1>
-		<div class="actions">
+<header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
+	<div class="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-2 px-4 py-3">
+		<h1 class="m-0 text-lg font-semibold tracking-tight sm:text-xl">resource-planner</h1>
+		<div class="flex flex-wrap items-center gap-2">
 			<ResourceManager {resources} assignments={dbAssignments} />
 			<ProjectManager {projects} assignments={dbAssignments} />
 			<AssignmentCreator {resources} {projects} />
 			<AssignmentManager assignments={dbAssignments} {resources} {projects} />
-			<form method="POST" action="/auth/signout" class="signout-form">
-				<button type="submit" class="signout-btn" title="サインアウト">
-					{data.user?.email ?? 'サインアウト'}
-				</button>
-			</form>
+			<AvatarDropdown email={data.user?.email ?? ''} />
 		</div>
-	</header>
+	</div>
+</header>
 
+<main class="mx-auto max-w-[1200px] px-4 py-6">
 	{#if resources.length === 0}
 		<div class="empty-state">
 			<p>まだ人が登録されていません。</p>
@@ -126,27 +125,7 @@
 
 <style>
 	main {
-		max-width: 1200px;
-		margin: 2rem auto;
-		padding: 0 1rem;
 		font-family: system-ui, sans-serif;
-	}
-
-	header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		margin-bottom: 1.5rem;
-	}
-
-	header .actions {
-		display: flex;
-		gap: 0.5rem;
-	}
-
-	h1 {
-		margin: 0;
-		font-size: 1.5rem;
 	}
 
 	.empty-state {


### PR DESCRIPTION
Playwright UX レビューで確認した critical issue (#96) を TDD で修正。

## 問題

- **390px (iPhone 12)**: `body.scrollWidth = 801px`、横スクロール 411px 必要
- **768px (iPad portrait)**: `body.scrollWidth = 808px`、こちらも overflow
- アクションボタン 5 つを 1 行に詰めて画面外に押し出されていた
- signout button が email 文字列をそのまま表示 (~250px) するのも幅圧迫の一因 + 誤クリック誘発

## 修正

### 新規 `AvatarDropdown.svelte`
- `bits-ui` DropdownMenu でアバター circle (email initial 表示)
- menu items: email (disabled / info)、サインアウト
- aria-label に email を含めて screen reader 対応 (a11y)

### 各 Manager の trigger button を responsive label 化
| Component | Mobile (<sm) | Desktop (≥sm) |
|---|---|---|
| ResourceManager | `👥` | `👥 人を管理 (N)` |
| ProjectManager | `📁` | `📁 案件を管理 (N)` |
| AssignmentCreator | `+` | `+ アサインを追加` |
| AssignmentManager | `📋` | `📋 アサイン一覧 (N)` |

### ヘッダ全面書き換え (`+page.svelte`)
- `sticky top-0 z-40 backdrop-blur` (burnnote パターン、長い timeline でも操作可能)
- `flex-wrap` で複数行に折り返し
- 旧 inline `<form action="/auth/signout">` を `<AvatarDropdown />` に置換
- 旧 `<style>` を Tailwind utility に整理

## TDD

RED → GREEN → REFACTOR (ADR 0007 / `/tdd` skill)

新規 / 拡充された tests:
- `AvatarDropdown.svelte.test.ts` (3 ケース、initial 変換 / aria-label / fallback)
- 各 Manager smoke test に「emoji 常時可視 + sm:inline span に text label」 を assert する case 追加 (4 ファイル)

## 検証
- `pnpm test` 緑 (**96 total: 90 passing + 6 skipped**)
- `pnpm check` 緑 (1786 files / 0 errors)
- `pnpm build` 緑

## 含まないもの
- Dialog max-h 不足 + Timeline 左 rail 長名侵食 → #95
- ThemeToggle / 言語切替を AvatarDropdown menu に追加 → #97 / #98
- 詳細な responsive E2E test → #99 / #100

Closes #96