### PR TITLE
fix(ui): Dialog max-h + responsive padding + ui-components 0.4.1 bump

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -58,7 +58,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.4.0",
+		"@tommykey-apps/ui-components": "^0.4.1",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"nodemailer": "^7.0.13",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.4.0
-        version: 0.4.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.4.1
+        version: 0.4.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1163,8 +1163,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.4.0':
-    resolution: {integrity: sha512-bFh9eyTklIHYw7pLG9ce2l00pm2pi83IT9+RNas1KpcLdl0IqSw2f9+rEjEpbIZYR5uMyDUUYkayrKCOw9nwDQ==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.4.0/324f4c27c7369269333e11c99dd10ef6ccccf65e}
+  '@tommykey-apps/ui-components@0.4.1':
+    resolution: {integrity: sha512-X3vXY+DtHoJ72X6DEGy5JnEOuF9GKsAysK29scVNT0dlj+MB7SkVZJznJAeEir8Ab7an9z/YlADQXofzoFHXWA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.4.1/3a67207590f582c4de15467d186f8e8b217b99a5}
     peerDependencies:
       svelte: ^5.0.0
 
@@ -3808,7 +3808,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.4.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.4.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       date-fns: 4.1.0
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)

--- a/web/src/lib/components/Dialog.svelte
+++ b/web/src/lib/components/Dialog.svelte
@@ -21,7 +21,7 @@
 			class="fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0"
 		/>
 		<BitsDialog.Content
-			class="fixed top-[50%] left-[50%] z-50 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg border border-border bg-background p-6 shadow-lg data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+			class="fixed top-[50%] left-[50%] z-50 flex max-h-[90vh] w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 flex-col overflow-y-auto rounded-lg border border-border bg-background p-4 shadow-lg data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:p-6"
 			style="border-radius: var(--radius)"
 		>
 			<BitsDialog.Title class="mb-1 text-base font-medium text-foreground">

--- a/web/src/lib/components/Dialog.svelte.test.ts
+++ b/web/src/lib/components/Dialog.svelte.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import Dialog from './Dialog.svelte';
+
+/**
+ * Dialog の overflow / mobile padding 挙動を保証 (#95)。
+ *
+ * Dialog が長いリスト (例: 22 件の resource) を含む場面で viewport を超えた時に
+ * 内部スクロールで読めるようにする (max-h-[90vh] + overflow-y-auto)。
+ * iPhone 12 (390px) では p-6 (24px) は両側 48px 取られて狭いので p-4 sm:p-6 に。
+ */
+describe('Dialog (smoke、#95 max-h + responsive padding)', () => {
+	const childrenSnippet = createRawSnippet(() => ({
+		render: () => '<div>テスト本文</div>'
+	}));
+
+	it('Content has max-h-[90vh] and overflow-y-auto for long content', () => {
+		render(Dialog, {
+			props: { open: true, title: 'テスト', children: childrenSnippet }
+		});
+		const content = screen.getByRole('dialog');
+		const cls = content.className;
+		expect(cls).toContain('max-h-[90vh]');
+		expect(cls).toContain('overflow-y-auto');
+	});
+
+	it('Content uses p-4 on mobile and sm:p-6 on small+ screens', () => {
+		render(Dialog, {
+			props: { open: true, title: 'テスト', children: childrenSnippet }
+		});
+		const content = screen.getByRole('dialog');
+		const cls = content.className;
+		expect(cls).toContain('p-4');
+		expect(cls).toContain('sm:p-6');
+	});
+});


### PR DESCRIPTION
#95 — Playwright UX レビューで確認した critical 問題を解消。

## 問題
- ResourceManager Dialog が長 list (22 件) で viewport を 100px 超え heading 画面外
- iPhone 12 (390px) の \`p-6\` (24px x 2 = 48px) は両側余白で実コンテンツ幅圧迫
- Timeline 左 rail で長名 resource が他行を侵食 (display 致命傷)

## 修正

### 1. Dialog.svelte
\`max-h-[90vh] overflow-y-auto flex flex-col p-4 sm:p-6\` に変更:
- \`max-h-[90vh]\` + \`overflow-y-auto\` で長コンテンツでも内部スクロール
- \`p-4 sm:p-6\` で mobile 16px / desktop 24px の padding (省スペース)

### 2. ui-components 0.4.0 → 0.4.1 bump
[ui-components #13](https://github.com/tommykey-apps/ui-components/pull/13) で left rail truncation 修正済 (publish 0.4.1):
- \`.resources\` aside に \`width: var(--ui-resource-col-width, 200px)\` で固定幅
- \`.resource-row\` text に \`overflow: hidden; white-space: nowrap; text-overflow: ellipsis\`
- \`title={resource.name}\` で hover 時に full name 確認

## TDD (RED → GREEN)
- \`web/src/lib/components/Dialog.svelte.test.ts\` (新規、2 ケース):
  - \`max-h-[90vh]\` + \`overflow-y-auto\` class 付与
  - \`p-4\` + \`sm:p-6\` class 付与

## 検証
- \`pnpm test\` 緑 (98 total: 92 passing + 6 skipped)
- \`pnpm check\` 緑 (1787 files / 0 errors)
- \`pnpm build\` 緑

## 含まないもの
- 各 Manager の list 内部 max-h (Dialog 内部スクロール済なので不要、AssignmentManager の \`max-h-[60vh]\` は維持)

Closes #95