### PR TITLE
feat(ui): trigger button の絵文字を phosphor icon に置換

### DIFF
--- a/web/src/lib/components/AssignmentCreator.svelte
+++ b/web/src/lib/components/AssignmentCreator.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import Plus from 'phosphor-svelte/lib/Plus';
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { formatLocalDate } from '$lib/timeline-adapter';
@@ -73,7 +74,8 @@
 	disabled={!canCreate}
 	title={canCreate ? '' : '人と案件を 1 件以上登録してから作成できます'}
 >
-	+<span class="hidden sm:ml-1 sm:inline">アサインを追加</span>
+	<Plus size={18} weight="bold" aria-hidden="true" />
+	<span class="hidden sm:ml-1 sm:inline">アサインを追加</span>
 </Button>
 
 <Dialog bind:open title="アサインを追加" description="人を案件に期間でアサインする">

--- a/web/src/lib/components/AssignmentCreator.svelte.test.ts
+++ b/web/src/lib/components/AssignmentCreator.svelte.test.ts
@@ -11,12 +11,15 @@ describe('AssignmentCreator (smoke)', () => {
 		expect(getByRole('button', { name: /アサイン/ })).toBeInTheDocument();
 	});
 
-	it('shows + icon always, wraps text label in sm:inline span (mobile responsive、#96)', () => {
+	it('shows phosphor Plus icon, wraps text label in sm:inline span (#96 / #105)', () => {
 		const { getByRole } = render(AssignmentCreator, {
 			props: { resources: [], projects: [] }
 		});
 		const trigger = getByRole('button');
-		expect(trigger.textContent).toMatch(/\+/);
+		const icon = trigger.querySelector('svg[aria-hidden="true"]');
+		expect(icon).toBeTruthy();
+		// プレーンな "+" 文字も使わない (text node の plus)
+		expect(trigger.textContent?.replace(/アサインを追加/, '').trim()).not.toContain('+');
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/アサインを追加/);
 	});
 });

--- a/web/src/lib/components/AssignmentManager.svelte
+++ b/web/src/lib/components/AssignmentManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import ListChecks from 'phosphor-svelte/lib/ListChecks';
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { addDays } from '$lib/date';
@@ -41,7 +42,8 @@
 </script>
 
 <Button variant="outline" onclick={() => (open = true)}>
-	📋<span class="hidden sm:ml-1 sm:inline">アサイン一覧 ({assignments.length})</span>
+	<ListChecks size={18} weight="regular" aria-hidden="true" />
+	<span class="hidden sm:ml-1 sm:inline">アサイン一覧 ({assignments.length})</span>
 </Button>
 
 <Dialog bind:open title="アサイン一覧" description="登録済みアサインの一覧と削除">

--- a/web/src/lib/components/AssignmentManager.svelte.test.ts
+++ b/web/src/lib/components/AssignmentManager.svelte.test.ts
@@ -11,12 +11,14 @@ describe('AssignmentManager (smoke)', () => {
 		expect(getByRole('button', { name: /アサイン一覧/ })).toBeInTheDocument();
 	});
 
-	it('emoji icon visible + text label wrapped in sm:inline span (mobile responsive、#96)', () => {
+	it('phosphor svg icon visible + text label wrapped in sm:inline span (#96 / #105)', () => {
 		const { getByRole } = render(AssignmentManager, {
 			props: { assignments: [], resources: [], projects: [] }
 		});
 		const trigger = getByRole('button', { name: /アサイン一覧/ });
-		expect(trigger.textContent).toMatch(/📋/);
+		const icon = trigger.querySelector('svg[aria-hidden="true"]');
+		expect(icon).toBeTruthy();
+		expect(trigger.textContent).not.toMatch(/📋/);
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/アサイン一覧/);
 	});
 });

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import Folder from 'phosphor-svelte/lib/Folder';
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
@@ -70,7 +71,8 @@
 </script>
 
 <Button variant="outline" onclick={() => (listOpen = true)}>
-	📁<span class="hidden sm:ml-1 sm:inline">案件を管理 ({projects.length})</span>
+	<Folder size={18} weight="regular" aria-hidden="true" />
+	<span class="hidden sm:ml-1 sm:inline">案件を管理 ({projects.length})</span>
 </Button>
 
 <Dialog

--- a/web/src/lib/components/ProjectManager.svelte.test.ts
+++ b/web/src/lib/components/ProjectManager.svelte.test.ts
@@ -21,12 +21,14 @@ describe('ProjectManager (smoke)', () => {
 		expect(getByRole('button', { name: /\(1\)/ })).toBeInTheDocument();
 	});
 
-	it('emoji icon visible + text label wrapped in sm:inline span (mobile responsive、#96)', () => {
+	it('phosphor svg icon visible + text label wrapped in sm:inline span (#96 / #105)', () => {
 		const { getByRole } = render(ProjectManager, {
 			props: { projects: [], assignments: [] }
 		});
 		const trigger = getByRole('button', { name: /案件を管理/ });
-		expect(trigger.textContent).toMatch(/📁/);
+		const icon = trigger.querySelector('svg[aria-hidden="true"]');
+		expect(icon).toBeTruthy();
+		expect(trigger.textContent).not.toMatch(/📁/);
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/案件を管理/);
 	});
 });

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import Users from 'phosphor-svelte/lib/Users';
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
@@ -65,7 +66,8 @@
 </script>
 
 <Button variant="outline" onclick={() => (listOpen = true)}>
-	👥<span class="hidden sm:ml-1 sm:inline">人を管理 ({resources.length})</span>
+	<Users size={18} weight="regular" aria-hidden="true" />
+	<span class="hidden sm:ml-1 sm:inline">人を管理 ({resources.length})</span>
 </Button>
 
 <Dialog bind:open={listOpen} title="人を管理" description="リソース (人) の追加・編集・削除">

--- a/web/src/lib/components/ResourceManager.svelte.test.ts
+++ b/web/src/lib/components/ResourceManager.svelte.test.ts
@@ -32,12 +32,16 @@ describe('ResourceManager (smoke)', () => {
 		expect(getByRole('button', { name: /\(2\)/ })).toBeInTheDocument();
 	});
 
-	it('keeps the emoji icon visible while wrapping the text label in a sm:inline span (mobile responsive、#96)', () => {
+	it('keeps the icon visible (phosphor svg) while wrapping the text label in a sm:inline span (mobile responsive、#96 / #105)', () => {
 		const { getByRole } = render(ResourceManager, {
 			props: { resources: [], assignments: [] }
 		});
 		const trigger = getByRole('button', { name: /人を管理/ });
-		expect(trigger.textContent).toMatch(/👥/);
+		// 絵文字ではなく phosphor icon (svg + aria-hidden) を使用 (#105)
+		const icon = trigger.querySelector('svg[aria-hidden="true"]');
+		expect(icon).toBeTruthy();
+		// 絵文字 👥 は使わない
+		expect(trigger.textContent).not.toMatch(/👥/);
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/人を管理/);
 	});
 });


### PR DESCRIPTION
#96 で絵文字を icon として導入したが、フォント / OS 揺れ + a11y 観点で問題があるため `phosphor-svelte` に置換。詳細は #105。

## 置換 (4 trigger button)

| Component | 旧 | 新 |
|---|---|---|
| ResourceManager | 👥 | \`Users\` |
| ProjectManager | 📁 | \`Folder\` |
| AssignmentCreator | + | \`Plus\` (weight=bold) |
| AssignmentManager | 📋 | \`ListChecks\` |

全 icon に \`aria-hidden=\"true\"\` 付与 (text label が読み上げ対象、screen reader 重複防止)。

## TDD (RED → GREEN)

各 \`*.svelte.test.ts\` の「絵文字 visible」 assertion を「\`svg[aria-hidden]\` visible + 絵文字 NOT match」 に書換 (4 ケース):
- 絵文字残ってる状態で **RED 4 fail を確認**
- 各 component を icon に置換 → **GREEN 92/92**

## 検証
- \`pnpm test\` 緑 (98 total: 92 passing + 6 skipped)
- \`pnpm check\` 緑 (1792 files / 0 errors)
- \`pnpm build\` 緑
- \`grep '👥|📁|📋' src/lib/components/*.svelte\` で **0 hit**

## 含まないもの
- AvatarDropdown の email initial (固有値、user 識別性が高い)
- ProjectManager の color swatch (装飾的、固有色なので維持)
- ThemeToggle / LocaleSwitcher の icon → #97 / #98 で同パターン採用

Closes #105