### PR TITLE
feat(i18n): 日英切替 + Accept-Language SSR + 言語混在解消

### DIFF
--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -1,7 +1,11 @@
+import type { Locale } from '$lib/i18n/index.svelte';
+
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
+		interface Locals {
+			locale: Locale;
+		}
 		// interface PageData {}
 		// interface PageState {}
 		// interface Platform {}

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -1,10 +1,26 @@
-import { handle } from './auth';
+import { sequence } from '@sveltejs/kit/hooks';
+import type { Handle } from '@sveltejs/kit';
+import { handle as authjsHandle } from './auth';
+import { COOKIE_NAME, pickLocaleFromAcceptLanguage, type Locale } from '$lib/i18n/index.svelte';
 
 /**
- * SvelteKit handle hook (#65 / #87)。
+ * locale を cookie / Accept-Language から決定して event.locals に格納する hook (#98)。
+ * 優先順位: cookie > Accept-Language > 'en' (fallback)。
  *
- * Auth.js (`@auth/sveltekit`) が `event.locals.auth` を async session getter として注入する。
- * ドメイン制限は Auth.js の `callbacks.signIn` (`auth.ts`) で実施するため、本 file には
- * 追加のミドルウェアは不要。Clerk 関連の SSM fetch / domain check / sequence は PR-A5 で撤去済。
+ * 実値は `+layout.server.ts` で `data.locale` として client に渡る。
  */
-export { handle };
+const localeHandle: Handle = async ({ event, resolve }) => {
+	const cookieLocale = event.cookies.get(COOKIE_NAME);
+	let locale: Locale;
+	if (cookieLocale === 'en' || cookieLocale === 'ja') {
+		locale = cookieLocale;
+	} else {
+		locale = pickLocaleFromAcceptLanguage(event.request.headers.get('accept-language'));
+	}
+	event.locals.locale = locale;
+	return resolve(event, {
+		transformPageChunk: ({ html }) => html.replace('<html lang="en">', `<html lang="${locale}">`)
+	});
+};
+
+export const handle: Handle = sequence(authjsHandle, localeHandle);

--- a/web/src/lib/components/AssignmentCreator.svelte
+++ b/web/src/lib/components/AssignmentCreator.svelte
@@ -5,6 +5,7 @@
 	import Dialog from './Dialog.svelte';
 	import { formatLocalDate } from '$lib/timeline-adapter';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { t } from '$lib/i18n/index.svelte';
 	import type { Resource, Project } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
 
@@ -72,13 +73,13 @@
 <Button
 	onclick={startCreate}
 	disabled={!canCreate}
-	title={canCreate ? '' : '人と案件を 1 件以上登録してから作成できます'}
+	title={canCreate ? '' : t('assignments.requirePeopleAndProjects')}
 >
 	<Plus size={18} weight="bold" aria-hidden="true" />
-	<span class="hidden sm:ml-1 sm:inline">アサインを追加</span>
+	<span class="hidden sm:ml-1 sm:inline">{t('assignments.add')}</span>
 </Button>
 
-<Dialog bind:open title="アサインを追加" description="人を案件に期間でアサインする">
+<Dialog bind:open title={t('assignments.createTitle')} description={t('assignments.description')}>
 	<form
 		method="POST"
 		action="?/createAssignment"
@@ -86,7 +87,7 @@
 		class="flex flex-col gap-3"
 	>
 		<label class="flex flex-col gap-1 text-sm">
-			<span>人</span>
+			<span>{t('assignments.resource')}</span>
 			<select
 				name="resourceId"
 				bind:value={resourceId}
@@ -104,7 +105,7 @@
 		</label>
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>案件</span>
+			<span>{t('assignments.project')}</span>
 			<select
 				name="projectId"
 				bind:value={projectId}
@@ -123,7 +124,7 @@
 
 		<div class="grid grid-cols-2 gap-3">
 			<label class="flex flex-col gap-1 text-sm">
-				<span>開始日</span>
+				<span>{t('assignments.startDate')}</span>
 				<input
 					name="startDate"
 					type="date"
@@ -138,7 +139,7 @@
 			</label>
 
 			<label class="flex flex-col gap-1 text-sm">
-				<span>終了日 (含む)</span>
+				<span>{t('assignments.endDate')}</span>
 				<input
 					name="endDate"
 					type="date"
@@ -161,10 +162,10 @@
 				onclick={() => (open = false)}
 				disabled={formSubmitState.submitting}
 			>
-				キャンセル
+				{t('common.cancel')}
 			</Button>
 			<Button type="submit" disabled={formSubmitState.submitting}>
-				{formSubmitState.submitting ? '送信中...' : '作成'}
+				{formSubmitState.submitting ? t('common.submitting') : t('assignments.create')}
 			</Button>
 		</div>
 	</form>

--- a/web/src/lib/components/AssignmentManager.svelte
+++ b/web/src/lib/components/AssignmentManager.svelte
@@ -5,6 +5,7 @@
 	import Dialog from './Dialog.svelte';
 	import { addDays } from '$lib/date';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { t } from '$lib/i18n/index.svelte';
 	import type { Assignment, Resource, Project } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
 
@@ -43,15 +44,17 @@
 
 <Button variant="outline" onclick={() => (open = true)}>
 	<ListChecks size={18} weight="regular" aria-hidden="true" />
-	<span class="hidden sm:ml-1 sm:inline">アサイン一覧 ({assignments.length})</span>
+	<span class="hidden sm:ml-1 sm:inline"
+		>{t('assignments.listWithCount', { count: assignments.length })}</span
+	>
 </Button>
 
-<Dialog bind:open title="アサイン一覧" description="登録済みアサインの一覧と削除">
+<Dialog bind:open title={t('assignments.listTitle')} description={t('assignments.listDescription')}>
 	<div class="flex flex-col gap-3">
 		{#if sorted.length === 0}
 			<p class="py-4 text-center text-sm text-muted-foreground">
-				まだアサインが登録されていません。<br />
-				右上の「+ アサインを追加」から作成できます。
+				{t('assignments.empty')}<br />
+				{t('assignments.emptyHint')}
 			</p>
 		{:else}
 			<ul class="max-h-[60vh] divide-y divide-border overflow-y-auto border border-border">
@@ -68,9 +71,9 @@
 							></span>
 							<div class="flex flex-1 flex-col">
 								<span>
-									{resource?.name ?? '(削除済リソース)'}
+									{resource?.name ?? t('assignments.deletedResource')}
 									<span class="text-muted-foreground">×</span>
-									{project?.name ?? '(削除済案件)'}
+									{project?.name ?? t('assignments.deletedProject')}
 								</span>
 								<span class="font-mono text-xs text-muted-foreground">
 									{a.startDate} 〜 {displayEndDate(a)}
@@ -82,8 +85,8 @@
 							action="?/deleteAssignment"
 							use:enhance={deleteSubmit}
 							onsubmit={(e) => {
-								const label = `${resource?.name ?? '(不明)'} × ${project?.name ?? '(不明)'} (${a.startDate} 〜 ${displayEndDate(a)})`;
-								if (!confirm(`このアサインを削除しますか?\n${label}`)) {
+								const label = `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`;
+								if (!confirm(t('assignments.confirmDelete', { label }))) {
 									e.preventDefault();
 								}
 							}}
@@ -96,7 +99,7 @@
 								type="submit"
 								disabled={deleteSubmitState.submitting}
 							>
-								削除
+								{t('common.delete')}
 							</Button>
 						</form>
 					</li>

--- a/web/src/lib/components/AvatarDropdown.svelte
+++ b/web/src/lib/components/AvatarDropdown.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
 	import { DropdownMenu } from 'bits-ui';
+	import { t } from '$lib/i18n/index.svelte';
 
 	let { email = '' }: { email?: string } = $props();
 
 	const initial = $derived(email.length > 0 ? email[0].toUpperCase() : '?');
-	const ariaLabel = $derived(email.length > 0 ? `ユーザーメニュー (${email})` : 'ユーザーメニュー');
+	const ariaLabel = $derived(
+		email.length > 0 ? t('avatar.labelWithEmail', { email }) : t('avatar.label')
+	);
 </script>
 
 <DropdownMenu.Root>
@@ -34,7 +37,7 @@
 				<DropdownMenu.Item
 					class="flex w-full cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent"
 				>
-					<button type="submit" class="flex-1 text-left">サインアウト</button>
+					<button type="submit" class="flex-1 text-left">{t('avatar.signout')}</button>
 				</DropdownMenu.Item>
 			</form>
 		</DropdownMenu.Content>

--- a/web/src/lib/components/LocaleSwitcher.svelte
+++ b/web/src/lib/components/LocaleSwitcher.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import Translate from 'phosphor-svelte/lib/Translate';
+	import { localeState, t, type Locale } from '$lib/i18n/index.svelte';
+
+	function cycle() {
+		const next: Locale = localeState.current === 'ja' ? 'en' : 'ja';
+		localeState.set(next);
+	}
+</script>
+
+<button
+	type="button"
+	onclick={cycle}
+	aria-label={t('locale.label')}
+	title={t('locale.label')}
+	class="inline-flex h-9 shrink-0 items-center justify-center gap-1 rounded-md border border-border bg-background px-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+>
+	<Translate size={18} weight="regular" aria-hidden="true" />
+	<span class="text-xs">{localeState.current === 'ja' ? 'JA' : 'EN'}</span>
+</button>

--- a/web/src/lib/components/LocaleSwitcher.svelte.test.ts
+++ b/web/src/lib/components/LocaleSwitcher.svelte.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it, beforeEach } from 'vitest';
+import LocaleSwitcher from './LocaleSwitcher.svelte';
+import { localeState } from '$lib/i18n/index.svelte';
+
+describe('LocaleSwitcher (smoke)', () => {
+	beforeEach(() => {
+		localeState.current = 'ja';
+	});
+
+	it('renders a button with phosphor svg icon and current locale code', () => {
+		const { getByRole } = render(LocaleSwitcher);
+		const btn = getByRole('button');
+		expect(btn.querySelector('svg[aria-hidden="true"]')).toBeTruthy();
+		expect(btn.textContent).toContain('JA');
+	});
+
+	it('shows EN code when locale is en', () => {
+		localeState.current = 'en';
+		const { getByRole } = render(LocaleSwitcher);
+		const btn = getByRole('button');
+		expect(btn.textContent).toContain('EN');
+	});
+
+	it('uses aria-label that mentions language / 言語', () => {
+		const { getByRole } = render(LocaleSwitcher);
+		const btn = getByRole('button');
+		const label = btn.getAttribute('aria-label') ?? '';
+		expect(label.toLowerCase()).toMatch(/language|言語/);
+	});
+});

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -4,6 +4,7 @@
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { t } from '$lib/i18n/index.svelte';
 	import type { Project, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
 
@@ -72,19 +73,17 @@
 
 <Button variant="outline" onclick={() => (listOpen = true)}>
 	<Folder size={18} weight="regular" aria-hidden="true" />
-	<span class="hidden sm:ml-1 sm:inline">案件を管理 ({projects.length})</span>
+	<span class="hidden sm:ml-1 sm:inline"
+		>{t('projects.manageWithCount', { count: projects.length })}</span
+	>
 </Button>
 
-<Dialog
-	bind:open={listOpen}
-	title="案件を管理"
-	description="案件 (プロジェクト) の追加・編集・削除"
->
+<Dialog bind:open={listOpen} title={t('projects.manage')} description={t('projects.description')}>
 	<div class="flex flex-col gap-3">
-		<Button onclick={startCreate}>+ 案件を追加</Button>
+		<Button onclick={startCreate}>{t('projects.add')}</Button>
 
 		{#if projects.length === 0}
-			<p class="py-4 text-center text-sm text-muted-foreground">まだ案件が登録されていません。</p>
+			<p class="py-4 text-center text-sm text-muted-foreground">{t('projects.empty')}</p>
 		{:else}
 			<ul class="divide-y divide-border border border-border">
 				{#each projects as p (p.id)}
@@ -94,14 +93,19 @@
 							<span
 								class="inline-block h-4 w-4 border border-black/10"
 								style="background-color: {p.color}; border-radius: calc(var(--radius) * 0.4)"
+								aria-hidden="true"
 							></span>
 							{p.name}
 							{#if count > 0}
-								<span class="text-xs text-muted-foreground">({count} 件のアサイン)</span>
+								<span class="text-xs text-muted-foreground"
+									>{t('projects.assignmentCount', { count })}</span
+								>
 							{/if}
 						</span>
 						<div class="flex gap-1">
-							<Button size="xs" variant="outline" onclick={() => startEdit(p)}>編集</Button>
+							<Button size="xs" variant="outline" onclick={() => startEdit(p)}
+								>{t('common.edit')}</Button
+							>
 							<form
 								method="POST"
 								action="?/deleteProject"
@@ -109,8 +113,8 @@
 								onsubmit={(e) => {
 									const msg =
 										count > 0
-											? `「${p.name}」と関連 ${count} 件のアサインを削除しますか?\n(取り消しできません)`
-											: `「${p.name}」を削除しますか?`;
+											? t('projects.confirmDeleteWithAssignments', { name: p.name, count })
+											: t('projects.confirmDelete', { name: p.name });
 									if (!confirm(msg)) {
 										e.preventDefault();
 									}
@@ -123,7 +127,7 @@
 									type="submit"
 									disabled={deleteSubmitState.submitting}
 								>
-									削除
+									{t('common.delete')}
 								</Button>
 							</form>
 						</div>
@@ -134,7 +138,7 @@
 	</div>
 </Dialog>
 
-<Dialog bind:open={formOpen} title={editing ? '案件を編集' : '案件を追加'}>
+<Dialog bind:open={formOpen} title={editing ? t('projects.editTitle') : t('projects.createTitle')}>
 	<form
 		method="POST"
 		action={editing ? '?/updateProject' : '?/createProject'}
@@ -146,7 +150,7 @@
 		{/if}
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>案件名</span>
+			<span>{t('projects.name')}</span>
 			<input
 				name="name"
 				type="text"
@@ -163,7 +167,7 @@
 		</label>
 
 		<label class="flex flex-col gap-1 text-sm">
-			<span>表示色</span>
+			<span>{t('projects.color')}</span>
 			<div class="flex items-center gap-2">
 				<input
 					name="color"
@@ -186,10 +190,14 @@
 				onclick={() => (formOpen = false)}
 				disabled={formSubmitState.submitting}
 			>
-				キャンセル
+				{t('common.cancel')}
 			</Button>
 			<Button type="submit" disabled={formSubmitState.submitting}>
-				{formSubmitState.submitting ? '送信中...' : editing ? '更新' : '追加'}
+				{formSubmitState.submitting
+					? t('common.submitting')
+					: editing
+						? t('common.update')
+						: t('common.create')}
 			</Button>
 		</div>
 	</form>

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -4,6 +4,7 @@
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { t } from '$lib/i18n/index.svelte';
 	import type { Resource, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
 
@@ -67,15 +68,17 @@
 
 <Button variant="outline" onclick={() => (listOpen = true)}>
 	<Users size={18} weight="regular" aria-hidden="true" />
-	<span class="hidden sm:ml-1 sm:inline">人を管理 ({resources.length})</span>
+	<span class="hidden sm:ml-1 sm:inline"
+		>{t('resources.manageWithCount', { count: resources.length })}</span
+	>
 </Button>
 
-<Dialog bind:open={listOpen} title="人を管理" description="リソース (人) の追加・編集・削除">
+<Dialog bind:open={listOpen} title={t('resources.manage')} description={t('resources.description')}>
 	<div class="flex flex-col gap-3">
-		<Button onclick={startCreate}>+ 人を追加</Button>
+		<Button onclick={startCreate}>{t('resources.add')}</Button>
 
 		{#if resources.length === 0}
-			<p class="py-4 text-center text-sm text-muted-foreground">まだ人が登録されていません。</p>
+			<p class="py-4 text-center text-sm text-muted-foreground">{t('resources.empty')}</p>
 		{:else}
 			<ul class="divide-y divide-border border border-border">
 				{#each resources as r (r.id)}
@@ -84,11 +87,15 @@
 						<span class="text-sm">
 							{r.name}
 							{#if count > 0}
-								<span class="ml-1 text-xs text-muted-foreground">({count} 件のアサイン)</span>
+								<span class="ml-1 text-xs text-muted-foreground"
+									>{t('resources.assignmentCount', { count })}</span
+								>
 							{/if}
 						</span>
 						<div class="flex gap-1">
-							<Button size="xs" variant="outline" onclick={() => startEdit(r)}>編集</Button>
+							<Button size="xs" variant="outline" onclick={() => startEdit(r)}
+								>{t('common.edit')}</Button
+							>
 							<form
 								method="POST"
 								action="?/deleteResource"
@@ -96,8 +103,8 @@
 								onsubmit={(e) => {
 									const msg =
 										count > 0
-											? `「${r.name}」と関連 ${count} 件のアサインを削除しますか?\n(取り消しできません)`
-											: `「${r.name}」を削除しますか?`;
+											? t('resources.confirmDeleteWithAssignments', { name: r.name, count })
+											: t('resources.confirmDelete', { name: r.name });
 									if (!confirm(msg)) {
 										e.preventDefault();
 									}
@@ -110,7 +117,7 @@
 									type="submit"
 									disabled={deleteSubmitState.submitting}
 								>
-									削除
+									{t('common.delete')}
 								</Button>
 							</form>
 						</div>
@@ -121,7 +128,10 @@
 	</div>
 </Dialog>
 
-<Dialog bind:open={formOpen} title={editing ? '人を編集' : '人を追加'}>
+<Dialog
+	bind:open={formOpen}
+	title={editing ? t('resources.editTitle') : t('resources.createTitle')}
+>
 	<form
 		method="POST"
 		action={editing ? '?/updateResource' : '?/createResource'}
@@ -132,7 +142,7 @@
 			<input type="hidden" name="id" value={editing.id} />
 		{/if}
 		<label class="flex flex-col gap-1 text-sm">
-			<span>名前</span>
+			<span>{t('resources.name')}</span>
 			<input
 				name="name"
 				type="text"
@@ -154,10 +164,14 @@
 				onclick={() => (formOpen = false)}
 				disabled={formSubmitState.submitting}
 			>
-				キャンセル
+				{t('common.cancel')}
 			</Button>
 			<Button type="submit" disabled={formSubmitState.submitting}>
-				{formSubmitState.submitting ? '送信中...' : editing ? '更新' : '追加'}
+				{formSubmitState.submitting
+					? t('common.submitting')
+					: editing
+						? t('common.update')
+						: t('common.create')}
 			</Button>
 		</div>
 	</form>

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -3,6 +3,7 @@
 	import Sun from 'phosphor-svelte/lib/Sun';
 	import Moon from 'phosphor-svelte/lib/Moon';
 	import Monitor from 'phosphor-svelte/lib/Monitor';
+	import { t } from '$lib/i18n/index.svelte';
 
 	/**
 	 * テーマ切替 (light → dark → system → light、#97)。
@@ -18,9 +19,10 @@
 
 	const label = $derived.by(() => {
 		const u = userPrefersMode.current;
-		if (u === 'system') return `テーマ: システム (${mode.current})`;
-		if (u === 'dark') return 'テーマ: ダーク';
-		return 'テーマ: ライト';
+		if (u === 'system') {
+			return t('theme.labelSystem', { resolved: t(`theme.${mode.current ?? 'light'}`) });
+		}
+		return t('theme.label', { mode: t(`theme.${u}`) });
 	});
 </script>
 

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -1,0 +1,127 @@
+{
+	"app": {
+		"title": "resource-planner"
+	},
+	"common": {
+		"create": "Create",
+		"update": "Update",
+		"cancel": "Cancel",
+		"delete": "Delete",
+		"edit": "Edit",
+		"submitting": "Submitting…",
+		"close": "Close",
+		"confirm": "Confirm",
+		"requiredError": "Required",
+		"maxLengthError": "{n} characters max"
+	},
+	"timeline": {
+		"today": "Today",
+		"prev": "Prev",
+		"next": "Next",
+		"prevAria": "Previous period",
+		"nextAria": "Next period",
+		"zoomDay": "Day",
+		"zoomWeek": "Week",
+		"zoomMonth": "Month",
+		"zoomYear": "Year"
+	},
+	"resources": {
+		"manage": "Manage people",
+		"manageWithCount": "Manage people ({count})",
+		"add": "+ Add person",
+		"addNew": "Add person",
+		"editTitle": "Edit person",
+		"createTitle": "Add person",
+		"description": "Add, edit and delete resources (people)",
+		"empty": "No people registered yet.",
+		"emptyHint": "Use the \"Manage people\" button at the top right to add the first resource.",
+		"name": "Name",
+		"assignmentCount": "({count} assignments)",
+		"confirmDelete": "Delete \"{name}\"?",
+		"confirmDeleteWithAssignments": "Delete \"{name}\" and {count} related assignments?\n(Cannot be undone)"
+	},
+	"projects": {
+		"manage": "Manage projects",
+		"manageWithCount": "Manage projects ({count})",
+		"add": "+ Add project",
+		"addNew": "Add project",
+		"editTitle": "Edit project",
+		"createTitle": "Add project",
+		"description": "Add, edit and delete projects",
+		"empty": "No projects registered yet.",
+		"name": "Project name",
+		"color": "Display color",
+		"assignmentCount": "({count} assignments)",
+		"confirmDelete": "Delete \"{name}\"?",
+		"confirmDeleteWithAssignments": "Delete \"{name}\" and {count} related assignments?\n(Cannot be undone)"
+	},
+	"assignments": {
+		"add": "Add assignment",
+		"addLong": "+ Add assignment",
+		"createTitle": "Add assignment",
+		"description": "Assign a person to a project for a date range",
+		"list": "Assignments",
+		"listWithCount": "Assignments ({count})",
+		"listTitle": "Assignments",
+		"listDescription": "List of registered assignments",
+		"empty": "No assignments registered yet.",
+		"emptyHint": "Use \"+ Add assignment\" at the top right to create one.",
+		"resource": "Person",
+		"project": "Project",
+		"startDate": "Start date",
+		"endDate": "End date (inclusive)",
+		"deletedResource": "(deleted resource)",
+		"deletedProject": "(deleted project)",
+		"create": "Create",
+		"requirePeopleAndProjects": "Register at least one person and one project to create assignments",
+		"updateError": "Failed to update the assignment",
+		"networkError": "Network error",
+		"confirmDelete": "Delete this assignment?\n{label}"
+	},
+	"signin": {
+		"title": "Sign in",
+		"description": "Enter your work email. We will send you a sign-in link by email.",
+		"emailLabel": "Email address",
+		"emailPlaceholder": "you@your-company.example.com",
+		"submit": "Send sign-in link",
+		"submitting": "Sending…",
+		"hint": "Only email addresses on the allowed domain can sign in.",
+		"checkEmailTitle": "Check your email",
+		"checkEmailDescription": "We sent a sign-in link to your email. Click the link to complete sign-in.",
+		"checkEmailFootnote": "If the email does not arrive, check your spam folder. The link expires in 24 hours.",
+		"checkEmailRetry": "Send to a different email",
+		"errorTitle": "Sign-in failed",
+		"errorAccessDenied": "This email domain is not allowed.",
+		"errorVerification": "The link is invalid or expired. Please send a new sign-in link.",
+		"errorConfiguration": "There is a problem with the auth configuration. Please contact the administrator.",
+		"errorDefault": "Sign-in failed. Please try again later.",
+		"errorCode": "Error code: {code}",
+		"backToSignin": "Back to sign-in"
+	},
+	"errorPage": {
+		"hint401": "Sign-in is required. Enter your email on the sign-in page.",
+		"hint403": "This action is not permitted. Check your permissions for the signed-in user.",
+		"hint404": "The requested URL does not exist.",
+		"hint5xx": "A server-side error occurred. Please try again later.",
+		"goHome": "Back to home",
+		"signin": "Sign in",
+		"unknownMessage": "An unknown error occurred"
+	},
+	"theme": {
+		"label": "Theme: {mode}",
+		"labelSystem": "Theme: system ({resolved})",
+		"light": "light",
+		"dark": "dark",
+		"system": "system"
+	},
+	"locale": {
+		"label": "Language",
+		"japanese": "日本語",
+		"english": "English"
+	},
+	"avatar": {
+		"label": "User menu",
+		"labelWithEmail": "User menu ({email})",
+		"signout": "Sign out"
+	}
+}

--- a/web/src/lib/i18n/index.svelte.test.ts
+++ b/web/src/lib/i18n/index.svelte.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { localeState, pickLocaleFromAcceptLanguage, t } from './index.svelte';
+
+describe('pickLocaleFromAcceptLanguage', () => {
+	it('returns ja when header starts with ja', () => {
+		expect(pickLocaleFromAcceptLanguage('ja,en;q=0.9')).toBe('ja');
+		expect(pickLocaleFromAcceptLanguage('ja-JP')).toBe('ja');
+		expect(pickLocaleFromAcceptLanguage('JA-jp;q=1')).toBe('ja');
+	});
+
+	it('returns en when header starts with en (no ja)', () => {
+		expect(pickLocaleFromAcceptLanguage('en-US,en;q=0.9')).toBe('en');
+		expect(pickLocaleFromAcceptLanguage('en')).toBe('en');
+	});
+
+	it('prefers ja when ja appears first (priority on order)', () => {
+		expect(pickLocaleFromAcceptLanguage('ja,en;q=0.9')).toBe('ja');
+		expect(pickLocaleFromAcceptLanguage('en;q=0.9,ja;q=0.8')).toBe('en');
+	});
+
+	it('returns en for unknown / empty', () => {
+		expect(pickLocaleFromAcceptLanguage('')).toBe('en');
+		expect(pickLocaleFromAcceptLanguage(null)).toBe('en');
+		expect(pickLocaleFromAcceptLanguage(undefined)).toBe('en');
+		expect(pickLocaleFromAcceptLanguage('zh-CN,fr;q=0.5')).toBe('en');
+	});
+});
+
+describe('t (translation lookup)', () => {
+	beforeEach(() => {
+		localeState.current = 'ja';
+	});
+
+	it('returns the translated string for a known key (ja default)', () => {
+		expect(t('resources.manage')).toBe('人を管理');
+	});
+
+	it('switches language when localeState changes', () => {
+		expect(t('resources.manage')).toBe('人を管理');
+		localeState.current = 'en';
+		expect(t('resources.manage')).toBe('Manage people');
+	});
+
+	it('substitutes {name} placeholders with params', () => {
+		const ja = t('resources.confirmDelete', { name: '山田' });
+		expect(ja).toContain('山田');
+	});
+
+	it('returns the key itself when not found (fail-soft)', () => {
+		expect(t('does.not.exist')).toBe('does.not.exist');
+	});
+
+	it('returns the unmodified template if a placeholder is unspecified', () => {
+		const result = t('resources.confirmDelete'); // no params provided
+		expect(result).toContain('{name}'); // placeholder kept as-is
+	});
+});

--- a/web/src/lib/i18n/index.svelte.ts
+++ b/web/src/lib/i18n/index.svelte.ts
@@ -1,0 +1,111 @@
+/**
+ * i18n core (#98)。burnnote から移植 + SSR cookie / Accept-Language 対応。
+ *
+ * - locale state を `$state` で reactive に保持
+ * - `t('key.subkey', { name })` で文字列取得 + `{name}` プレースホルダ補間
+ * - SSR は `+layout.server.ts` の load で cookie / Accept-Language から locale 決定し
+ *   `data.locale` で渡す → `+layout.svelte` で `localeState.set(...)` 同期
+ * - client は localStorage > navigator.language の優先順で初期化 (SSR 経由でも cookie から復元)
+ */
+import en from './en.json';
+import ja from './ja.json';
+
+export type Locale = 'en' | 'ja';
+
+const messages = { en, ja } as const;
+
+const STORAGE_KEY = 'resource-planner-locale';
+export const COOKIE_NAME = 'resource-planner-locale';
+
+type MessageNode = string | { [k: string]: MessageNode };
+
+class LocaleState {
+	current = $state<Locale>('ja');
+
+	set(next: Locale): void {
+		this.current = next;
+		if (typeof window !== 'undefined') {
+			try {
+				localStorage.setItem(STORAGE_KEY, next);
+				document.cookie = `${COOKIE_NAME}=${next}; path=/; max-age=31536000; samesite=lax`;
+			} catch {
+				// ignore storage errors
+			}
+			document.documentElement.lang = next;
+		}
+	}
+
+	/**
+	 * Client-side initialization。SSR で cookie 経由で渡された locale が優先、
+	 * cookie 無い場合は localStorage > navigator.language。
+	 */
+	init(serverLocale?: Locale | null): void {
+		if (serverLocale === 'en' || serverLocale === 'ja') {
+			this.current = serverLocale;
+			if (typeof document !== 'undefined') {
+				document.documentElement.lang = serverLocale;
+			}
+			return;
+		}
+		if (typeof window === 'undefined') return;
+		let stored: string | null = null;
+		try {
+			stored = localStorage.getItem(STORAGE_KEY);
+		} catch {
+			// ignore
+		}
+		if (stored === 'en' || stored === 'ja') {
+			this.set(stored);
+			return;
+		}
+		const nav = navigator.language?.toLowerCase() ?? '';
+		this.set(nav.startsWith('ja') ? 'ja' : 'en');
+	}
+}
+
+export const localeState = new LocaleState();
+
+export function getLocale(): Locale {
+	return localeState.current;
+}
+
+export function setLocale(next: Locale): void {
+	localeState.set(next);
+}
+
+export function initLocale(serverLocale?: Locale | null): void {
+	localeState.init(serverLocale);
+}
+
+/**
+ * `Accept-Language` header から ja/en を抽出 (server-side、純粋関数なのでテスト容易)。
+ * 例: `ja,en-US;q=0.9` → 'ja'、`en-US,en;q=0.9` → 'en'、不明 → 'en' (default)。
+ */
+export function pickLocaleFromAcceptLanguage(header: string | null | undefined): Locale {
+	if (!header) return 'en';
+	const lower = header.toLowerCase();
+	// 各 candidate を q 値で並べてもいいが、社内利用 (ja/en の 2 言語のみ) なので最初に
+	// マッチした方を採用。`ja` が含まれていれば ja を優先 (社内ユーザー主体想定)。
+	for (const part of lower.split(',')) {
+		const lang = part.trim().split(';')[0];
+		if (lang.startsWith('ja')) return 'ja';
+		if (lang.startsWith('en')) return 'en';
+	}
+	return 'en';
+}
+
+export function t(key: string, params?: Record<string, string | number>): string {
+	const parts = key.split('.');
+	let node: MessageNode = messages[localeState.current];
+	for (const p of parts) {
+		if (typeof node === 'string') return key;
+		node = node[p];
+		if (node === undefined) return key;
+	}
+	if (typeof node !== 'string') return key;
+	if (!params) return node;
+	return node.replace(/\{(\w+)\}/g, (_, k) => {
+		const v = params[k];
+		return v === undefined ? `{${k}}` : String(v);
+	});
+}

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -1,0 +1,127 @@
+{
+	"app": {
+		"title": "resource-planner"
+	},
+	"common": {
+		"create": "追加",
+		"update": "更新",
+		"cancel": "キャンセル",
+		"delete": "削除",
+		"edit": "編集",
+		"submitting": "送信中...",
+		"close": "閉じる",
+		"confirm": "確認",
+		"requiredError": "必須",
+		"maxLengthError": "{n} 文字以内"
+	},
+	"timeline": {
+		"today": "今日",
+		"prev": "前へ",
+		"next": "次へ",
+		"prevAria": "前の期間へ",
+		"nextAria": "次の期間へ",
+		"zoomDay": "日",
+		"zoomWeek": "週",
+		"zoomMonth": "月",
+		"zoomYear": "年"
+	},
+	"resources": {
+		"manage": "人を管理",
+		"manageWithCount": "人を管理 ({count})",
+		"add": "+ 人を追加",
+		"addNew": "人を追加",
+		"editTitle": "人を編集",
+		"createTitle": "人を追加",
+		"description": "リソース (人) の追加・編集・削除",
+		"empty": "まだ人が登録されていません。",
+		"emptyHint": "右上の「人を管理」ボタンから最初のリソースを追加してください。",
+		"name": "名前",
+		"assignmentCount": "({count} 件のアサイン)",
+		"confirmDelete": "「{name}」を削除しますか?",
+		"confirmDeleteWithAssignments": "「{name}」と関連 {count} 件のアサインを削除しますか?\n(取り消しできません)"
+	},
+	"projects": {
+		"manage": "案件を管理",
+		"manageWithCount": "案件を管理 ({count})",
+		"add": "+ 案件を追加",
+		"addNew": "案件を追加",
+		"editTitle": "案件を編集",
+		"createTitle": "案件を追加",
+		"description": "案件 (プロジェクト) の追加・編集・削除",
+		"empty": "まだ案件が登録されていません。",
+		"name": "案件名",
+		"color": "表示色",
+		"assignmentCount": "({count} 件のアサイン)",
+		"confirmDelete": "「{name}」を削除しますか?",
+		"confirmDeleteWithAssignments": "「{name}」と関連 {count} 件のアサインを削除しますか?\n(取り消しできません)"
+	},
+	"assignments": {
+		"add": "アサインを追加",
+		"addLong": "+ アサインを追加",
+		"createTitle": "アサインを追加",
+		"description": "人を案件に期間でアサインする",
+		"list": "アサイン一覧",
+		"listWithCount": "アサイン一覧 ({count})",
+		"listTitle": "アサイン一覧",
+		"listDescription": "登録済みアサインの一覧と削除",
+		"empty": "まだアサインが登録されていません。",
+		"emptyHint": "右上の「+ アサインを追加」から作成できます。",
+		"resource": "人",
+		"project": "案件",
+		"startDate": "開始日",
+		"endDate": "終了日 (含む)",
+		"deletedResource": "(削除済リソース)",
+		"deletedProject": "(削除済案件)",
+		"create": "作成",
+		"requirePeopleAndProjects": "人と案件を 1 件以上登録してから作成できます",
+		"updateError": "アサインの更新に失敗しました",
+		"networkError": "通信エラー",
+		"confirmDelete": "このアサインを削除しますか?\n{label}"
+	},
+	"signin": {
+		"title": "サインイン",
+		"description": "会社のメールアドレスを入力してください。サインインリンクをメールで送信します。",
+		"emailLabel": "メールアドレス",
+		"emailPlaceholder": "you@your-company.example.com",
+		"submit": "サインインリンクを送信",
+		"submitting": "送信中...",
+		"hint": "許可されたドメインのメールアドレスのみサインイン可能です。",
+		"checkEmailTitle": "メールを確認してください",
+		"checkEmailDescription": "サインインリンクをメールで送信しました。メール内のリンクをクリックしてサインインを完了してください。",
+		"checkEmailFootnote": "メールが届かない場合は、迷惑メールフォルダを確認してください。リンクは 24 時間で失効します。",
+		"checkEmailRetry": "別のメールアドレスで再送信",
+		"errorTitle": "サインインに失敗しました",
+		"errorAccessDenied": "許可されていないドメインのメールアドレスです。",
+		"errorVerification": "リンクが無効または期限切れです。再度サインインリンクを送信してください。",
+		"errorConfiguration": "認証設定に問題があります。管理者に連絡してください。",
+		"errorDefault": "サインインに失敗しました。しばらくして再試行してください。",
+		"errorCode": "エラーコード: {code}",
+		"backToSignin": "サインインに戻る"
+	},
+	"errorPage": {
+		"hint401": "サインインが必要です。サインイン画面でメールアドレスを入力してください。",
+		"hint403": "許可されていない操作です。サインインしているユーザーで権限を確認してください。",
+		"hint404": "指定された URL は存在しません。",
+		"hint5xx": "サーバー側でエラーが発生しました。時間をおいて再度お試しください。",
+		"goHome": "ホームに戻る",
+		"signin": "サインイン",
+		"unknownMessage": "不明なエラーが発生しました"
+	},
+	"theme": {
+		"label": "テーマ: {mode}",
+		"labelSystem": "テーマ: システム ({resolved})",
+		"light": "ライト",
+		"dark": "ダーク",
+		"system": "システム"
+	},
+	"locale": {
+		"label": "言語",
+		"japanese": "日本語",
+		"english": "English"
+	},
+	"avatar": {
+		"label": "ユーザーメニュー",
+		"labelWithEmail": "ユーザーメニュー ({email})",
+		"signout": "サインアウト"
+	}
+}

--- a/web/src/routes/+error.svelte
+++ b/web/src/routes/+error.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { Button } from '$lib/components/ui/button';
+	import { t } from '$lib/i18n/index.svelte';
 
 	const status = $derived(page.status);
-	const message = $derived(page.error?.message ?? '不明なエラーが発生しました');
+	const message = $derived(page.error?.message ?? t('errorPage.unknownMessage'));
 </script>
 
 <main>
@@ -12,21 +13,21 @@
 		<p class="message">{message}</p>
 
 		{#if status === 401}
-			<p class="hint">サインインが必要です。サインイン画面でメールアドレスを入力してください。</p>
+			<p class="hint">{t('errorPage.hint401')}</p>
 		{:else if status === 403}
-			<p class="hint">
-				許可されていない操作です。サインインしているユーザーで権限を確認してください。
-			</p>
+			<p class="hint">{t('errorPage.hint403')}</p>
 		{:else if status === 404}
-			<p class="hint">指定された URL は存在しません。</p>
+			<p class="hint">{t('errorPage.hint404')}</p>
 		{:else if status >= 500}
-			<p class="hint">サーバー側でエラーが発生しました。時間をおいて再度お試しください。</p>
+			<p class="hint">{t('errorPage.hint5xx')}</p>
 		{/if}
 
 		<div class="actions">
-			<Button variant="outline" onclick={() => (window.location.href = '/')}>ホームに戻る</Button>
+			<Button variant="outline" onclick={() => (window.location.href = '/')}>
+				{t('errorPage.goHome')}
+			</Button>
 			<Button variant="ghost" onclick={() => (window.location.href = '/sign-in')}>
-				サインイン
+				{t('errorPage.signin')}
 			</Button>
 		</div>
 	</div>

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -4,12 +4,13 @@ import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async (event) => {
 	const session = await event.locals.auth();
+	const locale = event.locals.locale;
 
 	// 未認証なら sign-in ページへ送る (#65 / #87、Clerk 撤去後)。
 	// /sign-in 系ページ自体は authenticated でも accessible (Auth.js 側で適切にハンドル)。
 	if (!session?.user?.id) {
 		if (event.url.pathname.startsWith('/sign-in') || event.url.pathname.startsWith('/auth')) {
-			return { resources: [], projects: [], assignments: [] };
+			return { locale, resources: [], projects: [], assignments: [] };
 		}
 		redirect(303, '/sign-in');
 	}
@@ -19,6 +20,7 @@ export const load: LayoutServerLoad = async (event) => {
 	const data = await queryAllByTeam(teamId);
 
 	return {
+		locale,
 		user: { id: session.user.id, email: session.user.email, name: session.user.name },
 		...data
 	};

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -3,8 +3,15 @@
 	import favicon from '$lib/assets/favicon.svg';
 	import { ModeWatcher } from 'mode-watcher';
 	import { Toaster } from 'svelte-sonner';
+	import { initLocale } from '$lib/i18n/index.svelte';
+	import type { LayoutData } from './$types';
 
-	let { children } = $props();
+	let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
+
+	// SSR で決定された locale (cookie / Accept-Language) を client にも同期 (#98)
+	$effect.pre(() => {
+		initLocale(data.locale);
+	});
 </script>
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -13,6 +13,8 @@
 	import AssignmentManager from '$lib/components/AssignmentManager.svelte';
 	import AvatarDropdown from '$lib/components/AvatarDropdown.svelte';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import LocaleSwitcher from '$lib/components/LocaleSwitcher.svelte';
+	import { t } from '$lib/i18n/index.svelte';
 	import type { Assignment as DbAssignment } from '$lib/types';
 	import type { PageData } from './$types';
 
@@ -71,8 +73,8 @@
 			}
 		} catch (e) {
 			dbAssignments = snapshot;
-			toast.error('アサインの更新に失敗しました', {
-				description: e instanceof Error ? e.message : '通信エラー'
+			toast.error(t('assignments.updateError'), {
+				description: e instanceof Error ? e.message : t('assignments.networkError')
 			});
 		}
 	}
@@ -80,12 +82,13 @@
 
 <header class="sticky top-0 z-40 border-b border-border bg-background/80 backdrop-blur">
 	<div class="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-2 px-4 py-3">
-		<h1 class="m-0 text-lg font-semibold tracking-tight sm:text-xl">resource-planner</h1>
+		<h1 class="m-0 text-lg font-semibold tracking-tight sm:text-xl">{t('app.title')}</h1>
 		<div class="flex flex-wrap items-center gap-2">
 			<ResourceManager {resources} assignments={dbAssignments} />
 			<ProjectManager {projects} assignments={dbAssignments} />
 			<AssignmentCreator {resources} {projects} />
 			<AssignmentManager assignments={dbAssignments} {resources} {projects} />
+			<LocaleSwitcher />
 			<ThemeToggle />
 			<AvatarDropdown email={data.user?.email ?? ''} />
 		</div>
@@ -95,23 +98,23 @@
 <main class="mx-auto max-w-[1200px] px-4 py-6">
 	{#if resources.length === 0}
 		<div class="empty-state">
-			<p>まだ人が登録されていません。</p>
-			<p class="hint">右上の「人を管理」ボタンから最初のリソースを追加してください。</p>
+			<p>{t('resources.empty')}</p>
+			<p class="hint">{t('resources.emptyHint')}</p>
 		</div>
 	{:else}
 		<TimelineToolbar
 			bind:viewportStart
 			bind:zoom
 			labels={{
-				today: '今日',
-				prev: '前へ',
-				next: '次へ',
-				zoomDay: '日',
-				zoomWeek: '週',
-				zoomMonth: '月',
-				zoomYear: '年'
+				today: t('timeline.today'),
+				prev: t('timeline.prev'),
+				next: t('timeline.next'),
+				zoomDay: t('timeline.zoomDay'),
+				zoomWeek: t('timeline.zoomWeek'),
+				zoomMonth: t('timeline.zoomMonth'),
+				zoomYear: t('timeline.zoomYear')
 			}}
-			ariaLabels={{ prev: '前の期間へ', next: '次の期間へ' }}
+			ariaLabels={{ prev: t('timeline.prevAria'), next: t('timeline.nextAria') }}
 		/>
 
 		<ResourceTimeline

--- a/web/src/routes/sign-in/+page.svelte
+++ b/web/src/routes/sign-in/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { t } from '$lib/i18n/index.svelte';
 	import type { PageData } from './$types';
 	let { data }: { data: PageData } = $props();
 
@@ -16,13 +17,13 @@
 </script>
 
 <svelte:head>
-	<title>サインイン — resource-planner</title>
+	<title>{t('signin.title')} — {t('app.title')}</title>
 </svelte:head>
 
 <main class="container mx-auto max-w-md px-4 py-12">
-	<h1 class="mb-2 text-2xl font-bold">サインイン</h1>
+	<h1 class="mb-2 text-2xl font-bold">{t('signin.title')}</h1>
 	<p class="mb-6 text-sm text-muted-foreground">
-		会社のメールアドレスを入力してください。サインインリンクをメールで送信します。
+		{t('signin.description')}
 	</p>
 
 	<!--
@@ -32,7 +33,7 @@
 	<form method="POST" action="/auth/signin/nodemailer" class="space-y-4" onsubmit={onSubmit}>
 		<input type="hidden" name="csrfToken" value={data.csrfToken} />
 		<div>
-			<label for="email" class="mb-1 block text-sm font-medium">メールアドレス</label>
+			<label for="email" class="mb-1 block text-sm font-medium">{t('signin.emailLabel')}</label>
 			<input
 				id="email"
 				name="email"
@@ -41,7 +42,7 @@
 				autocomplete="email"
 				disabled={submitting}
 				class="w-full rounded border border-input bg-background px-3 py-2 disabled:opacity-60"
-				placeholder="you@your-company.example.com"
+				placeholder={t('signin.emailPlaceholder')}
 			/>
 		</div>
 		<button
@@ -49,11 +50,11 @@
 			disabled={submitting}
 			class="w-full rounded bg-primary px-4 py-2 text-primary-foreground disabled:opacity-60"
 		>
-			{submitting ? '送信中...' : 'サインインリンクを送信'}
+			{submitting ? t('signin.submitting') : t('signin.submit')}
 		</button>
 	</form>
 
 	<p class="mt-6 text-xs text-muted-foreground">
-		許可されたドメインのメールアドレスのみサインイン可能です。
+		{t('signin.hint')}
 	</p>
 </main>

--- a/web/src/routes/sign-in/check-email/+page.svelte
+++ b/web/src/routes/sign-in/check-email/+page.svelte
@@ -1,17 +1,21 @@
+<script lang="ts">
+	import { t } from '$lib/i18n/index.svelte';
+</script>
+
 <svelte:head>
-	<title>メールを確認してください — resource-planner</title>
+	<title>{t('signin.checkEmailTitle')} — {t('app.title')}</title>
 </svelte:head>
 
 <main class="container mx-auto max-w-md px-4 py-12">
-	<h1 class="mb-2 text-2xl font-bold">メールを確認してください</h1>
+	<h1 class="mb-2 text-2xl font-bold">{t('signin.checkEmailTitle')}</h1>
 	<p class="mb-4">
-		サインインリンクをメールで送信しました。メール内のリンクをクリックしてサインインを完了してください。
+		{t('signin.checkEmailDescription')}
 	</p>
 	<p class="text-sm text-muted-foreground">
-		メールが届かない場合は、迷惑メールフォルダを確認してください。リンクは 24 時間で失効します。
+		{t('signin.checkEmailFootnote')}
 	</p>
 
 	<div class="mt-6">
-		<a href="/sign-in" class="text-sm text-primary underline">別のメールアドレスで再送信</a>
+		<a href="/sign-in" class="text-sm text-primary underline">{t('signin.checkEmailRetry')}</a>
 	</div>
 </main>

--- a/web/src/routes/sign-in/error/+page.svelte
+++ b/web/src/routes/sign-in/error/+page.svelte
@@ -1,32 +1,37 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { t } from '$lib/i18n/index.svelte';
 
 	const errorCode = $derived(page.url.searchParams.get('error') ?? 'Default');
 
-	const errorMessages: Record<string, string> = {
-		AccessDenied: '許可されていないドメインのメールアドレスです。',
-		Verification: 'リンクが無効または期限切れです。再度サインインリンクを送信してください。',
-		Configuration: '認証設定に問題があります。管理者に連絡してください。',
-		Default: 'サインインに失敗しました。しばらくして再試行してください。'
-	};
-
-	const message = $derived(errorMessages[errorCode] ?? errorMessages.Default);
+	const message = $derived.by(() => {
+		switch (errorCode) {
+			case 'AccessDenied':
+				return t('signin.errorAccessDenied');
+			case 'Verification':
+				return t('signin.errorVerification');
+			case 'Configuration':
+				return t('signin.errorConfiguration');
+			default:
+				return t('signin.errorDefault');
+		}
+	});
 </script>
 
 <svelte:head>
-	<title>サインインエラー — resource-planner</title>
+	<title>{t('signin.errorTitle')} — {t('app.title')}</title>
 </svelte:head>
 
 <main class="container mx-auto max-w-md px-4 py-12">
-	<h1 class="mb-2 text-2xl font-bold">サインインに失敗しました</h1>
+	<h1 class="mb-2 text-2xl font-bold">{t('signin.errorTitle')}</h1>
 	<p class="mb-4 rounded border-l-4 border-destructive bg-destructive/10 p-4 text-sm">
 		{message}
 	</p>
-	<p class="text-xs text-muted-foreground">エラーコード: {errorCode}</p>
+	<p class="text-xs text-muted-foreground">{t('signin.errorCode', { code: errorCode })}</p>
 
 	<div class="mt-6">
 		<a href="/sign-in" class="inline-block rounded bg-primary px-4 py-2 text-primary-foreground">
-			サインインに戻る
+			{t('signin.backToSignin')}
 		</a>
 	</div>
 </main>


### PR DESCRIPTION
#98 — ユーザー提示課題 #1 + #3 (lang) 対応。これで original 4 課題全部解消。

## 新規

### i18n core (\`lib/i18n/\`)
- \`index.svelte.ts\`: burnnote 移植 + SSR 拡張
  - \`localeState\` (\$state、ja default)、\`t(key, params)\`、\`Locale\` 型
  - \`pickLocaleFromAcceptLanguage\`: header parse の純粋関数 (テスト容易)
  - \`initLocale(serverLocale?)\`: SSR cookie 優先 → localStorage → navigator.language
  - cookie 名 \`resource-planner-locale\` で他 repo と分離
- \`en.json\` / \`ja.json\`: 9 セクション 75+ keys (app / common / timeline / resources / projects / assignments / signin / errorPage / theme / locale / avatar)
- \`index.svelte.test.ts\`: 9 unit test (header parse + t resolution + params 補間 + fallback)

### LocaleSwitcher
- phosphor \`Translate\` icon + JA/EN cycle button
- 3 smoke test

## 変更 (SSR + UI)
- \`hooks.server.ts\`: \`localeHandle\` で cookie / Accept-Language から \`event.locals.locale\` 決定、\`<html lang>\` を transformPageChunk で出力
- \`app.d.ts\`: \`App.Locals.locale: Locale\`
- \`+layout.server.ts\`: \`data.locale\` で client に渡す
- \`+layout.svelte\`: \`initLocale(data.locale)\` で client 同期
- \`+page.svelte\`: ヘッダに \`<LocaleSwitcher />\`、h1 / empty / TimelineToolbar / toast を \`t()\` 化
- 全 Manager / Creator: trigger / dialog title / form label / confirm / submitting / button text を \`t()\` 化
- sign-in / check-email / error / +error: 全文 \`t()\` 化
- AvatarDropdown / ThemeToggle: aria-label / menu item を \`t()\` 化

## TDD
RED → GREEN。i18n core 9 + LocaleSwitcher 3 ケースを先に書いて RED 確認、実装後 GREEN。

## 検証
- \`pnpm test\` 緑 (112 total: 106 passing + 6 skipped、+12 ケース)
- \`pnpm check\` 緑 (1831 files / 0 errors)
- \`pnpm build\` 緑

## 含まないもの
- \`window.confirm()\` → bits-ui AlertDialog 置換 → #101 で polish bundle として
- TimelineToolbar の曜日 \`(Sun)(Mon)\` 英語 → ui-components 側 prop 要対応、別 issue
- HTML5 date input の locale → browser 依存で変更不可
- SvelteKit fallback 404 page の英語 → \`+error.svelte\` (custom) は本 PR で t() 化、SvelteKit 標準 fallback はそのまま

## ユーザー提示課題の達成状況
- ✅ #1 i18n
- ✅ #2 theme (PR #107)
- ✅ #3 prefers-color-scheme + Accept-Language 追従 (theme: PR #107 / lang: 本 PR)
- ✅ #4 iPhone 12 レスポンシブ (PR #103)

Closes #98