### PR TITLE
fix(signin): use readonly instead of disabled on email input (fixes #109)

### DIFF
--- a/web/src/routes/sign-in/+page.svelte
+++ b/web/src/routes/sign-in/+page.svelte
@@ -40,8 +40,8 @@
 				type="email"
 				required
 				autocomplete="email"
-				disabled={submitting}
-				class="w-full rounded border border-input bg-background px-3 py-2 disabled:opacity-60"
+				readonly={submitting}
+				class="w-full rounded border border-input bg-background px-3 py-2 read-only:opacity-60"
 				placeholder={t('signin.emailPlaceholder')}
 			/>
 		</div>

--- a/web/src/routes/sign-in/page.svelte.test.ts
+++ b/web/src/routes/sign-in/page.svelte.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { render, fireEvent } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import SignInPage from './+page.svelte';
+import type { PageData } from './$types';
+
+/**
+ * #109 regression: sign-in form の email input が submit 時に `disabled` 化されると、
+ * HTML 仕様で disabled な input は form data から除外されるため、Auth.js が
+ * `Missing email from request body` で reject する。
+ *
+ * 連打防止は維持しつつ、input は disabled にせず (readonly 化 or 触らない) で
+ * form data に email が含まれることを保証する。
+ */
+const stubData = (): PageData => ({
+	csrfToken: 'test-csrf',
+	locale: 'ja',
+	resources: [],
+	projects: [],
+	assignments: []
+});
+
+describe('sign-in +page.svelte — email input must remain in form data on submit (#109)', () => {
+	it('does not set `disabled` on the email input after submit (would exclude it from form data)', async () => {
+		const { container } = render(SignInPage, {
+			props: { data: stubData() }
+		});
+
+		const form = container.querySelector('form') as HTMLFormElement;
+		const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement;
+		expect(emailInput).toBeTruthy();
+		emailInput.value = 'alice@example.com';
+
+		// jsdom は実 navigation しないので preventDefault でガード
+		form.addEventListener('submit', (e) => e.preventDefault());
+		await fireEvent.submit(form);
+
+		expect(emailInput.disabled).toBe(false);
+	});
+
+	it('still prevents double-submit by disabling the submit button', async () => {
+		const { container } = render(SignInPage, {
+			props: { data: stubData() }
+		});
+
+		const form = container.querySelector('form') as HTMLFormElement;
+		const submitBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+
+		form.addEventListener('submit', (e) => e.preventDefault());
+		await fireEvent.submit(form);
+
+		expect(submitBtn.disabled).toBe(true);
+	});
+
+	it('includes the email value in FormData built from the form after submit', async () => {
+		const { container } = render(SignInPage, {
+			props: { data: stubData() }
+		});
+
+		const form = container.querySelector('form') as HTMLFormElement;
+		const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement;
+		emailInput.value = 'alice@example.com';
+
+		form.addEventListener('submit', (e) => e.preventDefault());
+		await fireEvent.submit(form);
+
+		// disabled な input は FormData に乗らない。submit 後の FormData に email
+		// フィールドが含まれることが、本番 Auth.js が受け取れる条件。
+		const fd = new FormData(form);
+		expect(fd.get('email')).toBe('alice@example.com');
+	});
+});


### PR DESCRIPTION
## Summary

- Auth.js が「Missing email from request body」で reject していたバグ修正
- sign-in form の email input を \`disabled={submitting}\` → \`readonly={submitting}\` に変更
- 連打防止は submit button の \`disabled={submitting}\` で引き続き機能

## 原因

HTML 仕様で **\`disabled\` な input は form data から除外される**。 PR #94 (連打防止) で input + button 両方に \`disabled={submitting}\` を付けたため、submit と同時に email が POST body から消失していた。

## 修正内容

\`web/src/routes/sign-in/+page.svelte\`:

\`\`\`diff
-       disabled={submitting}
-       class=\"w-full rounded border border-input bg-background px-3 py-2 disabled:opacity-60\"
+       readonly={submitting}
+       class=\"w-full rounded border border-input bg-background px-3 py-2 read-only:opacity-60\"
\`\`\`

- \`readonly\` は **値を保持したまま編集不可** にする仕様 → form data に email が含まれる
- 視覚 (opacity-60) は \`read-only:\` variant で維持
- button 側の \`disabled={submitting}\` は維持 → 連打防止は不変

## Test plan

### Unit (vitest, jsdom)

新規 \`web/src/routes/sign-in/page.svelte.test.ts\` で 3 ケース:

- [x] submit 後の email input が \`disabled\` でないこと (regression guard)
- [x] submit 後の submit button が \`disabled\` (連打防止が壊れていない)
- [x] submit 後の FormData に \`email\` 値が含まれる (真の修正条件)

\`\`\`bash
pnpm test -- --run src/routes/sign-in/
# → 3 passed
\`\`\`

### Type check

\`\`\`bash
pnpm check
# → 0 errors
\`\`\`

### Manual

- [ ] main にマージ + CD 完了後、planner.tommykeyapp.com で実際にサインインメールが届くこと
- [ ] CloudWatch Logs で \`Missing email from request body\` エラーが消えること

fixes #109