### PR TITLE
fix(ui): dark mode の primary/accent/ring を neutral preset に揃える (fixes #110)

### DIFF
--- a/web/src/routes/layout.css
+++ b/web/src/routes/layout.css
@@ -34,18 +34,18 @@
 	--card-foreground: oklch(0.985 0 0);
 	--popover: oklch(0.205 0 0);
 	--popover-foreground: oklch(0.985 0 0);
-	--primary: oklch(0.75 0.18 55);
-	--primary-foreground: oklch(0.15 0 0);
+	--primary: oklch(0.985 0 0);
+	--primary-foreground: oklch(0.205 0 0);
 	--secondary: oklch(0.269 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.269 0 0);
 	--muted-foreground: oklch(0.708 0 0);
-	--accent: oklch(0.75 0.18 55);
-	--accent-foreground: oklch(0.15 0 0);
+	--accent: oklch(0.269 0 0);
+	--accent-foreground: oklch(0.985 0 0);
 	--destructive: oklch(0.704 0.191 22.216);
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
-	--ring: oklch(0.75 0.18 55);
+	--ring: oklch(0.556 0 0);
 }
 
 /* Tailwind v4 token として登録 (Tailwind utility 用) */


### PR DESCRIPTION
## Summary

- dark mode の \`--primary\` / \`--accent\` / \`--ring\` から鮮やかなオレンジ (\`oklch(0.75 0.18 55)\`) を撤去
- 周辺コメントが宣言する shadcn-svelte **neutral preset** に整合 → light と同じく monochrome
- light mode は触らない

## 変更

\`web/src/routes/layout.css\` の \`.dark\` ブロック:

\`\`\`diff
-       --primary: oklch(0.75 0.18 55);
-       --primary-foreground: oklch(0.15 0 0);
+       --primary: oklch(0.985 0 0);
+       --primary-foreground: oklch(0.205 0 0);
        ...
-       --accent: oklch(0.75 0.18 55);
-       --accent-foreground: oklch(0.15 0 0);
+       --accent: oklch(0.269 0 0);
+       --accent-foreground: oklch(0.985 0 0);
        ...
-       --ring: oklch(0.75 0.18 55);
+       --ring: oklch(0.556 0 0);
\`\`\`

## 影響範囲

\`--primary\` 経由で色が変わる場所:

- \`bg-primary\` を使う全 button (sign-in 送信、ホームの \"+ 人を追加\" 等)
- \`AvatarDropdown\` の trigger 円
- \`ResourceTimeline\` の Bar 帯 (\`--ui-bar-bg: var(--primary)\`)

\`--accent\` / \`--ring\` は hover / focus state で参照される。

## Test plan

### 視覚確認 (Playwright local)

- [x] \`/sign-in\` light mode — 既存と同じ (ボタン黒系)
- [x] \`/sign-in\` dark mode — ボタンが**白系** (旧: 鮮やかなオレンジ)、ring もオレンジから grey に
- [ ] CD 反映後、本番 dark mode で ResourceTimeline の Bar 帯 + AvatarDropdown 円が想定通りに見えること手動確認

### 自動テスト

- [x] \`pnpm test\` — 109 passed (CSS 変更のみ、test 影響なし)
- [x] \`pnpm check\` — 0 errors

## スクリーンショット

dark mode (before): \`bg-primary\` が **鮮やかなオレンジ**
dark mode (after): \`bg-primary\` が **near-white** で text が dark grey → 読みやすさ向上

fixes #110