### PR TITLE
ci(test-e2e): `if: false` ガード解除 + DDB Local + env wiring (fixes #112)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,12 +115,29 @@ jobs:
         run: pnpm test
         working-directory: web
 
-  # Playwright E2E。Phase 3 (Auth.js + Magic Link) 完了まで disable する。
-  # 有効化条件: web/e2e/ に sign-in fixture + 実 spec が揃った時点で `if: false` を外す。
-  # 詳細: ADR 0007 / issue #77
+  # Playwright E2E (#112)。Phase 3 (Auth.js + Magic Link) 完了済 → 未認証 smoke 段階で有効化。
+  # Magic Link 経由の sign-in fixture / 認証済 spec は #113 で別途追加予定。
+  # 詳細: ADR 0007
   test-e2e:
-    if: false
     runs-on: ubuntu-latest
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:latest
+        ports: ['8000:8000']
+        # NOTE: test job と同じく、image にシェルが無く services.options で health-cmd を渡せない。
+        # 後続ステップで wait ループする。
+    env:
+      AWS_ENDPOINT_URL: http://localhost:8000
+      AWS_REGION: ap-northeast-1
+      AWS_DEFAULT_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: local
+      AWS_SECRET_ACCESS_KEY: local
+      DYNAMODB_TABLE: resource-planner
+      # Auth.js を初期化するためのダミー値 (signin そのものはこの job では行わない)
+      AUTH_SECRET: e2e-secret-not-for-production-padding-padding-padding
+      AUTH_TRUST_HOST: 'true'
+      ALLOWED_DOMAIN: example.com
+      EMAIL_FROM: noreply@example.com
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -138,12 +155,57 @@ jobs:
         working-directory: web
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for DynamoDB Local
+        run: |
+          for i in {1..30}; do
+            curl -s http://localhost:8000 > /dev/null && exit 0
+            sleep 1
+          done
+          echo "DynamoDB Local did not start within 30s"
+          exit 1
+
+      # NOTE: 同じ create-table 定義が以下にもある (GSI1 も含めて全箇所同期):
+      #   - Makefile の db ターゲット
+      #   - .github/workflows/db-docs.yaml の Create table ステップ
+      #   - .github/workflows/ci.yaml の test ジョブ
+      # いずれかを変更したら必ず全箇所を同期すること。
+      - name: Create table
+        run: |
+          aws dynamodb create-table \
+            --table-name resource-planner \
+            --attribute-definitions \
+              AttributeName=pk,AttributeType=S \
+              AttributeName=sk,AttributeType=S \
+              AttributeName=GSI1PK,AttributeType=S \
+              AttributeName=GSI1SK,AttributeType=S \
+            --key-schema \
+              AttributeName=pk,KeyType=HASH \
+              AttributeName=sk,KeyType=RANGE \
+            --global-secondary-indexes \
+              'IndexName=GSI1,KeySchema=[{AttributeName=GSI1PK,KeyType=HASH},{AttributeName=GSI1SK,KeyType=RANGE}],Projection={ProjectionType=ALL}' \
+            --billing-mode PAY_PER_REQUEST \
+            --endpoint-url http://localhost:8000
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
         working-directory: web
+
+      - name: Build
+        run: pnpm build
+        working-directory: web
+
       - name: Run E2E tests
         run: pnpm test:e2e
         working-directory: web
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 7
 
   terraform-plan:
     runs-on: ubuntu-latest

--- a/docs/adr/0007-tdd-with-vitest-and-playwright.md
+++ b/docs/adr/0007-tdd-with-vitest-and-playwright.md
@@ -40,13 +40,16 @@ resource-planner はこれまで「動くコードを書いて手動で確認」
 - `pnpm test` — `vitest run` (CI / 一回実行)
 - `pnpm test:watch` — `vitest` (開発時の watch モード)
 - `pnpm test:coverage` — `vitest run --coverage`
-- `pnpm test:e2e` — `playwright test` (PR-T5 で導入、Phase 3 完了まで CI は disable)
+- `pnpm test:e2e` — `playwright test` (PR-T5 で導入、Phase 3 完了後 #112 で CI 有効化、未認証 smoke 段階)
 
 **Playwright 設定**:
 - `web/playwright.config.ts`: ローカル = Chromium / Firefox / WebKit、CI = Chromium のみ
 - `webServer` で `pnpm preview` を auto-start、port 4173
 - spec は `web/e2e/**/*.spec.ts`、結果は `test-results/` (.gitignore 済)
 - 実 sign-in fixture が必要なため、本格的な spec は **PR-A3 (Magic Link 移行)** 以降に書く
+- 履歴: PR-T5 (#77) では Phase 3 未完で `if: false` で disable、PR #109 / #110 を経て Phase 3
+  完了済となり #112 で test-e2e job を再有効化 (DDB Local + AUTH env stubs、未認証 smoke のみ)。
+  Magic Link sign-in fixture + 認証済 spec は #113 で扱う
 
 **起票プロセスへの反映**:
 - `.github/ISSUE_TEMPLATE/feature.yml` の AC に「unit test」「integration test (該当時)」「E2E

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,14 +1,20 @@
 import { expect, test } from '@playwright/test';
 
 /**
- * 最小 smoke spec。Phase 3 (Auth.js + Magic Link) 完了後に sign-in / CRUD spec を追加する前の土台。
+ * 最小 smoke spec (#112)。未認証で `/` にアクセスすると `/sign-in` にリダイレクトされることを
+ * 検証する。Auth.js + DDB が初期化済、redirect logic が正常動作している、の 2 点を CI で守る。
  *
- * 本テストは未認証アクセスの想定挙動 (sign-in リダイレクト or 認証画面表示) を確認するのみ。
- * 認証 fixture が必要な spec は PR-A3 以降で追加。
+ * Magic Link 経由の sign-in fixture / 認証済 spec は #113 で別途追加。
  */
-test('home page responds (any 2xx/3xx) — minimal smoke', async ({ page }) => {
+test('unauthenticated access to / redirects to /sign-in', async ({ page }) => {
 	const response = await page.goto('/');
 	expect(response).not.toBeNull();
-	const status = response!.status();
-	expect(status).toBeLessThan(400);
+	expect(response!.status()).toBeLessThan(400);
+	await expect(page).toHaveURL(/\/sign-in($|\?)/);
+});
+
+test('/sign-in renders the email sign-in form', async ({ page }) => {
+	await page.goto('/sign-in');
+	await expect(page.locator('input[name="email"]')).toBeVisible();
+	await expect(page.locator('button[type="submit"]')).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- \`test-e2e\` job の \`if: false\` を削除し、CI で smoke spec を実行
- \`test\` job と同じパターンで DynamoDB Local service + wait + create-table を追加
- Auth.js 初期化用 env (\`AUTH_SECRET\` / \`AUTH_TRUST_HOST\` / \`ALLOWED_DOMAIN\` / \`EMAIL_FROM\`) を dummy 値で wire
- smoke spec を強化: 未認証で \`/\` → \`/sign-in\` redirect、\`/sign-in\` の form 表示を assertion
- 失敗時の Playwright report を artifact として upload
- ADR 0007 に経緯を追記

## 範囲外 (別 issue)

- Magic Link 経由の sign-in fixture + 認証済 spec → **#113**

## Test plan

### ローカル

\`\`\`bash
# DDB Local 起動済、.env.local に dummy AUTH_SECRET 等を設定
cd web
pnpm build
CI=1 pnpm test:e2e
# → 2 passed (2.8s)
\`\`\`

- [x] \`unauthenticated access to / redirects to /sign-in\` 緑
- [x] \`/sign-in renders the email sign-in form\` 緑

### CI

- [ ] 本 PR の CI で \`test-e2e\` job が走り、緑になる
- [ ] わざと smoke を壊すと test-e2e が赤になる (regression guard 動作確認)

### Branch protection

- [ ] **必須 check には未追加** で merge 可能 (まずは observe フェーズ)。安定化後に必須化を判断

fixes #112