### PR TITLE
test(e2e): Magic Link sign-in fixture + sign-in flow spec (fixes #113)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,11 +133,14 @@ jobs:
       AWS_ACCESS_KEY_ID: local
       AWS_SECRET_ACCESS_KEY: local
       DYNAMODB_TABLE: resource-planner
-      # Auth.js を初期化するためのダミー値 (signin そのものはこの job では行わない)
+      # Auth.js を初期化するためのダミー値
       AUTH_SECRET: e2e-secret-not-for-production-padding-padding-padding
       AUTH_TRUST_HOST: 'true'
       ALLOWED_DOMAIN: example.com
       EMAIL_FROM: noreply@example.com
+      # #113: dev sendVerificationRequest が magic link URL を書き出すファイル。
+      # Playwright fixture がここから URL を取り出して sign-in flow を走らせる。
+      AUTH_TEST_MAGIC_LINK_FILE: /tmp/playwright-magic-links.txt
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4

--- a/web/e2e/fixtures/magic-link.ts
+++ b/web/e2e/fixtures/magic-link.ts
@@ -1,0 +1,38 @@
+import { promises as fs } from 'node:fs';
+
+/**
+ * E2E fixture: dev sendVerificationRequest が `AUTH_TEST_MAGIC_LINK_FILE` に append した
+ * tab 区切り `{email}\t{url}` ログから、対象 email の最新 URL を取り出す (#113)。
+ *
+ * Auth.js は token を hash 化して DDB に保存するため、URL の平文 token は送信側でしか取得できない。
+ * fixture から POST → check-email 遷移 → file polling → URL 取得 → goto、という flow で
+ * sign-in 完了させる。
+ */
+export const MAGIC_LINK_FILE = process.env.AUTH_TEST_MAGIC_LINK_FILE!;
+
+if (!MAGIC_LINK_FILE) {
+	throw new Error(
+		'AUTH_TEST_MAGIC_LINK_FILE env must be set. playwright.config.ts で設定済のはずです。'
+	);
+}
+
+export async function clearMagicLinks(): Promise<void> {
+	await fs.writeFile(MAGIC_LINK_FILE, '');
+}
+
+/**
+ * 指定 email の最新 magic link URL を返す。preview server が token を書くまで poll で待つ。
+ */
+export async function getMagicLinkUrl(email: string, timeoutMs = 5000): Promise<string> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		const content = await fs.readFile(MAGIC_LINK_FILE, 'utf-8').catch(() => '');
+		const lines = content.split('\n').filter(Boolean);
+		for (let i = lines.length - 1; i >= 0; i--) {
+			const [id, url] = lines[i].split('\t');
+			if (id === email && url) return url;
+		}
+		await new Promise((r) => setTimeout(r, 100));
+	}
+	throw new Error(`Magic link for ${email} not captured within ${timeoutMs}ms`);
+}

--- a/web/e2e/sign-in.spec.ts
+++ b/web/e2e/sign-in.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+import { clearMagicLinks, getMagicLinkUrl } from './fixtures/magic-link';
+
+/**
+ * #113: Magic Link sign-in の E2E。 #109 (sign-in email input が disabled で form data
+ * から消失) の真の regression guard を兼ねる — もし input が disabled に戻ったら
+ * Auth.js は email を受け取れず token を作らないので、本 spec は magic link 取得
+ * (file polling timeout) で必ず赤になる。
+ *
+ * test 間で session / token の共用は避けたいので serial 実行。
+ */
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async () => {
+	await clearMagicLinks();
+});
+
+test('Magic Link sign-in completes the flow and lands on home (regression for #109)', async ({
+	page
+}) => {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'allowed@example.com');
+	await page.click('button[type="submit"]');
+	await expect(page).toHaveURL(/\/sign-in\/check-email/);
+
+	const url = await getMagicLinkUrl('allowed@example.com');
+	await page.goto(url);
+	await expect(page).toHaveURL('/');
+});
+
+test('Disallowed domain is rejected at submit before any email is sent', async ({ page }) => {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'evil@other.example');
+	await page.click('button[type="submit"]');
+	// Auth.js は signIn callback で domain チェック → 拒否時は token 発行 / 送信を行わずに error 画面へ
+	await expect(page).toHaveURL(/\/sign-in\/error\?error=AccessDenied/);
+
+	// 拒否されているので magic link は1件も captured されていないはず (漏洩無し)
+	await expect(getMagicLinkUrl('evil@other.example', 500)).rejects.toThrow(/not captured/);
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,15 +1,20 @@
 import { defineConfig, devices } from '@playwright/test';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 /**
  * Playwright E2E test configuration.
  *
  * **位置づけ**: Auth.js 移行後 (PR-A3 以降) に Magic Link sign-in → CRUD のフルパス E2E を書く土台。
- * 本 PR (PR-T5) ではホーム画面の smoke 1 件のみ。
+ * 本 PR (PR-T5) ではホーム画面の smoke、#113 で Magic Link sign-in spec を追加。
  *
  * - 既定では preview build (`pnpm build && pnpm preview`) を Playwright が起動
  * - CI は Chromium のみ (コスト削減)、ローカルは 3 ブラウザ並行
- * - storageState は Phase 3 で sign-in fixture を作るときに利用 (現状は authless smoke のみ)
+ * - dev sendVerificationRequest が URL を書き出す `AUTH_TEST_MAGIC_LINK_FILE` を preview server に
+ *   渡すため、ここで process.env に注入する (webServer.env は process.env を引き継がない仕様のため)。
  */
+process.env.AUTH_TEST_MAGIC_LINK_FILE ??= join(tmpdir(), 'playwright-magic-links.txt');
+
 export default defineConfig({
 	testDir: 'e2e',
 	fullyParallel: true,

--- a/web/src/auth.test.ts
+++ b/web/src/auth.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { isDomainAllowed } from './auth';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isDomainAllowed, sendMagicLinkDev } from './auth';
 
 describe('isDomainAllowed', () => {
 	it('returns true when email ends with @{allowed}', () => {
@@ -40,5 +43,55 @@ describe('isDomainAllowed', () => {
 
 	it('returns false on email without @', () => {
 		expect(isDomainAllowed('not-an-email', 'example.com')).toBe(false);
+	});
+});
+
+/**
+ * #113: Playwright fixture が magic link URL を取り出せるよう、dev sendVerificationRequest が
+ * env.AUTH_TEST_MAGIC_LINK_FILE 指定時にファイルへ append することを保証する unit test。
+ * Auth.js が token を hash 化して DDB に保存するため、URL の生成側でしか平文 token は触れない。
+ */
+describe('sendMagicLinkDev (#113)', () => {
+	let originalEnvFile: string | undefined;
+	let tmpFile: string;
+
+	beforeEach(() => {
+		originalEnvFile = process.env.AUTH_TEST_MAGIC_LINK_FILE;
+		tmpFile = join(tmpdir(), `auth-magic-link-test-${Date.now()}-${Math.random()}.txt`);
+	});
+
+	afterEach(async () => {
+		if (originalEnvFile === undefined) {
+			delete process.env.AUTH_TEST_MAGIC_LINK_FILE;
+		} else {
+			process.env.AUTH_TEST_MAGIC_LINK_FILE = originalEnvFile;
+		}
+		await fs.unlink(tmpFile).catch(() => {});
+	});
+
+	it('appends "{email}\\t{url}\\n" to AUTH_TEST_MAGIC_LINK_FILE when set', async () => {
+		process.env.AUTH_TEST_MAGIC_LINK_FILE = tmpFile;
+		await sendMagicLinkDev({
+			identifier: 'alice@example.com',
+			url: 'http://localhost:4173/auth/callback/nodemailer?token=abc&email=alice%40example.com'
+		});
+		const content = await fs.readFile(tmpFile, 'utf-8');
+		expect(content).toBe(
+			'alice@example.com\thttp://localhost:4173/auth/callback/nodemailer?token=abc&email=alice%40example.com\n'
+		);
+	});
+
+	it('appends a new line per call (multiple sign-in attempts)', async () => {
+		process.env.AUTH_TEST_MAGIC_LINK_FILE = tmpFile;
+		await sendMagicLinkDev({ identifier: 'a@example.com', url: 'http://x/1' });
+		await sendMagicLinkDev({ identifier: 'b@example.com', url: 'http://x/2' });
+		const content = await fs.readFile(tmpFile, 'utf-8');
+		expect(content).toBe('a@example.com\thttp://x/1\nb@example.com\thttp://x/2\n');
+	});
+
+	it('does not touch the filesystem when AUTH_TEST_MAGIC_LINK_FILE is unset', async () => {
+		delete process.env.AUTH_TEST_MAGIC_LINK_FILE;
+		await sendMagicLinkDev({ identifier: 'alice@example.com', url: 'http://x/y' });
+		await expect(fs.access(tmpFile)).rejects.toThrow();
 	});
 });

--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -15,6 +15,7 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
 import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
+import { promises as fs } from 'node:fs';
 import { env } from '$env/dynamic/private';
 import { addMembership, DEFAULT_TEAM_ID, getOrCreateDefaultTeam } from '$lib/repository/team';
 
@@ -90,6 +91,29 @@ async function sendMagicLinkViaSES(params: { identifier: string; url: string }):
 	);
 }
 
+/**
+ * dev / test 用 sendVerificationRequest。
+ *
+ * デフォルトは console.log で開発時に URL を出すだけ。E2E test 時は
+ * `AUTH_TEST_MAGIC_LINK_FILE` を設定すると URL を tab 区切りでファイルへ append し、
+ * Playwright fixture が読み取って magic link を踏めるようにする (#113)。
+ * Auth.js は token を hash 化して DDB に保存するため、URL は送信側でしか平文を得られない。
+ */
+export async function sendMagicLinkDev(params: {
+	identifier: string;
+	url: string;
+}): Promise<void> {
+	// eslint-disable-next-line no-console
+	console.log(
+		`\n[Magic Link DEV] to=${params.identifier}\n  ${params.url}\n  (production は SES SDK で送信)\n`
+	);
+	// dev/test 専用 env のため SvelteKit $env (module load 時 snapshot) ではなく process.env を都度参照
+	const file = process.env.AUTH_TEST_MAGIC_LINK_FILE;
+	if (file) {
+		await fs.appendFile(file, `${params.identifier}\t${params.url}\n`);
+	}
+}
+
 export const { handle, signIn, signOut } = SvelteKitAuth({
 	secret: resolvedAuthSecret,
 	adapter: DynamoDBAdapter(adapterClient, {
@@ -101,14 +125,7 @@ export const { handle, signIn, signOut } = SvelteKitAuth({
 			// Auth.js が provider 初期化時に server 値を要求するため dummy を渡す。
 			server: env.EMAIL_SERVER ?? 'smtp://placeholder:25',
 			from: env.EMAIL_FROM ?? 'noreply@example.com',
-			sendVerificationRequest: isProductionTransport
-				? sendMagicLinkViaSES
-				: async ({ identifier, url }) => {
-						// eslint-disable-next-line no-console
-						console.log(
-							`\n[Magic Link DEV] to=${identifier}\n  ${url}\n  (production は SES SDK で送信)\n`
-						);
-					}
+			sendVerificationRequest: isProductionTransport ? sendMagicLinkViaSES : sendMagicLinkDev
 		})
 	],
 	pages: {


### PR DESCRIPTION
## Summary

- Magic Link 経由の sign-in を E2E で動かす fixture + spec を追加
- #109 (email input disabled) の **真の regression guard** を兼ねる (input が再 disabled 化されたら token 発行されず magic link 取得タイムアウトで赤)

## Approach

Auth.js DDB adapter は token を hash 化して保存するため、URL 平文は **送信側でしか触れない**。よって:

1. \`auth.ts\` の dev \`sendVerificationRequest\` を \`sendMagicLinkDev\` として named export
2. \`AUTH_TEST_MAGIC_LINK_FILE\` env が set されているとき、URL を tab 区切りでファイル append
3. Playwright fixture が同ファイルを poll で読み取って email → URL を解決

production パス (\`sendMagicLinkViaSES\`) はノータッチ。

## 変更

- \`web/src/auth.ts\` — \`sendMagicLinkDev\` 抽出 + ファイル append
- \`web/src/auth.test.ts\` — \`sendMagicLinkDev\` 3 ケース (env set → write、累積、env unset → no write)
- \`web/e2e/fixtures/magic-link.ts\` — \`clearMagicLinks\` / \`getMagicLinkUrl\`
- \`web/e2e/sign-in.spec.ts\` — 2 ケース:
  - **Magic Link sign-in が \`/\` に着地** (#109 regression guard 兼用)
  - **Disallowed domain は signIn callback で email 送信前に rejection** (情報漏洩無しを確認)
- \`web/playwright.config.ts\` — preview server に渡す \`AUTH_TEST_MAGIC_LINK_FILE\` を process.env で wire
- \`.github/workflows/ci.yaml\` — test-e2e job に同 env 追加

## Test plan

ローカル:

\`\`\`bash
cd web && pnpm build
CI=1 pnpm test:e2e
# → 4 passed (smoke 2 + sign-in 2)
\`\`\`

- [x] Magic Link sign-in が \`/\` 到達
- [x] Disallowed domain で \`/sign-in/error?error=AccessDenied\`、magic link 一切 captured されない
- [x] unit test 112 passed (sendMagicLinkDev 3 件追加 + 既存維持)

CI:

- [ ] test-e2e job で 4 spec 緑

## 既知の問題 (本 PR 範囲外)

- \`pnpm check\` がローカルで \`auth.ts:45\` に型エラー (\`resolvedAuthSecret\` への \`string | undefined\` 代入)。**main にも同じ状態**で CI build-web は通っている mystery、別途調査要

## #109 regression guard

\`web/src/routes/sign-in/+page.svelte\` の \`readonly={submitting}\` を \`disabled={submitting}\` に巻き戻すと、Magic Link sign-in spec が \`Magic link for allowed@example.com not captured\` で赤になる (= POST body に email が乗らないため token 作成されない)。手動で検証済。

fixes #113