### PR TITLE
fix(a11y/polish): /sign-in/error alignment + check-email guard + focus ring 統一 (fixes #101)

### DIFF
--- a/web/e2e/sign-in.spec.ts
+++ b/web/e2e/sign-in.spec.ts
@@ -28,6 +28,14 @@ test('Magic Link sign-in completes the flow and lands on home (regression for #1
 	await expect(page).toHaveURL('/');
 });
 
+test('Direct navigation to /sign-in/check-email redirects to /sign-in (#101 guard)', async ({
+	page
+}) => {
+	// 初回直接アクセス: sec-fetch-site: none → /sign-in に redirect
+	await page.goto('/sign-in/check-email');
+	await expect(page).toHaveURL(/\/sign-in($|\?)/);
+});
+
 test('Disallowed domain is rejected at submit before any email is sent', async ({ page }) => {
 	await page.goto('/sign-in');
 	await page.fill('input[name="email"]', 'evil@other.example');

--- a/web/src/lib/components/LocaleSwitcher.svelte
+++ b/web/src/lib/components/LocaleSwitcher.svelte
@@ -13,7 +13,7 @@
 	onclick={cycle}
 	aria-label={t('locale.label')}
 	title={t('locale.label')}
-	class="inline-flex h-9 shrink-0 items-center justify-center gap-1 rounded-md border border-border bg-background px-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+	class="inline-flex h-9 shrink-0 items-center justify-center gap-1 rounded-md border border-border bg-background px-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
 >
 	<Translate size={18} weight="regular" aria-hidden="true" />
 	<span class="text-xs">{localeState.current === 'ja' ? 'JA' : 'EN'}</span>

--- a/web/src/lib/components/LocaleSwitcher.svelte.test.ts
+++ b/web/src/lib/components/LocaleSwitcher.svelte.test.ts
@@ -29,4 +29,11 @@ describe('LocaleSwitcher (smoke)', () => {
 		const label = btn.getAttribute('aria-label') ?? '';
 		expect(label.toLowerCase()).toMatch(/language|言語/);
 	});
+
+	it('has focus-visible ring classes consistent with shadcn Button (#101 item 5)', () => {
+		const { getByRole } = render(LocaleSwitcher);
+		const btn = getByRole('button');
+		const cls = btn.className;
+		expect(cls).toMatch(/focus-visible:ring/);
+	});
 });

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -31,7 +31,7 @@
 	onclick={cycle}
 	aria-label={label}
 	title={label}
-	class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background transition-colors hover:bg-accent hover:text-accent-foreground"
+	class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
 >
 	{#if userPrefersMode.current === 'light'}
 		<Sun size={18} weight="regular" aria-hidden="true" />

--- a/web/src/lib/components/ThemeToggle.svelte.test.ts
+++ b/web/src/lib/components/ThemeToggle.svelte.test.ts
@@ -24,4 +24,10 @@ describe('ThemeToggle (smoke)', () => {
 		const icon = btn.querySelector('svg[aria-hidden="true"]');
 		expect(icon).toBeTruthy();
 	});
+
+	it('has focus-visible ring classes consistent with shadcn Button (#101 item 5)', () => {
+		const { getByRole } = render(ThemeToggle);
+		const btn = getByRole('button');
+		expect(btn.className).toMatch(/focus-visible:ring/);
+	});
 });

--- a/web/src/routes/sign-in/+page.svelte
+++ b/web/src/routes/sign-in/+page.svelte
@@ -48,7 +48,7 @@
 		<button
 			type="submit"
 			disabled={submitting}
-			class="w-full rounded bg-primary px-4 py-2 text-primary-foreground disabled:opacity-60"
+			class="w-full rounded bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none disabled:opacity-60"
 		>
 			{submitting ? t('signin.submitting') : t('signin.submit')}
 		</button>

--- a/web/src/routes/sign-in/check-email/+page.server.ts
+++ b/web/src/routes/sign-in/check-email/+page.server.ts
@@ -1,0 +1,18 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+/**
+ * #101 item 4: 直接 navigate / ブックマークでの到達を防ぐ guard。
+ *
+ * `sec-fetch-site` ヘッダ (Chrome / FF / Safari 16.4+) で navigation 種別を判定:
+ *   - 'none'                       : direct entry / bookmark → /sign-in に redirect
+ *   - 'same-origin' / 'same-site'  : in-app navigation → 通す
+ *   - 欠落                         : 古い browser → fail-open で通す (過剰防御を避ける)
+ */
+export const load: PageServerLoad = async ({ request }) => {
+	const fetchSite = request.headers.get('sec-fetch-site');
+	if (fetchSite === 'none') {
+		redirect(303, '/sign-in');
+	}
+	return {};
+};

--- a/web/src/routes/sign-in/check-email/page.server.test.ts
+++ b/web/src/routes/sign-in/check-email/page.server.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { load } from './+page.server';
+
+/**
+ * #101 item 4: `/sign-in/check-email` をブックマーク等で直接 navigate されたら
+ * `/sign-in` に redirect する。`sec-fetch-site` ヘッダ (Chrome/FF/Safari16+) で判定:
+ *   - 'none'       : direct entry / bookmark → redirect
+ *   - 'same-origin' / 'same-site' : 同一サイト経由 → 通す
+ *   - 欠落         : 古い browser、識別不能 → 通す (fail-open、過剰防御を避ける)
+ */
+function makeEvent(headers: Record<string, string> = {}) {
+	const h = new Headers(headers);
+	return {
+		request: { headers: h } as unknown as Request
+	} as Parameters<typeof load>[0];
+}
+
+describe('check-email load — direct navigation guard (#101)', () => {
+	it('redirects to /sign-in when sec-fetch-site is "none" (direct entry / bookmark)', async () => {
+		await expect(load(makeEvent({ 'sec-fetch-site': 'none' }))).rejects.toMatchObject({
+			status: 303,
+			location: '/sign-in'
+		});
+	});
+
+	it('allows same-origin navigation (Auth.js redirect or in-app link)', async () => {
+		const result = await load(makeEvent({ 'sec-fetch-site': 'same-origin' }));
+		expect(result).toEqual({});
+	});
+
+	it('allows same-site navigation', async () => {
+		const result = await load(makeEvent({ 'sec-fetch-site': 'same-site' }));
+		expect(result).toEqual({});
+	});
+
+	it('allows requests with no sec-fetch-site header (older browsers — fail-open)', async () => {
+		const result = await load(makeEvent({}));
+		expect(result).toEqual({});
+	});
+});

--- a/web/src/routes/sign-in/error/+page.svelte
+++ b/web/src/routes/sign-in/error/+page.svelte
@@ -22,16 +22,25 @@
 	<title>{t('signin.errorTitle')} — {t('app.title')}</title>
 </svelte:head>
 
-<main class="container mx-auto max-w-md px-4 py-12">
-	<h1 class="mb-2 text-2xl font-bold">{t('signin.errorTitle')}</h1>
-	<p class="mb-4 rounded border-l-4 border-destructive bg-destructive/10 p-4 text-sm">
-		{message}
-	</p>
-	<p class="text-xs text-muted-foreground">{t('signin.errorCode', { code: errorCode })}</p>
+<!--
+	#101 item 2: 404 (`+error.svelte`) と同じ centered-card レイアウトに揃える。
+	min-h-screen + flex 中央配置 + max-w カード で alignment を統一。
+-->
+<main class="flex min-h-screen items-center justify-center bg-background px-4 py-12">
+	<div class="w-full max-w-md rounded border border-border bg-card p-8 text-center">
+		<h1 class="mb-2 text-2xl font-bold text-destructive">{t('signin.errorTitle')}</h1>
+		<p class="mb-4 rounded border-l-4 border-destructive bg-destructive/10 p-4 text-left text-sm">
+			{message}
+		</p>
+		<p class="text-xs text-muted-foreground">{t('signin.errorCode', { code: errorCode })}</p>
 
-	<div class="mt-6">
-		<a href="/sign-in" class="inline-block rounded bg-primary px-4 py-2 text-primary-foreground">
-			{t('signin.backToSignin')}
-		</a>
+		<div class="mt-6">
+			<a
+				href="/sign-in"
+				class="inline-block rounded bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
+			>
+				{t('signin.backToSignin')}
+			</a>
+		</div>
 	</div>
 </main>

--- a/web/src/routes/sign-in/error/page.svelte.test.ts
+++ b/web/src/routes/sign-in/error/page.svelte.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import ErrorPage from './+page.svelte';
+
+/**
+ * #101 item 2: /sign-in/error を `+error.svelte` と同じ centered-card 構造に揃える。
+ *
+ * 404 / +error.svelte は `<main>` を `min-h-screen` + flex centered + `.card` で構成済。
+ * /sign-in/error も同じパターンに揃え、視覚的不整合を解消する。
+ */
+describe('/sign-in/error +page.svelte — centered card layout (#101)', () => {
+	it('renders main element with min-height: 100vh wrapper for vertical centering', () => {
+		const { container } = render(ErrorPage);
+		const main = container.querySelector('main');
+		expect(main).toBeTruthy();
+		// Tailwind `min-h-screen` (= min-height: 100vh) を含む
+		expect(main!.className).toMatch(/min-h-screen/);
+	});
+
+	it('places content inside a flex-centered layout (matches +error.svelte alignment)', () => {
+		const { container } = render(ErrorPage);
+		const main = container.querySelector('main');
+		expect(main!.className).toMatch(/flex/);
+		expect(main!.className).toMatch(/items-center/);
+		expect(main!.className).toMatch(/justify-center/);
+	});
+
+	it('renders the error code paragraph and back-to-signin link', () => {
+		const { getByRole, getByText } = render(ErrorPage);
+		// errorCode 表記が出る (i18n の signin.errorCode)
+		expect(getByText(/エラーコード/)).toBeTruthy();
+		const link = getByRole('link', { name: /サインインに戻る/ });
+		expect(link.getAttribute('href')).toBe('/sign-in');
+	});
+});

--- a/web/src/routes/sign-in/page.svelte.test.ts
+++ b/web/src/routes/sign-in/page.svelte.test.ts
@@ -69,4 +69,12 @@ describe('sign-in +page.svelte — email input must remain in form data on submi
 		const fd = new FormData(form);
 		expect(fd.get('email')).toBe('alice@example.com');
 	});
+
+	it('submit button has focus-visible ring classes consistent with shadcn Button (#101 item 5)', () => {
+		const { container } = render(SignInPage, {
+			props: { data: stubData() }
+		});
+		const submitBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+		expect(submitBtn.className).toMatch(/focus-visible:ring/);
+	});
 });


### PR DESCRIPTION
## Summary

#101 a11y/polish bundle のうち、本 PR で **item 2 / 4 / 5** を解消:

- **item 2** \`/sign-in/error\` を \`+error.svelte\` と同じ centered-card レイアウトに揃える
- **item 4** \`/sign-in/check-email\` を直接 navigate / ブックマークで開いた時は \`/sign-in\` に redirect (\`sec-fetch-site: none\` 判定)
- **item 5** LocaleSwitcher / ThemeToggle / sign-in submit button に shadcn Button と同じ \`focus-visible:ring-1 focus-visible:ring-ring/50\` を追加

それぞれ TDD で先に test を書き、実装で緑にする手順。

## #101 全体の進捗

| Sub-item | Status | 担当 |
|---|---|---|
| 1. resize separator touch target 44×44 | ⏭ 別 repo へ deferred | [tommykey-apps/ui-components#20](https://github.com/tommykey-apps/ui-components/issues/20) |
| 2. /sign-in/error layout 統一 | ✅ 本 PR |
| 3. signout aria-label | ✅ 既存 (PR #103 + #108) |
| 4. check-email 直接 navigate guard | ✅ 本 PR |
| 5. focus ring inconsistency | ✅ 本 PR |
| 6. color swatch aria-hidden | ✅ 既存 (main で対応済) |

→ 残 1 件 (item 1) は ui-components#20 で扱う。本 issue 自体は close 可能。

## Test plan

### Unit (vitest)

- [x] check-email guard 4 ケース (\`none\` redirect / \`same-origin\` allow / \`same-site\` allow / 欠落 allow)
- [x] /sign-in/error が \`min-h-screen items-center justify-center max-w-md\` を含む + back link が \`/sign-in\` 指す
- [x] LocaleSwitcher / ThemeToggle / sign-in submit に \`focus-visible:ring\` クラスが含まれる
- [x] 計 122 passed

### E2E (Playwright, CI=1 chromium)

- [x] 既存 4 spec + 新規「直接 navigate /sign-in/check-email → /sign-in redirect」追加
- [x] 5 passed (4.5s)

### Manual (curl)

\`\`\`bash
curl -sI -H 'sec-fetch-site: none' http://localhost:5173/sign-in/check-email
# → HTTP/1.1 303 See Other / location: /sign-in

curl -sI -H 'sec-fetch-site: same-origin' http://localhost:5173/sign-in/check-email
# → HTTP/1.1 200 OK
\`\`\`

\`/sign-in/error\` のレンダリングは tests + クラス含有 grep で確認 (Playwright MCP がローカル不調のためビジュアル比較は割愛)。

## 余話

- 本 PR の check-email guard は **cookie/session ではなく \`sec-fetch-site\` ヘッダ** を採用。Chrome / FF / Safari 16.4+ で送信される標準ヘッダで、bookmark / direct entry を 'none' で識別できる。古い browser は fail-open。
- focus-visible ring を追加した raw button は **キーボード Tab で focus した時のみ** ring 表示。マウス click 時の余計な ring 表示は出ない (\`focus\` ではなく \`focus-visible\` を使用)。

fixes #101