### PR TITLE
feat(assignment): AssignmentManager に編集機能を追加 (#99 item 1)

### DIFF
--- a/web/src/lib/components/AssignmentManager.svelte
+++ b/web/src/lib/components/AssignmentManager.svelte
@@ -37,9 +37,52 @@
 		return addDays(a.endDateExclusive, -1);
 	}
 
+	// 編集 dialog (#99 item 1)。Resource / Project と一貫した CRUD パターンに揃える。
+	let editOpen = $state(false);
+	let editing = $state<Assignment | null>(null);
+	let formResourceId = $state('');
+	let formProjectId = $state('');
+	let formStartDate = $state('');
+	let formEndDate = $state(''); // inclusive 表示
+	let formError = $state<{
+		resourceId?: string;
+		projectId?: string;
+		startDate?: string;
+		endDate?: string;
+	} | null>(null);
+
+	function startEdit(a: Assignment) {
+		editing = a;
+		formResourceId = a.resourceId;
+		formProjectId = a.projectId;
+		formStartDate = a.startDate;
+		formEndDate = displayEndDate(a);
+		formError = null;
+		editOpen = true;
+	}
+
 	// 連打抑制 + submitting state (#94)
 	const deleteSubmitState = createSubmitState();
 	const deleteSubmit: SubmitFunction = deleteSubmitState.wrap();
+	const editSubmitState = createSubmitState();
+	const editSubmit: SubmitFunction = editSubmitState.wrap(() => {
+		formError = null;
+		return async ({ result, update }) => {
+			if (result.type === 'success') {
+				editOpen = false;
+				editing = null;
+			} else if (result.type === 'failure') {
+				const errs = (result.data as { errors?: Record<string, string> })?.errors;
+				formError = {
+					resourceId: errs?.resourceId,
+					projectId: errs?.projectId,
+					startDate: errs?.startDate,
+					endDate: errs?.endDate
+				};
+			}
+			await update();
+		};
+	});
 </script>
 
 <Button variant="outline" onclick={() => (open = true)}>
@@ -80,31 +123,139 @@
 								</span>
 							</div>
 						</div>
-						<form
-							method="POST"
-							action="?/deleteAssignment"
-							use:enhance={deleteSubmit}
-							onsubmit={(e) => {
-								const label = `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`;
-								if (!confirm(t('assignments.confirmDelete', { label }))) {
-									e.preventDefault();
-								}
-							}}
-						>
-							<input type="hidden" name="id" value={a.id} />
-							<input type="hidden" name="startDate" value={a.startDate} />
-							<Button
-								size="xs"
-								variant="destructive"
-								type="submit"
-								disabled={deleteSubmitState.submitting}
-							>
-								{t('common.delete')}
+						<div class="flex gap-1">
+							<Button size="xs" variant="outline" onclick={() => startEdit(a)}>
+								{t('common.edit')}
 							</Button>
-						</form>
+							<form
+								method="POST"
+								action="?/deleteAssignment"
+								use:enhance={deleteSubmit}
+								onsubmit={(e) => {
+									const label = `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`;
+									if (!confirm(t('assignments.confirmDelete', { label }))) {
+										e.preventDefault();
+									}
+								}}
+							>
+								<input type="hidden" name="id" value={a.id} />
+								<input type="hidden" name="startDate" value={a.startDate} />
+								<Button
+									size="xs"
+									variant="destructive"
+									type="submit"
+									disabled={deleteSubmitState.submitting}
+								>
+									{t('common.delete')}
+								</Button>
+							</form>
+						</div>
 					</li>
 				{/each}
 			</ul>
 		{/if}
 	</div>
+</Dialog>
+
+<Dialog
+	bind:open={editOpen}
+	title={t('assignments.editTitle')}
+	description={t('assignments.description')}
+>
+	<form
+		method="POST"
+		action="?/updateAssignment"
+		use:enhance={editSubmit}
+		class="flex flex-col gap-3"
+	>
+		{#if editing}
+			<input type="hidden" name="id" value={editing.id} />
+			<input type="hidden" name="prevStartDate" value={editing.startDate} />
+		{/if}
+
+		<label class="flex flex-col gap-1 text-sm">
+			<span>{t('assignments.resource')}</span>
+			<select
+				name="resourceId"
+				aria-label={t('assignments.resource')}
+				bind:value={formResourceId}
+				required
+				class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+				style="border-radius: calc(var(--radius) * 0.6)"
+			>
+				{#each resources as r (r.id)}
+					<option value={r.id}>{r.name}</option>
+				{/each}
+			</select>
+			{#if formError?.resourceId}
+				<span class="text-xs text-destructive">{formError.resourceId}</span>
+			{/if}
+		</label>
+
+		<label class="flex flex-col gap-1 text-sm">
+			<span>{t('assignments.project')}</span>
+			<select
+				name="projectId"
+				aria-label={t('assignments.project')}
+				bind:value={formProjectId}
+				required
+				class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+				style="border-radius: calc(var(--radius) * 0.6)"
+			>
+				{#each projects as p (p.id)}
+					<option value={p.id}>{p.name}</option>
+				{/each}
+			</select>
+			{#if formError?.projectId}
+				<span class="text-xs text-destructive">{formError.projectId}</span>
+			{/if}
+		</label>
+
+		<div class="grid grid-cols-2 gap-3">
+			<label class="flex flex-col gap-1 text-sm">
+				<span>{t('assignments.startDate')}</span>
+				<input
+					name="startDate"
+					type="date"
+					bind:value={formStartDate}
+					required
+					class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					style="border-radius: calc(var(--radius) * 0.6)"
+				/>
+				{#if formError?.startDate}
+					<span class="text-xs text-destructive">{formError.startDate}</span>
+				{/if}
+			</label>
+
+			<label class="flex flex-col gap-1 text-sm">
+				<span>{t('assignments.endDate')}</span>
+				<input
+					name="endDate"
+					type="date"
+					bind:value={formEndDate}
+					required
+					min={formStartDate}
+					class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
+					style="border-radius: calc(var(--radius) * 0.6)"
+				/>
+				{#if formError?.endDate}
+					<span class="text-xs text-destructive">{formError.endDate}</span>
+				{/if}
+			</label>
+		</div>
+
+		<div class="mt-2 flex justify-end gap-2">
+			<Button
+				variant="ghost"
+				type="button"
+				onclick={() => (editOpen = false)}
+				disabled={editSubmitState.submitting}
+			>
+				{t('common.cancel')}
+			</Button>
+			<Button type="submit" disabled={editSubmitState.submitting}>
+				{editSubmitState.submitting ? t('common.submitting') : t('common.update')}
+			</Button>
+		</div>
+	</form>
 </Dialog>

--- a/web/src/lib/components/AssignmentManager.svelte.test.ts
+++ b/web/src/lib/components/AssignmentManager.svelte.test.ts
@@ -1,7 +1,24 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/svelte';
+import { fireEvent, render, screen, within } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import AssignmentManager from './AssignmentManager.svelte';
+import type { Assignment, Project, Resource } from '$lib/types';
+
+const sampleResources: Resource[] = [
+	{ id: 'r1', name: 'Alice' },
+	{ id: 'r2', name: 'Bob' }
+];
+const sampleProjects: Project[] = [
+	{ id: 'p1', name: 'Atlas', color: '#4D72F3' },
+	{ id: 'p2', name: 'Beacon', color: '#FF7755' }
+];
+const sampleAssignment: Assignment = {
+	id: 'asn-1',
+	resourceId: 'r1',
+	projectId: 'p1',
+	startDate: '2026-05-01',
+	endDateExclusive: '2026-05-08'
+};
 
 describe('AssignmentManager (smoke)', () => {
 	it('renders the trigger button with the assignment count', () => {
@@ -20,5 +37,63 @@ describe('AssignmentManager (smoke)', () => {
 		expect(icon).toBeTruthy();
 		expect(trigger.textContent).not.toMatch(/📋/);
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/アサイン一覧/);
+	});
+});
+
+describe('AssignmentManager — edit (#99 item 1)', () => {
+	it('renders an edit button per assignment row when the list dialog is open', async () => {
+		const { getByRole } = render(AssignmentManager, {
+			props: {
+				assignments: [sampleAssignment],
+				resources: sampleResources,
+				projects: sampleProjects
+			}
+		});
+		// Trigger を click して list dialog を open
+		await fireEvent.click(getByRole('button', { name: /アサイン一覧/ }));
+
+		// 各行に edit button が存在
+		const editBtns = screen.getAllByRole('button', { name: /編集/ });
+		expect(editBtns.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('opens the edit dialog with form pre-filled and includes prevStartDate hidden input', async () => {
+		const { getByRole } = render(AssignmentManager, {
+			props: {
+				assignments: [sampleAssignment],
+				resources: sampleResources,
+				projects: sampleProjects
+			}
+		});
+		await fireEvent.click(getByRole('button', { name: /アサイン一覧/ }));
+		const editBtn = screen.getAllByRole('button', { name: /編集/ })[0];
+		await fireEvent.click(editBtn);
+
+		// edit dialog 内の form action
+		const form = document.querySelector(
+			'form[action="?/updateAssignment"]'
+		) as HTMLFormElement | null;
+		expect(form).toBeTruthy();
+
+		// hidden field: id + prevStartDate
+		const idInput = form!.querySelector('input[name="id"]') as HTMLInputElement;
+		expect(idInput?.value).toBe('asn-1');
+		const prev = form!.querySelector('input[name="prevStartDate"]') as HTMLInputElement;
+		expect(prev?.value).toBe('2026-05-01');
+
+		// pre-fill: resource / project / start / end (inclusive 表示)
+		const resourceSelect = within(form!).getByRole('combobox', {
+			name: /人/
+		}) as HTMLSelectElement;
+		expect(resourceSelect.value).toBe('r1');
+		const projectSelect = within(form!).getByRole('combobox', {
+			name: /案件/
+		}) as HTMLSelectElement;
+		expect(projectSelect.value).toBe('p1');
+		const startInput = form!.querySelector('input[name="startDate"]') as HTMLInputElement;
+		expect(startInput.value).toBe('2026-05-01');
+		// endDate は inclusive = endDateExclusive - 1 (ADR 0004 / displayEndDate)
+		const endInput = form!.querySelector('input[name="endDate"]') as HTMLInputElement;
+		expect(endInput.value).toBe('2026-05-07');
 	});
 });

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -59,6 +59,7 @@
 		"add": "Add assignment",
 		"addLong": "+ Add assignment",
 		"createTitle": "Add assignment",
+		"editTitle": "Edit assignment",
 		"description": "Assign a person to a project for a date range",
 		"list": "Assignments",
 		"listWithCount": "Assignments ({count})",

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -59,6 +59,7 @@
 		"add": "アサインを追加",
 		"addLong": "+ アサインを追加",
 		"createTitle": "アサインを追加",
+		"editTitle": "アサインを編集",
 		"description": "人を案件に期間でアサインする",
 		"list": "アサイン一覧",
 		"listWithCount": "アサイン一覧 ({count})",

--- a/web/src/lib/schemas/index.test.ts
+++ b/web/src/lib/schemas/index.test.ts
@@ -3,6 +3,7 @@ import {
 	assignmentApiUpdateSchema,
 	assignmentCreateSchema,
 	assignmentUpdateSchema,
+	assignmentFormUpdateSchema,
 	projectCreateSchema,
 	projectUpdateSchema,
 	resourceCreateSchema,
@@ -163,6 +164,47 @@ describe('assignmentUpdateSchema', () => {
 				endDate: '2026-05-31'
 			}).success
 		).toBe(false);
+	});
+});
+
+describe('assignmentFormUpdateSchema (#99)', () => {
+	const valid = {
+		id: 'a1',
+		resourceId: 'r1',
+		projectId: 'p1',
+		prevStartDate: '2026-05-01',
+		startDate: '2026-05-03',
+		endDate: '2026-05-09'
+	};
+
+	it('splits prevStartDate from payload and applies the +1-day transform', () => {
+		const r = assignmentFormUpdateSchema.safeParse(valid);
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data).toEqual({
+			prevStartDate: '2026-05-01',
+			payload: {
+				id: 'a1',
+				resourceId: 'r1',
+				projectId: 'p1',
+				startDate: '2026-05-03',
+				endDateExclusive: '2026-05-10'
+			}
+		});
+	});
+
+	it('rejects when prevStartDate is not YYYY-MM-DD', () => {
+		const r = assignmentFormUpdateSchema.safeParse({ ...valid, prevStartDate: 'bad' });
+		expect(r.success).toBe(false);
+	});
+
+	it('rejects when endDate < startDate', () => {
+		const r = assignmentFormUpdateSchema.safeParse({
+			...valid,
+			startDate: '2026-05-10',
+			endDate: '2026-05-09'
+		});
+		expect(r.success).toBe(false);
 	});
 });
 

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -81,6 +81,36 @@ export const assignmentUpdateSchema = z
 		endDateExclusive: addDays(input.endDate, 1)
 	}));
 
+/**
+ * 編集フォーム送信用 schema (#99 item 1)。`prevStartDate` を含めて受け取り、
+ * post-transform で repository 呼び出しに必要な `(prevStartDate, AssignmentUpdatePayload)` 構造に分割する。
+ *
+ * `prevStartDate` は SK = `ASN#{startDate}#{id}` 再構築に必要 (startDate を変更したとき旧 SK を削除する)。
+ */
+export const assignmentFormUpdateSchema = z
+	.object({
+		id: z.string().min(1),
+		resourceId: z.string().min(1),
+		projectId: z.string().min(1),
+		prevStartDate: dateString,
+		startDate: dateString,
+		endDate: dateString
+	})
+	.refine((v) => v.startDate <= v.endDate, {
+		message: '終了日は開始日以降にしてください',
+		path: ['endDate']
+	})
+	.transform((input) => ({
+		prevStartDate: input.prevStartDate,
+		payload: {
+			id: input.id,
+			resourceId: input.resourceId,
+			projectId: input.projectId,
+			startDate: input.startDate,
+			endDateExclusive: addDays(input.endDate, 1)
+		}
+	}));
+
 /** フォーム生 shape (UX inclusive)。`+page.svelte` のフォームバインディングで使う。 */
 export type AssignmentCreateInput = z.input<typeof assignmentCreateSchema>;
 export type AssignmentUpdateInput = z.input<typeof assignmentUpdateSchema>;

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -5,7 +5,8 @@ import {
 	resourceUpdateSchema,
 	projectCreateSchema,
 	projectUpdateSchema,
-	assignmentCreateSchema
+	assignmentCreateSchema,
+	assignmentFormUpdateSchema
 } from '$lib/schemas';
 import {
 	createResource,
@@ -15,6 +16,7 @@ import {
 	updateProject,
 	deleteProject,
 	createAssignment,
+	updateAssignment,
 	deleteAssignment
 } from '$lib/repository';
 import { requireSession } from '$lib/auth';
@@ -150,6 +152,28 @@ export const actions: Actions = {
 		// SK は ASN#{startDate}#{ulid()} で時系列順にソートされる。
 		await createAssignment(session.teamId, parsed.data);
 		return { action: 'createAssignment', success: true };
+	},
+
+	updateAssignment: async (event) => {
+		const session = await requireSession(event);
+		const data = await event.request.formData();
+		const parsed = assignmentFormUpdateSchema.safeParse({
+			id: data.get('id'),
+			resourceId: data.get('resourceId'),
+			projectId: data.get('projectId'),
+			prevStartDate: data.get('prevStartDate'),
+			startDate: data.get('startDate'),
+			endDate: data.get('endDate')
+		});
+		if (!parsed.success) {
+			return fail(400, {
+				action: 'updateAssignment',
+				errors: formatErrors(parsed)
+			});
+		}
+		// SK = ASN#{startDate}#{id}: startDate 変更時は旧 SK Delete + 新 SK Put (assignment.ts 参照)。
+		await updateAssignment(session.teamId, parsed.data.prevStartDate, parsed.data.payload);
+		return { action: 'updateAssignment', success: true };
 	},
 
 	deleteAssignment: async (event) => {

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * `?/updateAssignment` action の TDD (#99 item 1)。
+ *
+ * 既存の form action パターン (updateResource / updateProject) と整合させつつ、
+ * Assignment 固有の `prevStartDate` 引数を渡せること、Zod validation で `endDate < startDate`
+ * を fail させること、を保証する。
+ *
+ * repository / auth はモックし、handler の引数 mapping + 戻り値だけを assert。
+ */
+
+const requireSessionMock = vi.fn();
+const updateAssignmentMock = vi.fn();
+
+vi.mock('$lib/auth', () => ({
+	requireSession: (event: unknown) => requireSessionMock(event)
+}));
+
+vi.mock('$lib/repository', () => ({
+	createResource: vi.fn(),
+	updateResource: vi.fn(),
+	deleteResource: vi.fn(),
+	createProject: vi.fn(),
+	updateProject: vi.fn(),
+	deleteProject: vi.fn(),
+	createAssignment: vi.fn(),
+	updateAssignment: (...args: unknown[]) => updateAssignmentMock(...args),
+	deleteAssignment: vi.fn()
+}));
+
+import { actions } from './+page.server';
+
+function makeEvent(form: Record<string, string>) {
+	const data = new FormData();
+	for (const [k, v] of Object.entries(form)) data.append(k, v);
+	return {
+		request: { formData: async () => data }
+	} as unknown as Parameters<NonNullable<typeof actions.updateAssignment>>[0];
+}
+
+describe('?/updateAssignment action (#99)', () => {
+	beforeEach(() => {
+		requireSessionMock.mockReset().mockResolvedValue({ teamId: 'team_default', userId: 'u1' });
+		updateAssignmentMock.mockReset().mockResolvedValue(undefined);
+	});
+
+	it('is exported on actions', () => {
+		expect(typeof actions.updateAssignment).toBe('function');
+	});
+
+	it('calls updateAssignment(teamId, prevStartDate, payload) with endDateExclusive transform applied', async () => {
+		const event = makeEvent({
+			id: 'asn-1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			prevStartDate: '2026-05-01',
+			startDate: '2026-05-03',
+			endDate: '2026-05-09' // inclusive
+		});
+		const result = await actions.updateAssignment!(event);
+		expect(updateAssignmentMock).toHaveBeenCalledTimes(1);
+		const [teamId, prevStartDate, payload] = updateAssignmentMock.mock.calls[0];
+		expect(teamId).toBe('team_default');
+		expect(prevStartDate).toBe('2026-05-01');
+		expect(payload).toEqual({
+			id: 'asn-1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-03',
+			endDateExclusive: '2026-05-10' // endDate + 1
+		});
+		expect(result).toEqual({ action: 'updateAssignment', success: true });
+	});
+
+	it('returns 400 failure when endDate is before startDate (zod refine)', async () => {
+		const event = makeEvent({
+			id: 'asn-1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			prevStartDate: '2026-05-01',
+			startDate: '2026-05-10',
+			endDate: '2026-05-09'
+		});
+		const result = (await actions.updateAssignment!(event)) as {
+			status: number;
+			data: { action: string; errors: Record<string, string> };
+		};
+		expect(result.status).toBe(400);
+		expect(result.data.errors.endDate).toBeTruthy();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('returns 400 failure when prevStartDate is missing or wrong format', async () => {
+		const event = makeEvent({
+			id: 'asn-1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			prevStartDate: 'not-a-date',
+			startDate: '2026-05-03',
+			endDate: '2026-05-09'
+		});
+		const result = (await actions.updateAssignment!(event)) as {
+			status: number;
+			data: { errors: Record<string, string> };
+		};
+		expect(result.status).toBe(400);
+		expect(result.data.errors.prevStartDate).toBeTruthy();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

#99 a11y/polish bundle のうち、最大価値の **item 1 (AssignmentEditor / 編集 button)** を実装。残 item 2-4 (URL state / 空状態 chip / 楽観的 UI) は本 issue 内で継続。

## 動機

Resource / Project は manager 内で create / edit / delete 揃ってる一方、Assignment は **delete のみ** で日付ミス時は「削除 → 新規作成」しかなかった。一貫性 + 履歴保全のための機能追加。

## 変更

### Server side

- \`web/src/lib/schemas/index.ts\` — \`assignmentFormUpdateSchema\` 追加 (\`prevStartDate\` + inclusive→exclusive transform)
- \`web/src/routes/+page.server.ts\` — \`?/updateAssignment\` action

\`prevStartDate\` は SK = \`ASN#{startDate}#{id}\` 再構築 (assignment.ts の TransactWriteItems で旧 SK Delete + 新 SK Put) に必要。

### Client side

- \`web/src/lib/components/AssignmentManager.svelte\`:
  - 各行に「編集」 button 追加
  - 別 Dialog で pre-filled な edit form
  - submit 後 \`invalidateAll\` で list 自動更新
- \`web/src/lib/i18n/{ja,en}.json\` — \`assignments.editTitle\` 追加

## Test plan

### Unit (vitest)

- [x] \`assignmentFormUpdateSchema\` 3 ケース (valid transform / bad prevStartDate / endDate<startDate)
- [x] \`?/updateAssignment\` action 4 ケース (export / 正常呼び出し / endDate refine / prevStartDate format)
- [x] AssignmentManager component 2 ケース (edit button 表示 / 編集 dialog の pre-fill + prevStartDate hidden)
- [x] 計 131 passed (+9)

### E2E (Playwright)

- [x] 既存 5 spec 緑 (本 PR は edit UI 追加のみ、smoke / sign-in 影響なし)

### Manual (CD 後)

- [ ] 本番で assignment 行の編集 button → 日付 / 人 / 案件 変更 → save → 一覧反映を確認

## #99 全体進捗

| Sub-item | Status |
|---|---|
| 1. AssignmentEditor 編集 button | ✅ 本 PR |
| 2. URL 状態同期 (viewport / zoom) | ⏳ 未着手 |
| 3. 空状態のステップガイド (3 step chip) | ⏳ 未着手 |
| 4. 楽観的 UI のもう一段の磨き込み | ⏳ 未着手 |
| 5. signout aria-label | ✅ 既存 (PR #103 + #108) |