### PR TITLE
feat(onboarding): 3-step setup guide chip (#99 item 3)

### DIFF
--- a/web/src/lib/components/AssignmentManager.svelte.test.ts
+++ b/web/src/lib/components/AssignmentManager.svelte.test.ts
@@ -1,8 +1,16 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, within } from '@testing-library/svelte';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import AssignmentManager from './AssignmentManager.svelte';
 import type { Assignment, Project, Resource } from '$lib/types';
+
+// edit dialog を開く test で bits-ui body-scroll-lock が 24ms 遅延 cleanup timer を仕込む。
+// testing-library の auto-cleanup 後に timer が発火し、その時点で jsdom document が
+// 消えていると CI で "ReferenceError: document is not defined" の unhandled error になる。
+// teardown 前に必ず timer を消化するため少し待つ。
+afterEach(async () => {
+	await new Promise((resolve) => setTimeout(resolve, 50));
+});
 
 const sampleResources: Resource[] = [
 	{ id: 'r1', name: 'Alice' },

--- a/web/src/lib/components/EmptyStateGuide.svelte
+++ b/web/src/lib/components/EmptyStateGuide.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import Check from 'phosphor-svelte/lib/Check';
+	import { t } from '$lib/i18n/index.svelte';
+
+	/**
+	 * 3-step onboarding chip (#99 item 3)。「人 → 案件 → アサイン」 の 3 段階を可視化し、
+	 * 各 step は対応する entity が >0 件存在すれば done として ✓ 表示する。
+	 *
+	 * すべて done になったらコンポーネント自身が null を返し、UI から消える。
+	 */
+	let {
+		resourceCount,
+		projectCount,
+		assignmentCount
+	}: {
+		resourceCount: number;
+		projectCount: number;
+		assignmentCount: number;
+	} = $props();
+
+	const step1Done = $derived(resourceCount > 0);
+	const step2Done = $derived(projectCount > 0);
+	const step3Done = $derived(assignmentCount > 0);
+	const allDone = $derived(step1Done && step2Done && step3Done);
+</script>
+
+{#if !allDone}
+	<ol class="mb-6 grid gap-3 sm:grid-cols-3" aria-label={t('emptyGuide.label')}>
+		<li
+			class="flex items-center gap-2 rounded border px-3 py-2 text-sm transition-colors"
+			class:border-primary={step1Done}
+			class:bg-primary={step1Done}
+			class:text-primary-foreground={step1Done}
+			class:border-border={!step1Done}
+			class:bg-card={!step1Done}
+			data-testid="empty-step-1"
+			data-done={step1Done}
+		>
+			<span class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border">
+				{#if step1Done}
+					<Check size={14} weight="bold" aria-hidden="true" />
+				{:else}
+					<span aria-hidden="true">1</span>
+				{/if}
+			</span>
+			<span>{t('emptyGuide.step1')}</span>
+		</li>
+		<li
+			class="flex items-center gap-2 rounded border px-3 py-2 text-sm transition-colors"
+			class:border-primary={step2Done}
+			class:bg-primary={step2Done}
+			class:text-primary-foreground={step2Done}
+			class:border-border={!step2Done}
+			class:bg-card={!step2Done}
+			data-testid="empty-step-2"
+			data-done={step2Done}
+		>
+			<span class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border">
+				{#if step2Done}
+					<Check size={14} weight="bold" aria-hidden="true" />
+				{:else}
+					<span aria-hidden="true">2</span>
+				{/if}
+			</span>
+			<span>{t('emptyGuide.step2')}</span>
+		</li>
+		<li
+			class="flex items-center gap-2 rounded border px-3 py-2 text-sm transition-colors"
+			class:border-primary={step3Done}
+			class:bg-primary={step3Done}
+			class:text-primary-foreground={step3Done}
+			class:border-border={!step3Done}
+			class:bg-card={!step3Done}
+			data-testid="empty-step-3"
+			data-done={step3Done}
+		>
+			<span class="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border">
+				{#if step3Done}
+					<Check size={14} weight="bold" aria-hidden="true" />
+				{:else}
+					<span aria-hidden="true">3</span>
+				{/if}
+			</span>
+			<span>{t('emptyGuide.step3')}</span>
+		</li>
+	</ol>
+{/if}

--- a/web/src/lib/components/EmptyStateGuide.svelte.test.ts
+++ b/web/src/lib/components/EmptyStateGuide.svelte.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import EmptyStateGuide from './EmptyStateGuide.svelte';
+
+/**
+ * #99 item 3: 「① 人を追加 ② 案件を追加 ③ アサインを作成」 の 3 step chip 表示。
+ *
+ * 4 状態 + 完了 (隠す) を確認:
+ *   - 両方空: 1 / 2 / 3 すべて未完
+ *   - resource のみ空: 2 だけ ✓
+ *   - project のみ空: 1 だけ ✓
+ *   - resource + project あり、assignment 空: 1 / 2 ✓、3 だけ未完
+ *   - すべてあり: 描画自体しない (null)
+ */
+function renderGuide(counts: {
+	resourceCount: number;
+	projectCount: number;
+	assignmentCount: number;
+}) {
+	return render(EmptyStateGuide, { props: counts });
+}
+
+describe('EmptyStateGuide (#99 item 3)', () => {
+	it('all three steps incomplete when everything is empty', () => {
+		const { getByTestId } = renderGuide({
+			resourceCount: 0,
+			projectCount: 0,
+			assignmentCount: 0
+		});
+		expect(getByTestId('empty-step-1').getAttribute('data-done')).toBe('false');
+		expect(getByTestId('empty-step-2').getAttribute('data-done')).toBe('false');
+		expect(getByTestId('empty-step-3').getAttribute('data-done')).toBe('false');
+	});
+
+	it('marks step 1 done when at least one resource exists', () => {
+		const { getByTestId } = renderGuide({
+			resourceCount: 1,
+			projectCount: 0,
+			assignmentCount: 0
+		});
+		expect(getByTestId('empty-step-1').getAttribute('data-done')).toBe('true');
+		expect(getByTestId('empty-step-2').getAttribute('data-done')).toBe('false');
+		expect(getByTestId('empty-step-3').getAttribute('data-done')).toBe('false');
+	});
+
+	it('marks step 2 done when at least one project exists', () => {
+		const { getByTestId } = renderGuide({
+			resourceCount: 0,
+			projectCount: 1,
+			assignmentCount: 0
+		});
+		expect(getByTestId('empty-step-1').getAttribute('data-done')).toBe('false');
+		expect(getByTestId('empty-step-2').getAttribute('data-done')).toBe('true');
+		expect(getByTestId('empty-step-3').getAttribute('data-done')).toBe('false');
+	});
+
+	it('marks steps 1 and 2 done when both resource and project exist but no assignment', () => {
+		const { getByTestId } = renderGuide({
+			resourceCount: 2,
+			projectCount: 3,
+			assignmentCount: 0
+		});
+		expect(getByTestId('empty-step-1').getAttribute('data-done')).toBe('true');
+		expect(getByTestId('empty-step-2').getAttribute('data-done')).toBe('true');
+		expect(getByTestId('empty-step-3').getAttribute('data-done')).toBe('false');
+	});
+
+	it('renders nothing when all three steps are complete (guide is dismissed)', () => {
+		const { container } = renderGuide({
+			resourceCount: 1,
+			projectCount: 1,
+			assignmentCount: 1
+		});
+		// no chip rendered
+		expect(container.querySelector('[data-testid^="empty-step-"]')).toBeNull();
+	});
+});

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -124,5 +124,11 @@
 		"label": "User menu",
 		"labelWithEmail": "User menu ({email})",
 		"signout": "Sign out"
+	},
+	"emptyGuide": {
+		"label": "Setup steps",
+		"step1": "Add a person",
+		"step2": "Add a project",
+		"step3": "Create an assignment"
 	}
 }

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -124,5 +124,11 @@
 		"label": "ユーザーメニュー",
 		"labelWithEmail": "ユーザーメニュー ({email})",
 		"signout": "サインアウト"
+	},
+	"emptyGuide": {
+		"label": "セットアップステップ",
+		"step1": "人を追加",
+		"step2": "案件を追加",
+		"step3": "アサインを作成"
 	}
 }

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 	import ProjectManager from '$lib/components/ProjectManager.svelte';
 	import AssignmentCreator from '$lib/components/AssignmentCreator.svelte';
 	import AssignmentManager from '$lib/components/AssignmentManager.svelte';
+	import EmptyStateGuide from '$lib/components/EmptyStateGuide.svelte';
 	import AvatarDropdown from '$lib/components/AvatarDropdown.svelte';
 	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
 	import LocaleSwitcher from '$lib/components/LocaleSwitcher.svelte';
@@ -112,10 +113,15 @@
 </header>
 
 <main class="mx-auto max-w-[1200px] px-4 py-6">
+	<EmptyStateGuide
+		resourceCount={resources.length}
+		projectCount={projects.length}
+		assignmentCount={dbAssignments.length}
+	/>
+
 	{#if resources.length === 0}
 		<div class="empty-state">
-			<p>{t('resources.empty')}</p>
-			<p class="hint">{t('resources.emptyHint')}</p>
+			<p>{t('resources.emptyHint')}</p>
 		</div>
 	{:else}
 		<TimelineToolbar


### PR DESCRIPTION
## Summary

#99 item 3 を実装。「① 人を追加 ② 案件を追加 ③ アサインを作成」 の 3 chip を表示、各 entity が >0 件存在すれば ✓ で done 表示、3 つ全て done になったら自動で消える。

## 動機 (issue より)

> 現状: \`resources.length === 0\` のときテキストのみ、\`projects\` 単独空 / 両方空 / どちらか空のケースで親切さに差

→ 4 状態 (両空 / R のみ / P のみ / RP のみ) のいずれでも親切な onboarding パスを示す。

## 設計

\`EmptyStateGuide.svelte\` — props \`{ resourceCount, projectCount, assignmentCount }\` を受け取り、自前で done 判定 + 隠す/出す決定。呼び出し側 (\`+page.svelte\`) は count を渡すだけ。

\`+page.svelte\`:
- guide を常に mount (component 内で allDone のとき null)
- resources が 0 件のときの empty-state テキストは \`emptyHint\` だけ残す (guide が \"何をすべきか\" を担う)

## Test plan

### Unit (vitest, jsdom)

- [x] 4 状態 + allDone 隠す = 5 ケース
- [x] 計 144 passed (+5)

### E2E

- [x] 既存 5 spec 緑

### Manual (CD 後)

- [ ] 本番で新規 sign-in → 3 chip 全部未完表示
- [ ] 人を 1 件追加 → step 1 のみ ✓
- [ ] 案件を 1 件追加 → step 2 も ✓
- [ ] アサインを 1 件追加 → guide 消える

## #99 全体進捗

| Sub-item | Status |
|---|---|
| 1. AssignmentEditor 編集 button | ✅ PR #118 |
| 2. URL 状態同期 (viewport / zoom) | ✅ PR #119 |
| 3. 空状態のステップガイド (3 step chip) | ✅ 本 PR |
| 4. 楽観的 UI のもう一段の磨き込み | ⏳ |
| 5. signout aria-label | ✅ 既存 (PR #103 + #108) |