### PR TITLE
chore(deps): bump @tommykey-apps/ui-components to 0.5.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -58,7 +58,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.4.1",
+		"@tommykey-apps/ui-components": "^0.5.0",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.4.1
-        version: 0.4.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.5.0
+        version: 0.5.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1166,8 +1166,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.4.1':
-    resolution: {integrity: sha512-X3vXY+DtHoJ72X6DEGy5JnEOuF9GKsAysK29scVNT0dlj+MB7SkVZJznJAeEir8Ab7an9z/YlADQXofzoFHXWA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.4.1/3a67207590f582c4de15467d186f8e8b217b99a5}
+  '@tommykey-apps/ui-components@0.5.0':
+    resolution: {integrity: sha512-H6gd+YqzLjbnoRF1w5SN6DAUQ+5AjHpn8STc04TRqo2xf5fMWYSJ5VVrTa0VZsFTTC9lJwKjsBqCYDXWvVKc1w==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.5.0/3d359636b27d0e92658d973602c815f1b13db2ca}
     peerDependencies:
       svelte: ^5.0.0
 
@@ -3832,7 +3832,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.4.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.5.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       date-fns: 4.1.0
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)


### PR DESCRIPTION
## Summary

ui-components の v0.5.0 を取り込む。先に上流で行った 3 件の修正を本リポジトリにも反映するための version bump。

## 取り込まれる変更

| ui-components Issue / PR | 内容 |
|---|---|
| [#21](https://github.com/tommykey-apps/ui-components/issues/21) (PR [#25](https://github.com/tommykey-apps/ui-components/pull/25)) | TimelineToolbar の \`aria-pressed=true\` button が dark mode で fg=bg=白 になる問題を fallback chain に \`--ui-bar-fg\` を挟んで修正 |
| [#22](https://github.com/tommykey-apps/ui-components/issues/22) (PR [#24](https://github.com/tommykey-apps/ui-components/pull/24)) | drag/resize 中の Bar が sticky な resource rail / header より手前に表示される問題を \`.canvas\` の \`isolation: isolate\` で修正 |
| [#23](https://github.com/tommykey-apps/ui-components/issues/23) (PR [#26](https://github.com/tommykey-apps/ui-components/pull/26)) | label が truncate されている時だけ Bar に hover tooltip で案件名を出す |

## Test plan

- [x] \`pnpm test\` 緑 (144 passed)
- [x] \`pnpm build\` 緑
- [ ] **本番反映後の手動確認** (CD merge → planner.tommykeyapp.com):
  - dark mode で 日/週/月/年 button のアクティブ状態が読める
  - 帯を drag/resize 中に resource rail が見えたまま
  - 短い帯 (zoom out) を hover で案件名 tooltip が出る、広い帯では出ない