### PR TITLE
fix(security): DynamoDB client env guard + Playwright webServer.env 明示 (fixes #125)

### DIFF
--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -6,14 +6,27 @@ import { join } from 'node:path';
  * Playwright E2E test configuration.
  *
  * **位置づけ**: Auth.js 移行後 (PR-A3 以降) に Magic Link sign-in → CRUD のフルパス E2E を書く土台。
- * 本 PR (PR-T5) ではホーム画面の smoke、#113 で Magic Link sign-in spec を追加。
  *
  * - 既定では preview build (`pnpm build && pnpm preview`) を Playwright が起動
  * - CI は Chromium のみ (コスト削減)、ローカルは 3 ブラウザ並行
- * - dev sendVerificationRequest が URL を書き出す `AUTH_TEST_MAGIC_LINK_FILE` を preview server に
- *   渡すため、ここで process.env に注入する (webServer.env は process.env を引き継がない仕様のため)。
+ *
+ * **env 注入** (#125): `vite preview` は SvelteKit 統合と違って `.env.local` を process.env に
+ * 注入しない。host shell に本番 AWS credential が残っていると preview server が本番 DynamoDB に
+ * 到達して書き込み事故になる (実発生済)。`webServer.env` で AWS / AUTH 系を明示上書きし、
+ * `assertSafeDbEnv` (#125 アプリ guard) と合わせて二重防御。
+ *
+ * Playwright の `webServer.env`:
+ *   - 未設定 → spawn 時に process.env を継承
+ *   - 設定 → そのオブジェクトで完全置換 (継承しない)
+ *
+ * よって `...process.env` を最初に展開して PATH 等を流し、AWS 系は後から明示で上書きする
+ * (object spread 後勝ち)。
  */
-process.env.AUTH_TEST_MAGIC_LINK_FILE ??= join(tmpdir(), 'playwright-magic-links.txt');
+
+// fixture (test runner プロセス) と webServer 両方が同じファイルを読み書きするため、
+// この config 評価時に env で固定し、両プロセスが同じ path を見るようにする。
+const magicLinkFile = join(tmpdir(), 'playwright-magic-links.txt');
+process.env.AUTH_TEST_MAGIC_LINK_FILE ??= magicLinkFile;
 
 export default defineConfig({
 	testDir: 'e2e',
@@ -37,6 +50,22 @@ export default defineConfig({
 		command: 'pnpm preview --host 127.0.0.1 --port 4173',
 		url: 'http://localhost:4173',
 		reuseExistingServer: !process.env.CI,
-		timeout: 120_000
+		timeout: 120_000,
+		env: {
+			// host env (PATH / HOME 等) を継承 → AWS 系は後で明示上書きする
+			...process.env,
+			// ローカル DDB に固定 (host shell に本番 cred があっても無視される + アプリ側 guard も通る)
+			AWS_ENDPOINT_URL: 'http://localhost:8000',
+			AWS_ACCESS_KEY_ID: 'local',
+			AWS_SECRET_ACCESS_KEY: 'local',
+			AWS_REGION: 'ap-northeast-1',
+			AWS_DEFAULT_REGION: 'ap-northeast-1',
+			DYNAMODB_TABLE: 'resource-planner',
+			AUTH_SECRET: 'e2e-secret-not-for-production-padding-padding-padding',
+			AUTH_TRUST_HOST: 'true',
+			ALLOWED_DOMAIN: 'example.com',
+			EMAIL_FROM: 'noreply@example.com',
+			AUTH_TEST_MAGIC_LINK_FILE: process.env.AUTH_TEST_MAGIC_LINK_FILE ?? magicLinkFile
+		}
 	}
 });

--- a/web/src/lib/db/client.ts
+++ b/web/src/lib/db/client.ts
@@ -2,11 +2,21 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { building } from '$app/environment';
 import { env } from '$env/dynamic/private';
+import { assertSafeDbEnv } from './env-guard';
 
 // SvelteKit の `analyse` ステップ (postbuild) はサーバーモジュールを top-level 評価するため、
 // build 中は env チェックをスキップする (Lambda 実行時にのみ env が揃う)。
-if (!building && !env.DYNAMODB_TABLE) {
-	throw new Error('DYNAMODB_TABLE env not set');
+if (!building) {
+	if (!env.DYNAMODB_TABLE) {
+		throw new Error('DYNAMODB_TABLE env not set');
+	}
+	// 本番安全 guard (#125): Lambda 環境 OR localhost endpoint でないと client 構築を拒否。
+	// vite preview などで .env.local が process.env に注入されないケースで AWS SDK が
+	// default credential chain に落ちて本番 AWS に到達する事故を防ぐ。
+	assertSafeDbEnv({
+		isLambda: !!process.env.AWS_LAMBDA_FUNCTION_NAME,
+		endpoint: env.AWS_ENDPOINT_URL
+	});
 }
 
 // AWS SDK v3 は AWS_ENDPOINT_URL を自動認識する (v3.385+)。

--- a/web/src/lib/db/env-guard.test.ts
+++ b/web/src/lib/db/env-guard.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { assertSafeDbEnv } from './env-guard';
+
+/**
+ * #125: DynamoDB client 構築前の env 安全判定。
+ *
+ * Lambda 環境 (`AWS_LAMBDA_FUNCTION_NAME` 自動セット) または local endpoint (localhost / 127.0.0.1)
+ * のいずれかでないと throw する。dev / preview / CI で env 注入失敗で本番 AWS に到達する事故を防ぐ。
+ */
+describe('assertSafeDbEnv (#125)', () => {
+	it('allows Lambda environment (isLambda=true) regardless of endpoint', () => {
+		expect(() => assertSafeDbEnv({ isLambda: true, endpoint: null })).not.toThrow();
+		expect(() => assertSafeDbEnv({ isLambda: true, endpoint: undefined })).not.toThrow();
+		expect(() =>
+			assertSafeDbEnv({ isLambda: true, endpoint: 'https://dynamodb.ap-northeast-1.amazonaws.com' })
+		).not.toThrow();
+	});
+
+	it('allows localhost endpoint when not in Lambda', () => {
+		expect(() =>
+			assertSafeDbEnv({ isLambda: false, endpoint: 'http://localhost:8000' })
+		).not.toThrow();
+	});
+
+	it('allows 127.0.0.1 endpoint when not in Lambda', () => {
+		expect(() =>
+			assertSafeDbEnv({ isLambda: false, endpoint: 'http://127.0.0.1:8000' })
+		).not.toThrow();
+	});
+
+	it('throws when endpoint is unset and not in Lambda', () => {
+		expect(() => assertSafeDbEnv({ isLambda: false, endpoint: null })).toThrow(
+			/Refusing to construct DynamoDB client/
+		);
+		expect(() => assertSafeDbEnv({ isLambda: false, endpoint: undefined })).toThrow();
+		expect(() => assertSafeDbEnv({ isLambda: false, endpoint: '' })).toThrow();
+	});
+
+	it('throws when endpoint points to a non-localhost host and not in Lambda', () => {
+		expect(() =>
+			assertSafeDbEnv({
+				isLambda: false,
+				endpoint: 'https://dynamodb.ap-northeast-1.amazonaws.com'
+			})
+		).toThrow(/Refusing to construct DynamoDB client/);
+	});
+
+	it('error message includes the offending endpoint and the fix hint', () => {
+		try {
+			assertSafeDbEnv({ isLambda: false, endpoint: 'https://prod.example.com' });
+			expect.fail('should have thrown');
+		} catch (e) {
+			expect(e).toBeInstanceOf(Error);
+			const msg = (e as Error).message;
+			expect(msg).toContain('https://prod.example.com');
+			expect(msg).toContain('AWS_ENDPOINT_URL=http://localhost:8000');
+			expect(msg).toContain('.env.local');
+		}
+	});
+
+	it('rejects http://example.localhost-ish prefix bypass attempts', () => {
+		// "http://localhost.evil.com" は host が evil.com で localhost ではない。正規表現が安全であることを確認。
+		expect(() =>
+			assertSafeDbEnv({ isLambda: false, endpoint: 'http://localhost.evil.com' })
+		).toThrow();
+	});
+});

--- a/web/src/lib/db/env-guard.ts
+++ b/web/src/lib/db/env-guard.ts
@@ -1,0 +1,28 @@
+/**
+ * DynamoDB client 構築前の env 安全判定 (#125)。
+ *
+ * Lambda 環境 (= AWS Lambda runtime が `AWS_LAMBDA_FUNCTION_NAME` を自動セットする) または
+ * local endpoint (localhost / 127.0.0.1) のいずれかでないと throw する。
+ *
+ * 目的: dev / preview / CI で env 注入失敗 (例: vite preview が .env.local を process.env に
+ * 注入しない仕様) で AWS SDK が default credential chain に落ちて本番 AWS に到達する事故を防ぐ。
+ *
+ * 純粋関数として抽出 = 単体テスト容易、呼び出し側 (`client.ts`) で signal 取得を行う。
+ */
+
+const LOCAL_ENDPOINT_PATTERN = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/;
+
+export function assertSafeDbEnv(opts: {
+	isLambda: boolean;
+	endpoint: string | null | undefined;
+}): void {
+	if (opts.isLambda) return;
+	const endpoint = opts.endpoint ?? '';
+	if (LOCAL_ENDPOINT_PATTERN.test(endpoint)) return;
+	throw new Error(
+		`Refusing to construct DynamoDB client: not in Lambda ` +
+			`(AWS_LAMBDA_FUNCTION_NAME unset) and AWS_ENDPOINT_URL is not localhost ` +
+			`(got: "${endpoint || '<unset>'}"). ` +
+			`Set AWS_ENDPOINT_URL=http://localhost:8000 in web/.env.local for local dev.`
+	);
+}


### PR DESCRIPTION
## Summary

Local incident: vite preview + Playwright e2e で **本番 DynamoDB に書き込み事故が発生**した root cause を多層防御。

## 変更

### 1. App-level fail-fast guard (\`web/src/lib/db/env-guard.ts\`)

純粋関数 \`assertSafeDbEnv\` を新設、\`client.ts\` で構築前に呼ぶ:

\`\`\`ts
if (!isLambda && !isLocalEndpoint) throw new Error(...)
\`\`\`

- \`isLambda\`: \`AWS_LAMBDA_FUNCTION_NAME\` (AWS Lambda runtime が自動セット) で判定
- \`isLocalEndpoint\`: \`AWS_ENDPOINT_URL\` が \`http://localhost:*\` or \`http://127.0.0.1:*\` で始まる
- 両方 false なら throw、Error message に該当 endpoint と修正手順を含む

7 ケース unit test (Lambda / localhost / 127.0.0.1 / unset / 本番風 endpoint / error message / \`localhost.evil.com\` bypass 防止)。

### 2. Playwright \`webServer.env\` 明示 (\`web/playwright.config.ts\`)

\`\`\`ts
webServer: {
  command: 'pnpm preview ...',
  env: {
    ...process.env,           // PATH / HOME 等を継承
    AWS_ENDPOINT_URL: 'http://localhost:8000',  // 明示で上書き
    AWS_ACCESS_KEY_ID: 'local', ...
  }
}
\`\`\`

host shell に本番 AWS credential があっても test 起動時に \`local\` に上書き → guard も通る → 二重防御。

## 業界標準準拠

- Twelve-Factor App / Config — startup-time env validation
- defense in depth (NIST / OWASP) — 単一防御に頼らない
- Playwright 公式 \`webServer.env\` API
- AWS Lambda runtime env (\`AWS_LAMBDA_FUNCTION_NAME\`) — 公式 docs

## Test plan

- [x] \`pnpm test\` 緑 (151 passed、env-guard 7 新規)
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 spec 緑
- [x] **smoke**: env-unset 状態で built handler 起動 → \`Refusing to construct DynamoDB client\` で即 throw、本番に届かない (\`env -i\` で sandboxed 実行確認済)

## 既知

- \`pnpm check\` で auth.ts:45 の pre-existing 型エラーが残る (CI build-web は通る mystery、本 PR と無関係)

fixes #125