### PR TITLE
fix(ui): button hover で pointer cursor (shadcn base + raw buttons) (fixes #124)

### DIFF
--- a/web/src/lib/components/AvatarDropdown.svelte
+++ b/web/src/lib/components/AvatarDropdown.svelte
@@ -12,7 +12,7 @@
 
 <DropdownMenu.Root>
 	<DropdownMenu.Trigger
-		class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-background text-sm font-semibold transition-colors hover:bg-accent"
+		class="inline-flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-full border border-border bg-background text-sm font-semibold transition-colors hover:bg-accent"
 		aria-label={ariaLabel}
 		title={ariaLabel}
 	>

--- a/web/src/lib/components/LocaleSwitcher.svelte
+++ b/web/src/lib/components/LocaleSwitcher.svelte
@@ -13,7 +13,7 @@
 	onclick={cycle}
 	aria-label={t('locale.label')}
 	title={t('locale.label')}
-	class="inline-flex h-9 shrink-0 items-center justify-center gap-1 rounded-md border border-border bg-background px-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
+	class="inline-flex h-9 shrink-0 cursor-pointer items-center justify-center gap-1 rounded-md border border-border bg-background px-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
 >
 	<Translate size={18} weight="regular" aria-hidden="true" />
 	<span class="text-xs">{localeState.current === 'ja' ? 'JA' : 'EN'}</span>

--- a/web/src/lib/components/LocaleSwitcher.svelte.test.ts
+++ b/web/src/lib/components/LocaleSwitcher.svelte.test.ts
@@ -36,4 +36,9 @@ describe('LocaleSwitcher (smoke)', () => {
 		const cls = btn.className;
 		expect(cls).toMatch(/focus-visible:ring/);
 	});
+
+	it('has cursor-pointer class consistent with shadcn Button (#124)', () => {
+		const { getByRole } = render(LocaleSwitcher);
+		expect(getByRole('button').className).toMatch(/\bcursor-pointer\b/);
+	});
 });

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -31,7 +31,7 @@
 	onclick={cycle}
 	aria-label={label}
 	title={label}
-	class="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
+	class="inline-flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center rounded-md border border-border bg-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none"
 >
 	{#if userPrefersMode.current === 'light'}
 		<Sun size={18} weight="regular" aria-hidden="true" />

--- a/web/src/lib/components/ThemeToggle.svelte.test.ts
+++ b/web/src/lib/components/ThemeToggle.svelte.test.ts
@@ -30,4 +30,9 @@ describe('ThemeToggle (smoke)', () => {
 		const btn = getByRole('button');
 		expect(btn.className).toMatch(/focus-visible:ring/);
 	});
+
+	it('has cursor-pointer class consistent with shadcn Button (#124)', () => {
+		const { getByRole } = render(ThemeToggle);
+		expect(getByRole('button').className).toMatch(/\bcursor-pointer\b/);
+	});
 });

--- a/web/src/lib/components/ui/button/button.svelte
+++ b/web/src/lib/components/ui/button/button.svelte
@@ -4,7 +4,7 @@
 	import { type VariantProps, tv } from 'tailwind-variants';
 
 	export const buttonVariants = tv({
-		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-none border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-none border border-transparent bg-clip-padding text-xs font-medium focus-visible:ring-1 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-1 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 cursor-pointer items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
 		variants: {
 			variant: {
 				default: 'bg-primary text-primary-foreground [a]:hover:bg-primary/80',

--- a/web/src/lib/components/ui/button/button.svelte.test.ts
+++ b/web/src/lib/components/ui/button/button.svelte.test.ts
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { buttonVariants } from './button.svelte';
+import { Button } from './index.js';
+
+/**
+ * #124: shadcn Button を hover した時に pointer cursor が出るよう class に `cursor-pointer` を含める。
+ * disabled 時は `cursor-not-allowed` で意味的に分ける (現状 disabled は `pointer-events: none` で
+ * hover 自体無効化されるが、コンテキストメニュー等で visible になる時のために慣例を守る)。
+ *
+ * children prop は Snippet 型を要求するので、test は `buttonVariants` ヘルパで生成した
+ * class string を直接 assert する (render は 1 ケースだけ smoke として残す)。
+ */
+describe('Button cursor (#124)', () => {
+	it('base class includes cursor-pointer', () => {
+		expect(buttonVariants()).toMatch(/\bcursor-pointer\b/);
+	});
+
+	it('base class includes disabled:cursor-not-allowed', () => {
+		expect(buttonVariants()).toMatch(/disabled:cursor-not-allowed/);
+	});
+
+	it('outline variant also has cursor-pointer (inherited from base)', () => {
+		expect(buttonVariants({ variant: 'outline' })).toMatch(/\bcursor-pointer\b/);
+	});
+
+	it('destructive variant also has cursor-pointer (inherited from base)', () => {
+		expect(buttonVariants({ variant: 'destructive' })).toMatch(/\bcursor-pointer\b/);
+	});
+
+	it('rendered Button DOM has cursor-pointer class (smoke)', () => {
+		const { getByRole } = render(Button);
+		expect(getByRole('button').className).toMatch(/\bcursor-pointer\b/);
+	});
+});

--- a/web/src/routes/sign-in/+page.svelte
+++ b/web/src/routes/sign-in/+page.svelte
@@ -48,7 +48,7 @@
 		<button
 			type="submit"
 			disabled={submitting}
-			class="w-full rounded bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none disabled:opacity-60"
+			class="w-full cursor-pointer rounded bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:border-ring focus-visible:ring-1 focus-visible:ring-ring/50 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
 		>
 			{submitting ? t('signin.submitting') : t('signin.submit')}
 		</button>

--- a/web/src/routes/sign-in/page.svelte.test.ts
+++ b/web/src/routes/sign-in/page.svelte.test.ts
@@ -77,4 +77,10 @@ describe('sign-in +page.svelte — email input must remain in form data on submi
 		const submitBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
 		expect(submitBtn.className).toMatch(/focus-visible:ring/);
 	});
+
+	it('submit button has cursor-pointer class (#124)', () => {
+		const { container } = render(SignInPage, { props: { data: stubData() } });
+		const submitBtn = container.querySelector('button[type="submit"]') as HTMLButtonElement;
+		expect(submitBtn.className).toMatch(/\bcursor-pointer\b/);
+	});
 });


### PR DESCRIPTION
## Summary

shadcn Button の base class に \`cursor-pointer\` + \`disabled:cursor-not-allowed\`、raw \`<button>\` (LocaleSwitcher / ThemeToggle / sign-in submit / AvatarDropdown trigger) にも同じく追加。

shadcn-svelte 本家は UA default を尊重して付けない方針だが、本プロダクトのヘッダで「クリックできる」 視覚的フィードバックが弱かったため独自に追加。

## Test plan

- [x] \`pnpm test\` 緑 (159 passed)
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑
- [ ] **本番反映後 manual**: ResourceManager / ProjectManager / AvatarDropdown / ThemeToggle / LocaleSwitcher / sign-in submit 全てで hover → pointer cursor

fixes #124