### PR TITLE
feat(sign-in): /sign-in 系に ThemeToggle / LocaleSwitcher 追加 (fixes #123)

### DIFF
--- a/web/src/routes/sign-in/+layout.svelte
+++ b/web/src/routes/sign-in/+layout.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import ThemeToggle from '$lib/components/ThemeToggle.svelte';
+	import LocaleSwitcher from '$lib/components/LocaleSwitcher.svelte';
+
+	let { children } = $props();
+</script>
+
+<!--
+	#123: /sign-in 系ページ (= /sign-in, /sign-in/check-email, /sign-in/error) で
+	テーマ・言語切替を右上に常時表示する。各 page は max-w-md で中央寄せなので
+	fixed right-top と被らない。z-40 で modal overlay より下に置く (sign-in 系では
+	modal は無いが、将来 alert dialog を入れた時の overlay 衝突を避けるため)。
+-->
+<div
+	class="fixed right-4 top-4 z-40 flex items-center gap-2"
+	data-testid="signin-layout-toggles"
+>
+	<LocaleSwitcher />
+	<ThemeToggle />
+</div>
+
+{@render children?.()}

--- a/web/src/routes/sign-in/layout.svelte.test.ts
+++ b/web/src/routes/sign-in/layout.svelte.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import SignInLayout from './+layout.svelte';
+
+/**
+ * #123: /sign-in 系ページに ThemeToggle / LocaleSwitcher を右上 corner で表示する。
+ * /sign-in / /sign-in/check-email / /sign-in/error すべてに継承される shared layout。
+ */
+describe('/sign-in +layout.svelte (#123)', () => {
+	it('renders both ThemeToggle and LocaleSwitcher in a fixed right-top container', () => {
+		const { container } = render(SignInLayout);
+		// ThemeToggle: aria-label に "theme" or "テーマ" を含む
+		const themeBtn = container.querySelector('button[aria-label*="テーマ"], button[aria-label*="theme" i]');
+		expect(themeBtn).toBeTruthy();
+		// LocaleSwitcher: aria-label に "言語" or "language" を含む
+		const localeBtn = container.querySelector(
+			'button[aria-label*="言語"], button[aria-label*="language" i]'
+		);
+		expect(localeBtn).toBeTruthy();
+	});
+
+	it('wraps the toggles in a fixed-position container at right-top so they overlay any page content', () => {
+		const { container } = render(SignInLayout);
+		const wrapper = container.querySelector('[data-testid="signin-layout-toggles"]');
+		expect(wrapper).toBeTruthy();
+		const cls = wrapper!.className;
+		expect(cls).toMatch(/\bfixed\b/);
+		expect(cls).toMatch(/right-/);
+		expect(cls).toMatch(/top-/);
+		expect(cls).toMatch(/\bz-/);
+	});
+});


### PR DESCRIPTION
## Summary

\`/sign-in\` 系ページ (= \`/sign-in\`, \`/sign-in/check-email\`, \`/sign-in/error\`) 共通の \`+layout.svelte\` を新設し、ThemeToggle + LocaleSwitcher を **右上 corner に固定** で表示。

未認証の user でもダーク/ライト・日本語/英語を選べる。

## Test plan

- [x] \`pnpm test\` 153 緑 (+2 新規)
- [x] \`pnpm check\` 緑 (pre-existing auth.ts:45 のみ、本 PR と無関係)
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑
- [ ] **本番反映後 manual**:
  - \`/sign-in\` 右上の言語 / テーマ button をクリック → 即時反映、ホーム到達後も継続
  - \`/sign-in/check-email\` でも同じ button が見える
  - \`/sign-in/error\` (e.g., \`?error=AccessDenied\`) でも

fixes #123