### PR TITLE
feat(ux): Resource create を optimistic UI 化 (#121 PoC)

### DIFF
--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -10,10 +10,17 @@
 
 	let {
 		resources,
-		assignments
+		assignments,
+		onOptimisticCreate,
+		onConfirmCreate,
+		onRollbackCreate
 	}: {
 		resources: Resource[];
 		assignments: Assignment[];
+		/** #121 optimistic UI hooks。create 時に temp → server entity の swap を親で行う。 */
+		onOptimisticCreate?: (temp: Resource) => void;
+		onConfirmCreate?: (temp: Resource, real: Resource) => void;
+		onRollbackCreate?: (temp: Resource) => void;
 	} = $props();
 
 	/** 各 Resource に紐づく Assignment 数 (cascade delete 時の警告で使う、UC-06) */
@@ -49,9 +56,39 @@
 		formOpen = true;
 	}
 
-	const formSubmit: SubmitFunction = formSubmitState.wrap(() => {
+	/**
+	 * Optimistic UI for create (#121):
+	 * - submit 前に temp ID 付きの Resource を親 state に即時追加 (dialog も即時 close)
+	 * - server success → 親で temp → real swap、`update()` は不要 (refetch 回避)
+	 * - server failure → 親で temp 削除 + 親側で toast、form は再 open しないので入力は失う設計
+	 *   (HTML5 required / maxlength でクライアント側 validation は通過済の前提)
+	 * Update path (editing 時) は従来通り `update()` で invalidateAll、後続 PR で同 pattern 化候補。
+	 */
+	let pendingTemp: Resource | null = null;
+
+	const formSubmit: SubmitFunction = formSubmitState.wrap(({ formData }) => {
 		formError = null;
+		const isCreate = !editing && !!onOptimisticCreate;
+		if (isCreate) {
+			const name = (formData.get('name') ?? '').toString().trim();
+			if (name.length > 0) {
+				pendingTemp = { id: `temp-${crypto.randomUUID()}`, name };
+				onOptimisticCreate(pendingTemp);
+				formOpen = false; // dialog 即時 close
+			}
+		}
 		return async ({ result, update }) => {
+			if (isCreate && pendingTemp) {
+				const tempSnapshot = pendingTemp;
+				pendingTemp = null;
+				if (result.type === 'success') {
+					const real = (result.data as { resource?: Resource })?.resource;
+					if (real && onConfirmCreate) onConfirmCreate(tempSnapshot, real);
+				} else {
+					if (onRollbackCreate) onRollbackCreate(tempSnapshot);
+				}
+				return; // optimistic は update() 不要
+			}
 			if (result.type === 'success') {
 				formOpen = false;
 				editing = null;

--- a/web/src/lib/components/ResourceManager.svelte.test.ts
+++ b/web/src/lib/components/ResourceManager.svelte.test.ts
@@ -44,4 +44,29 @@ describe('ResourceManager (smoke)', () => {
 		expect(trigger.textContent).not.toMatch(/👥/);
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/人を管理/);
 	});
+
+	/**
+	 * #121: optimistic UI props を受け取り、create flow で callback を発火する。
+	 * 詳細な DOM 駆動 test は use:enhance の SubmitFunction 内部実装 + bits-ui Dialog の
+	 * portal 越しになり jsdom で安定再現しづらいため、callbacks の prop signature だけ assert する。
+	 */
+	it('accepts optimistic create callbacks as props (#121 contract)', () => {
+		const onOptimisticCreate = (_temp: { id: string; name: string }) => {};
+		const onConfirmCreate = (
+			_temp: { id: string },
+			_real: { id: string; name: string }
+		) => {};
+		const onRollbackCreate = (_temp: { id: string }) => {};
+		const result = render(ResourceManager, {
+			props: {
+				resources: [],
+				assignments: [],
+				onOptimisticCreate,
+				onConfirmCreate,
+				onRollbackCreate
+			}
+		});
+		// レンダリングが壊れないことを確認 (callback は実行されない)
+		expect(result.getByRole('button', { name: /人を管理/ })).toBeInTheDocument();
+	});
 });

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -38,7 +38,8 @@
 		"name": "Name",
 		"assignmentCount": "({count} assignments)",
 		"confirmDelete": "Delete \"{name}\"?",
-		"confirmDeleteWithAssignments": "Delete \"{name}\" and {count} related assignments?\n(Cannot be undone)"
+		"confirmDeleteWithAssignments": "Delete \"{name}\" and {count} related assignments?\n(Cannot be undone)",
+		"createFailed": "Failed to add the person. Please try again."
 	},
 	"projects": {
 		"manage": "Manage projects",

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -38,7 +38,8 @@
 		"name": "名前",
 		"assignmentCount": "({count} 件のアサイン)",
 		"confirmDelete": "「{name}」を削除しますか?",
-		"confirmDeleteWithAssignments": "「{name}」と関連 {count} 件のアサインを削除しますか?\n(取り消しできません)"
+		"confirmDeleteWithAssignments": "「{name}」と関連 {count} 件のアサインを削除しますか?\n(取り消しできません)",
+		"createFailed": "人の追加に失敗しました。もう一度お試しください。"
 	},
 	"projects": {
 		"manage": "案件を管理",

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -48,8 +48,9 @@ export const actions: Actions = {
 				errors: formatErrors(parsed)
 			});
 		}
-		await createResource(session.teamId, parsed.data);
-		return { action: 'createResource', success: true };
+		// #121: 作成された entity を返して optimistic UI の temp → real swap を可能にする。
+		const resource = await createResource(session.teamId, parsed.data);
+		return { action: 'createResource', success: true, resource };
 	},
 
 	updateResource: async (event) => {

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -32,8 +32,25 @@
 		dbAssignments = data.assignments;
 	});
 
-	const resources = $derived(data.resources);
+	// #121: optimistic UI 用に resources / projects も local state へ lift。
+	// load 再実行で `data.resources` が更新されたら sync (= 楽観的更新 → server confirm 後に
+	// invalidate されたら server truth に rebase される)。
+	let resources = $state<typeof data.resources>([]);
+	$effect(() => {
+		resources = data.resources;
+	});
 	const projects = $derived(data.projects);
+
+	function optimisticAddResource(temp: { id: string; name: string }) {
+		resources = [...resources, temp];
+	}
+	function confirmResourceCreate(temp: { id: string }, real: { id: string; name: string }) {
+		resources = resources.map((r) => (r.id === temp.id ? real : r));
+	}
+	function rollbackResourceCreate(temp: { id: string }) {
+		resources = resources.filter((r) => r.id !== temp.id);
+		toast.error(t('resources.createFailed'));
+	}
 	const projectMap = $derived(new Map(projects.map((p) => [p.id, p])));
 
 	const timelineAssignments = $derived(
@@ -101,7 +118,13 @@
 	<div class="mx-auto flex max-w-[1200px] flex-wrap items-center justify-between gap-2 px-4 py-3">
 		<h1 class="m-0 text-lg font-semibold tracking-tight sm:text-xl">{t('app.title')}</h1>
 		<div class="flex flex-wrap items-center gap-2">
-			<ResourceManager {resources} assignments={dbAssignments} />
+			<ResourceManager
+				{resources}
+				assignments={dbAssignments}
+				onOptimisticCreate={optimisticAddResource}
+				onConfirmCreate={confirmResourceCreate}
+				onRollbackCreate={rollbackResourceCreate}
+			/>
 			<ProjectManager {projects} assignments={dbAssignments} />
 			<AssignmentCreator {resources} {projects} />
 			<AssignmentManager assignments={dbAssignments} {resources} {projects} />

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -12,13 +12,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 const requireSessionMock = vi.fn();
 const updateAssignmentMock = vi.fn();
+const createResourceMock = vi.fn();
 
 vi.mock('$lib/auth', () => ({
 	requireSession: (event: unknown) => requireSessionMock(event)
 }));
 
 vi.mock('$lib/repository', () => ({
-	createResource: vi.fn(),
+	createResource: (...args: unknown[]) => createResourceMock(...args),
 	updateResource: vi.fn(),
 	deleteResource: vi.fn(),
 	createProject: vi.fn(),
@@ -107,5 +108,39 @@ describe('?/updateAssignment action (#99)', () => {
 		expect(result.status).toBe(400);
 		expect(result.data.errors.prevStartDate).toBeTruthy();
 		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * #121: createResource action は optimistic UI のため、作成された Resource entity を success
+ * result に含めて返す。フロント側で temp ID → real ID への swap に使う。
+ */
+describe('?/createResource action (#121)', () => {
+	beforeEach(() => {
+		requireSessionMock.mockReset().mockResolvedValue({ teamId: 'team_default', userId: 'u1' });
+		createResourceMock.mockReset();
+	});
+
+	it('returns the created resource on success for optimistic UI swap', async () => {
+		createResourceMock.mockResolvedValue({ id: 'res-real-id', name: 'Alice' });
+		const event = makeEvent({ name: 'Alice' });
+		const result = (await actions.createResource!(event)) as {
+			action: string;
+			success: boolean;
+			resource: { id: string; name: string };
+		};
+		expect(result.action).toBe('createResource');
+		expect(result.success).toBe(true);
+		expect(result.resource).toEqual({ id: 'res-real-id', name: 'Alice' });
+	});
+
+	it('still returns 400 failure for invalid name (no resource in result)', async () => {
+		const event = makeEvent({ name: '' });
+		const result = (await actions.createResource!(event)) as {
+			status: number;
+			data: { errors: Record<string, string> };
+		};
+		expect(result.status).toBe(400);
+		expect(createResourceMock).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Resource create を **optimistic UI** 化。本番 Lambda の 500-2000ms の round-trip を待たずに dialog 即 close + list 即時反映。失敗時は revert + toast。

## 設計 (#121 spec 通り)

1. \`?/createResource\` action が **作成された entity** を success result に含めて返す
2. \`+page.svelte\` で \`resources\` を \`\$state\` に lift (既存 \`dbAssignments\` 同様 \`\$effect\` で data.resources sync)
3. \`ResourceManager\` に 3 つの **optional callback** 追加:
   - \`onOptimisticCreate(temp)\` — submit 前に temp ID で親 state に即時追加
   - \`onConfirmCreate(temp, real)\` — success result の \`resource\` を swap
   - \`onRollbackCreate(temp)\` — failure 時に温度を除去
4. ResourceManager の formSubmit が callbacks を呼んで dialog 即 close
5. **\`await update()\` は optimistic path で skip** (invalidate 不要、temp swap 完了)

## scope (PoC)

- ✅ Resource **create のみ**
- ⏭ Resource update / delete、Project の全 CRUD、Assignment edit は今回は対象外、後続 PR で同 pattern 展開

## Test plan

- [x] \`?/createResource\` action test: success result に \`resource\` を含む (zod validation fail はそのまま)
- [x] \`ResourceManager\` contract test: 3 callbacks を prop で受け取って render 壊れず
- [x] \`pnpm test\` 164 緑
- [x] \`pnpm check\` 緑 (pre-existing auth.ts:45)
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑
- [ ] **本番反映後 manual**:
  - 「人を管理」 → 「+ 人を追加」 → 名前入力 → 「追加」 → **dialog 即 close + リストに即時表示**
  - server confirm 後 (200ms 程度後) に temp ID → 実 ID へ swap (体感差なし)
  - わざと network 切ってリトライ → 短時間で消えて toast 表示

fixes #121