### PR TITLE
fix(i18n): 削除 confirm dialog の OK/Cancel を app i18n に揃える (fixes #132)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
 		"@eslint/compat": "^2.0.4",
 		"@eslint/js": "^10.0.1",
 		"@fontsource-variable/jetbrains-mono": "^5.2.8",
+		"@internationalized/date": "^3.12.1",
 		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/kit": "^2.57.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
+      '@internationalized/date':
+        specifier: ^3.12.1
+        version: 3.12.1
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1

--- a/web/src/lib/components/ConfirmDialog.svelte
+++ b/web/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import * as AlertDialog from './ui/alert-dialog';
+	import { Button, buttonVariants } from './ui/button';
+	import { cn } from '$lib/utils.js';
+	import { t } from '$lib/i18n/index.svelte';
+	import { confirmRequest, resolveConfirm } from '$lib/forms/confirm-dialog';
+
+	const open = $derived($confirmRequest !== null);
+	const req = $derived($confirmRequest);
+</script>
+
+<AlertDialog.Root
+	{open}
+	onOpenChange={(next) => {
+		// 外側クリック / Escape で閉じた = cancel 扱い
+		if (!next && req) resolveConfirm(false);
+	}}
+>
+	<AlertDialog.Portal>
+		<AlertDialog.Overlay />
+		<AlertDialog.Content>
+			{#if req}
+				<AlertDialog.Header>
+					<AlertDialog.Title>{req.title}</AlertDialog.Title>
+					<AlertDialog.Description class="whitespace-pre-line">
+						{req.message}
+					</AlertDialog.Description>
+				</AlertDialog.Header>
+				<AlertDialog.Footer>
+					<AlertDialog.Cancel onclick={() => resolveConfirm(false)}>
+						{req.cancelLabel ?? t('common.cancel')}
+					</AlertDialog.Cancel>
+					<AlertDialog.Action
+						class={cn(
+							buttonVariants({ variant: req.destructive ? 'destructive' : 'default' })
+						)}
+						onclick={() => resolveConfirm(true)}
+					>
+						{req.confirmLabel ?? t('common.confirm')}
+					</AlertDialog.Action>
+				</AlertDialog.Footer>
+			{/if}
+		</AlertDialog.Content>
+	</AlertDialog.Portal>
+</AlertDialog.Root>

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -4,6 +4,7 @@
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { confirmDialog } from '$lib/forms/confirm-dialog';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Project, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -50,9 +51,8 @@
 		formOpen = true;
 	}
 
-	// 連打抑制 + submitting state (#94)
+	// 連打抑制 + submitting state (#94)。delete は #132 で confirm dialog が modal ブロックする。
 	const formSubmitState = createSubmitState();
-	const deleteSubmitState = createSubmitState();
 
 	const formSubmit: SubmitFunction = formSubmitState.wrap(() => {
 		formError = null;
@@ -68,7 +68,22 @@
 		};
 	});
 
-	const deleteSubmit: SubmitFunction = deleteSubmitState.wrap();
+	/** #132: project の delete 確認 dialog (window.confirm の代替)。 */
+	function makeDeleteSubmit(args: { name: string; count: number }): SubmitFunction {
+		return async ({ cancel }) => {
+			const msg =
+				args.count > 0
+					? t('projects.confirmDeleteWithAssignments', { name: args.name, count: args.count })
+					: t('projects.confirmDelete', { name: args.name });
+			const ok = await confirmDialog({
+				title: t('common.confirm'),
+				message: msg,
+				confirmLabel: t('common.delete'),
+				destructive: true
+			});
+			if (!ok) cancel();
+		};
+	}
 </script>
 
 <Button variant="outline" onclick={() => (listOpen = true)}>
@@ -109,24 +124,10 @@
 							<form
 								method="POST"
 								action="?/deleteProject"
-								use:enhance={deleteSubmit}
-								onsubmit={(e) => {
-									const msg =
-										count > 0
-											? t('projects.confirmDeleteWithAssignments', { name: p.name, count })
-											: t('projects.confirmDelete', { name: p.name });
-									if (!confirm(msg)) {
-										e.preventDefault();
-									}
-								}}
+								use:enhance={makeDeleteSubmit({ name: p.name, count })}
 							>
 								<input type="hidden" name="id" value={p.id} />
-								<Button
-									size="xs"
-									variant="destructive"
-									type="submit"
-									disabled={deleteSubmitState.submitting}
-								>
+								<Button size="xs" variant="destructive" type="submit">
 									{t('common.delete')}
 								</Button>
 							</form>

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -4,6 +4,7 @@
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { confirmDialog } from '$lib/forms/confirm-dialog';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Resource, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -38,9 +39,8 @@
 	let formName = $state('');
 	let formError = $state<string | null>(null);
 
-	// 連打抑制 + submitting state (#94)。create / update form と delete form でそれぞれ独立に管理。
+	// 連打抑制 + submitting state (#94)。create / update form 用 (delete は #132 で confirm dialog が modal ブロックするため不要)。
 	const formSubmitState = createSubmitState();
-	const deleteSubmitState = createSubmitState();
 
 	function startCreate() {
 		editing = null;
@@ -100,7 +100,27 @@
 		};
 	});
 
-	const deleteSubmit: SubmitFunction = deleteSubmitState.wrap();
+	/**
+	 * #132: delete 押下時に confirmDialog (= bits-ui AlertDialog、i18n 完全対応) を await し、
+	 * cancel 押下なら enhance の cancel() で form action 自体を抑止する。
+	 * window.confirm の OS-native ボタンが locale に乗らない問題の代替。連打抑制は dialog が
+	 * modal で UI ブロックするので submit-state wrap 不要。
+	 */
+	function makeDeleteSubmit(args: { name: string; count: number }): SubmitFunction {
+		return async ({ cancel }) => {
+			const msg =
+				args.count > 0
+					? t('resources.confirmDeleteWithAssignments', { name: args.name, count: args.count })
+					: t('resources.confirmDelete', { name: args.name });
+			const ok = await confirmDialog({
+				title: t('common.confirm'),
+				message: msg,
+				confirmLabel: t('common.delete'),
+				destructive: true
+			});
+			if (!ok) cancel();
+		};
+	}
 </script>
 
 <Button variant="outline" onclick={() => (listOpen = true)}>
@@ -136,24 +156,13 @@
 							<form
 								method="POST"
 								action="?/deleteResource"
-								use:enhance={deleteSubmit}
-								onsubmit={(e) => {
-									const msg =
-										count > 0
-											? t('resources.confirmDeleteWithAssignments', { name: r.name, count })
-											: t('resources.confirmDelete', { name: r.name });
-									if (!confirm(msg)) {
-										e.preventDefault();
-									}
-								}}
+								use:enhance={makeDeleteSubmit({
+									name: r.name,
+									count
+								})}
 							>
 								<input type="hidden" name="id" value={r.id} />
-								<Button
-									size="xs"
-									variant="destructive"
-									type="submit"
-									disabled={deleteSubmitState.submitting}
-								>
+								<Button size="xs" variant="destructive" type="submit">
 									{t('common.delete')}
 								</Button>
 							</form>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-action.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import {
+		buttonVariants,
+		type ButtonVariant,
+		type ButtonSize,
+	} from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "default",
+		size = "default",
+		...restProps
+	}: AlertDialogPrimitive.ActionProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Action
+	bind:ref
+	data-slot="alert-dialog-action"
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-action", className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-cancel.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import {
+		buttonVariants,
+		type ButtonVariant,
+		type ButtonSize,
+	} from "$lib/components/ui/button/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		variant = "outline",
+		size = "default",
+		...restProps
+	}: AlertDialogPrimitive.CancelProps & {
+		variant?: ButtonVariant;
+		size?: ButtonSize;
+	} = $props();
+</script>
+
+<AlertDialogPrimitive.Cancel
+	bind:ref
+	data-slot="alert-dialog-cancel"
+	class={cn(buttonVariants({ variant, size }), "cn-alert-dialog-cancel", className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import AlertDialogPortal from "./alert-dialog-portal.svelte";
+	import AlertDialogOverlay from "./alert-dialog-overlay.svelte";
+	import { cn, type WithoutChild, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		size = "default",
+		portalProps,
+		...restProps
+	}: WithoutChild<AlertDialogPrimitive.ContentProps> & {
+		size?: "default" | "sm";
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof AlertDialogPortal>>;
+	} = $props();
+</script>
+
+<AlertDialogPortal {...portalProps}>
+	<AlertDialogOverlay />
+	<AlertDialogPrimitive.Content
+		bind:ref
+		data-slot="alert-dialog-content"
+		data-size={size}
+		class={cn(
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-none p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			className
+		)}
+		{...restProps}
+	/>
+</AlertDialogPortal>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.DescriptionProps = $props();
+</script>
+
+<AlertDialogPrimitive.Description
+	bind:ref
+	data-slot="alert-dialog-description"
+	class={cn("text-muted-foreground *:[a]:hover:text-foreground text-xs/relaxed text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3", className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-footer.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-footer"
+	class={cn(
+		"cn-alert-dialog-footer flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-header"
+	class={cn("grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-media.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-media.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="alert-dialog-media"
+	class={cn("bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-none sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.OverlayProps = $props();
+</script>
+
+<AlertDialogPrimitive.Overlay
+	bind:ref
+	data-slot="alert-dialog-overlay"
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ...restProps }: AlertDialogPrimitive.PortalProps = $props();
+</script>
+
+<AlertDialogPrimitive.Portal {...restProps} />

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: AlertDialogPrimitive.TitleProps = $props();
+</script>
+
+<AlertDialogPrimitive.Title
+	bind:ref
+	data-slot="alert-dialog-title"
+	class={cn("text-sm font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2", className)}
+	{...restProps}
+/>

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: AlertDialogPrimitive.TriggerProps = $props();
+</script>
+
+<AlertDialogPrimitive.Trigger bind:ref data-slot="alert-dialog-trigger" {...restProps} />

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { AlertDialog as AlertDialogPrimitive } from "bits-ui";
+
+	let { open = $bindable(false), ...restProps }: AlertDialogPrimitive.RootProps = $props();
+</script>
+
+<AlertDialogPrimitive.Root bind:open {...restProps} />

--- a/web/src/lib/components/ui/alert-dialog/index.ts
+++ b/web/src/lib/components/ui/alert-dialog/index.ts
@@ -1,0 +1,40 @@
+import Root from "./alert-dialog.svelte";
+import Portal from "./alert-dialog-portal.svelte";
+import Trigger from "./alert-dialog-trigger.svelte";
+import Title from "./alert-dialog-title.svelte";
+import Action from "./alert-dialog-action.svelte";
+import Cancel from "./alert-dialog-cancel.svelte";
+import Footer from "./alert-dialog-footer.svelte";
+import Header from "./alert-dialog-header.svelte";
+import Overlay from "./alert-dialog-overlay.svelte";
+import Content from "./alert-dialog-content.svelte";
+import Description from "./alert-dialog-description.svelte";
+import Media from "./alert-dialog-media.svelte";
+
+export {
+	Root,
+	Title,
+	Action,
+	Cancel,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
+	Description,
+	Media,
+	//
+	Root as AlertDialog,
+	Title as AlertDialogTitle,
+	Action as AlertDialogAction,
+	Cancel as AlertDialogCancel,
+	Portal as AlertDialogPortal,
+	Footer as AlertDialogFooter,
+	Header as AlertDialogHeader,
+	Trigger as AlertDialogTrigger,
+	Overlay as AlertDialogOverlay,
+	Content as AlertDialogContent,
+	Description as AlertDialogDescription,
+	Media as AlertDialogMedia,
+};

--- a/web/src/lib/forms/confirm-dialog.test.ts
+++ b/web/src/lib/forms/confirm-dialog.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { confirmDialog, confirmRequest, resolveConfirm } from './confirm-dialog';
+
+/**
+ * #132: confirmDialog imperative API の挙動。
+ * - request を store に push
+ * - resolveConfirm(true) で promise が true で resolve
+ * - resolveConfirm(false) で false で resolve、store を clear
+ */
+describe('confirmDialog (#132)', () => {
+	it('pushes a request to the store', () => {
+		const promise = confirmDialog({ title: 'Confirm', message: 'really?' });
+		const req = get(confirmRequest);
+		expect(req).not.toBeNull();
+		expect(req?.title).toBe('Confirm');
+		expect(req?.message).toBe('really?');
+		// resolve to clean up
+		resolveConfirm(false);
+		return promise.then((ok) => expect(ok).toBe(false));
+	});
+
+	it('resolves with true when resolveConfirm(true) is called', async () => {
+		const p = confirmDialog({ title: 'T', message: 'M' });
+		resolveConfirm(true);
+		expect(await p).toBe(true);
+	});
+
+	it('clears the store after resolve', () => {
+		confirmDialog({ title: 'T', message: 'M' });
+		resolveConfirm(false);
+		expect(get(confirmRequest)).toBeNull();
+	});
+
+	it('preserves optional fields confirmLabel / cancelLabel / destructive', () => {
+		confirmDialog({
+			title: 'T',
+			message: 'M',
+			confirmLabel: 'Delete',
+			cancelLabel: 'Keep',
+			destructive: true
+		});
+		const req = get(confirmRequest);
+		expect(req?.confirmLabel).toBe('Delete');
+		expect(req?.cancelLabel).toBe('Keep');
+		expect(req?.destructive).toBe(true);
+		resolveConfirm(false);
+	});
+});

--- a/web/src/lib/forms/confirm-dialog.ts
+++ b/web/src/lib/forms/confirm-dialog.ts
@@ -1,0 +1,44 @@
+/**
+ * confirmDialog (#132)。
+ *
+ * window.confirm の OS-native ボタン (OK / Cancel) が app の i18n に乗らない問題を回避する。
+ * 共有 store に request を積み、root に mount された `<ConfirmDialog />` が読んで AlertDialog を開く。
+ *
+ * Usage:
+ * ```ts
+ * import { confirmDialog } from '$lib/components/ConfirmDialog.svelte';
+ * const ok = await confirmDialog({
+ *   title: t('common.confirm'),
+ *   message: t('resources.confirmDelete', { name }),
+ *   confirmLabel: t('common.delete'),
+ *   destructive: true
+ * });
+ * if (ok) await action();
+ * ```
+ */
+import { writable, type Writable } from 'svelte/store';
+
+export type ConfirmRequest = {
+	title: string;
+	message: string;
+	confirmLabel?: string;
+	cancelLabel?: string;
+	destructive?: boolean;
+};
+
+type Pending = ConfirmRequest & { resolve: (ok: boolean) => void };
+
+export const confirmRequest: Writable<Pending | null> = writable(null);
+
+export function confirmDialog(opts: ConfirmRequest): Promise<boolean> {
+	return new Promise((resolve) => {
+		confirmRequest.set({ ...opts, resolve });
+	});
+}
+
+export function resolveConfirm(ok: boolean): void {
+	confirmRequest.update((req) => {
+		req?.resolve(ok);
+		return null;
+	});
+}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import { ModeWatcher } from 'mode-watcher';
 	import { Toaster } from 'svelte-sonner';
 	import { initLocale } from '$lib/i18n/index.svelte';
+	import ConfirmDialog from '$lib/components/ConfirmDialog.svelte';
 	import type { LayoutData } from './$types';
 
 	let { data, children }: { data: LayoutData; children: import('svelte').Snippet } = $props();
@@ -20,5 +21,8 @@
 <ModeWatcher />
 
 <Toaster richColors closeButton position="top-right" />
+
+<!-- #132: confirmDialog の root mount。app 全体で 1 つだけ。 -->
+<ConfirmDialog />
 
 {@render children()}

--- a/web/src/routes/assignments/+page.svelte
+++ b/web/src/routes/assignments/+page.svelte
@@ -5,7 +5,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import * as Table from '$lib/components/ui/table';
 	import { addDays } from '$lib/date';
-	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { confirmDialog } from '$lib/forms/confirm-dialog';
 	import { t } from '$lib/i18n/index.svelte';
 	import AssignmentEditor from '$lib/components/AssignmentEditor.svelte';
 	import {
@@ -76,8 +76,18 @@
 		editOpen = true;
 	}
 
-	const deleteState = createSubmitState();
-	const deleteSubmit: SubmitFunction = deleteState.wrap();
+	/** #132: assignment の delete 確認 dialog (window.confirm 代替)。 */
+	function makeDeleteSubmit(args: { label: string }): SubmitFunction {
+		return async ({ cancel }) => {
+			const ok = await confirmDialog({
+				title: t('common.confirm'),
+				message: t('assignments.confirmDelete', { label: args.label }),
+				confirmLabel: t('common.delete'),
+				destructive: true
+			});
+			if (!ok) cancel();
+		};
+	}
 
 	function clearFilters() {
 		filters = { q: '', resourceId: '', projectId: '', from: '', to: '' };
@@ -189,22 +199,13 @@
 									<form
 										method="POST"
 										action="/?/deleteAssignment"
-										use:enhance={deleteSubmit}
-										onsubmit={(e) => {
-											const label = `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`;
-											if (!confirm(t('assignments.confirmDelete', { label }))) {
-												e.preventDefault();
-											}
-										}}
+										use:enhance={makeDeleteSubmit({
+											label: `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`
+										})}
 									>
 										<input type="hidden" name="id" value={a.id} />
 										<input type="hidden" name="startDate" value={a.startDate} />
-										<Button
-											size="xs"
-											variant="destructive"
-											type="submit"
-											disabled={deleteState.submitting}
-										>
+										<Button size="xs" variant="destructive" type="submit">
 											{t('common.delete')}
 										</Button>
 									</form>


### PR DESCRIPTION
## Summary

\`window.confirm\` の OS-native ボタン (OK/Cancel) が app の locale 切替に追従しない問題を解決。 shadcn-svelte の AlertDialog (bits-ui ベース) で置換し、ボタンも含めて全テキストを \`t()\` 経由に。

## 動作確認 (実機 screenshot 添付)

| Locale | Title | Cancel button | Confirm button |
|---|---|---|---|
| **ja** | 確認 | キャンセル | 削除 |
| **en** | Confirm | Cancel | Delete |

すべて切替が反映、OS 言語非依存。

## 設計

\`confirmDialog({ title, message, confirmLabel?, cancelLabel?, destructive? }): Promise<boolean>\` の imperative API。 内部:
- \`web/src/lib/forms/confirm-dialog.ts\` で writable store + 解決関数
- \`web/src/lib/components/ConfirmDialog.svelte\` を root の \`+layout.svelte\` に 1 度だけ mount、store 購読して AlertDialog を開閉
- 呼び出し側は \`use:enhance\` SubmitFunction 内で \`await confirmDialog(...)\`、\`cancel()\` で form action 抑止

## 対応箇所

- \`ResourceManager.svelte\` (delete resource)
- \`ProjectManager.svelte\` (delete project)
- \`/assignments/+page.svelte\` (delete assignment)

これら 3 箇所の \`window.confirm\` を完全置換、合わせて使われなくなった \`deleteSubmitState\` (連打抑制) も削除 (modal dialog が UI block するので不要)。

## Test plan

- [x] \`pnpm test\` 178 緑 (confirmDialog store 4 test 追加)
- [x] \`pnpm check\` 緑 (pre-existing auth.ts:45 のみ)
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑
- [x] **実機 visual verify (Playwright MCP)**: ja → 「確認 / キャンセル / 削除」、en → 「Confirm / Cancel / Delete」
- [ ] 本番反映後 manual: ja / en 切替 + 削除 dialog の button が locale 通り

## 関連

- #101 で deferred されていた "window.confirm → AlertDialog 化" 項目
- bits-ui Tooltip (#28 経由 peerDep) と同じ primitive ライブラリ採用

fixes #132