### PR TITLE
fix(security): auth.ts も env guard を通って構築 (Critical: #125 bypass 解消) (fixes #135)

### DIFF
--- a/web/src/auth.ts
+++ b/web/src/auth.ts
@@ -8,6 +8,10 @@
  * - production (Lambda): env.AUTH_SECRET 未設定 + env.AUTH_SECRET_PARAM 設定
  *   → SSM SecureString から resolve、sendVerificationRequest を SES SDK で送信
  */
+// 本番安全 guard を副作用 import で最上位に置く (#135、#125 の強化)。
+// auth.ts は独立に DynamoDBClient を構築 (DDB adapter 経由) するので、 client.ts と同じ
+// guard を必ず通すように import する。これを怠ると Auth.js が本番 DDB に到達する事故が再発する。
+import '$lib/db/guard';
 import { SvelteKitAuth } from '@auth/sveltekit';
 import Nodemailer from '@auth/sveltekit/providers/nodemailer';
 import { DynamoDBAdapter } from '@auth/dynamodb-adapter';

--- a/web/src/lib/db/client.ts
+++ b/web/src/lib/db/client.ts
@@ -1,22 +1,16 @@
+// 本番安全 guard を副作用 import で最上位に置く (#135、#125 の強化)。
+// この副作用 import は client.ts と auth.ts の双方で行うことで、別 DynamoDBClient 経路でも
+// guard を bypass できないことを保証する。
+import './guard';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { building } from '$app/environment';
 import { env } from '$env/dynamic/private';
-import { assertSafeDbEnv } from './env-guard';
 
 // SvelteKit の `analyse` ステップ (postbuild) はサーバーモジュールを top-level 評価するため、
 // build 中は env チェックをスキップする (Lambda 実行時にのみ env が揃う)。
-if (!building) {
-	if (!env.DYNAMODB_TABLE) {
-		throw new Error('DYNAMODB_TABLE env not set');
-	}
-	// 本番安全 guard (#125): Lambda 環境 OR localhost endpoint でないと client 構築を拒否。
-	// vite preview などで .env.local が process.env に注入されないケースで AWS SDK が
-	// default credential chain に落ちて本番 AWS に到達する事故を防ぐ。
-	assertSafeDbEnv({
-		isLambda: !!process.env.AWS_LAMBDA_FUNCTION_NAME,
-		endpoint: env.AWS_ENDPOINT_URL
-	});
+if (!building && !env.DYNAMODB_TABLE) {
+	throw new Error('DYNAMODB_TABLE env not set');
 }
 
 // AWS SDK v3 は AWS_ENDPOINT_URL を自動認識する (v3.385+)。

--- a/web/src/lib/db/guard.ts
+++ b/web/src/lib/db/guard.ts
@@ -1,0 +1,20 @@
+/**
+ * Module-level DynamoDB env guard (#135 で #125 を強化)。
+ *
+ * このモジュールを **副作用 import** する (`import './guard'` または `import '$lib/db/guard'`)
+ * だけで、 module 評価時に `assertSafeDbEnv` が発火する。
+ *
+ * 目的: `client.ts` と `auth.ts` の両方で別々に DynamoDBClient を構築しているため、
+ * guard を片方だけに置くと bypass される。両方の最上位 import に本ファイルを置くことで、
+ * どちらのコードパスでも guard が確実に通る。
+ */
+import { building } from '$app/environment';
+import { env } from '$env/dynamic/private';
+import { assertSafeDbEnv } from './env-guard';
+
+if (!building) {
+	assertSafeDbEnv({
+		isLambda: !!process.env.AWS_LAMBDA_FUNCTION_NAME,
+		endpoint: env.AWS_ENDPOINT_URL
+	});
+}


### PR DESCRIPTION
## Summary

#125 で入れた env guard を **module-level の副作用 import** に昇格 (\`web/src/lib/db/guard.ts\`)、 \`client.ts\` と \`auth.ts\` の双方の **最上位 import** に置いた。 これで Auth.js (User / Session / Account / VerificationToken adapter) 経由でも guard が確実に発火する。

## 動機 (incident 再発リスク)

PR #126 (#125) は \`client.ts\` の module 評価時のみ guard 発火していたが、 \`auth.ts:51\` で別 \`new DynamoDBClient({})\` を生成しており、 Auth.js 経由は guard を bypass できる経路が残っていた。 5/11 の \"Alice\" 本番事故と同種が sign-in flow で再現可能な状態。

## 変更

- \`web/src/lib/db/guard.ts\` (新規): module-level で \`assertSafeDbEnv\` を実行
- \`web/src/lib/db/client.ts\`: 最上位 \`import './guard'\` (重複の inline assert は削除)
- \`web/src/auth.ts\`: 最上位 \`import '\$lib/db/guard'\`

## smoke test (本 PR で実機確認)

\`\`\`bash
env -i PATH=... HOME=... DYNAMODB_TABLE=... AUTH_SECRET=... AUTH_TRUST_HOST=... \\
  ALLOWED_DOMAIN=... EMAIL_FROM=... node build/index.js
# → \"Refusing to construct DynamoDB client\" で即 throw
\`\`\`

\`AWS_ENDPOINT_URL\` 未設定で Auth.js init が走る前に guard が発火することを確認。

## Test plan

- [x] \`pnpm test\` 178 緑 (既存テスト regression なし)
- [x] \`pnpm check\` 緑 (pre-existing auth.ts:49 のみ)
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑
- [x] **smoke**: env unset で built handler 起動 → guard 即 throw

fixes #135