### PR TITLE
fix(ConfirmDialog): 二重 Portal/Overlay 解消 (fixes #137)

### DIFF
--- a/web/src/lib/components/ConfirmDialog.svelte
+++ b/web/src/lib/components/ConfirmDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import * as AlertDialog from './ui/alert-dialog';
-	import { Button, buttonVariants } from './ui/button';
+	import { buttonVariants } from './ui/button';
 	import { cn } from '$lib/utils.js';
 	import { t } from '$lib/i18n/index.svelte';
 	import { confirmRequest, resolveConfirm } from '$lib/forms/confirm-dialog';
@@ -9,6 +9,12 @@
 	const req = $derived($confirmRequest);
 </script>
 
+<!--
+	#137: shadcn-svelte の AlertDialog.Content は内部で Portal + Overlay を mount するため
+	outer に `<AlertDialog.Portal>` / `<AlertDialog.Overlay />` を書くと **二重 Portal / 二重 Overlay**
+	になる (overlay の bg が暗くなる、focus trap 二重発火の risk)。shadcn 公式 example に揃えて
+	Root → Content の直構成にする。
+-->
 <AlertDialog.Root
 	{open}
 	onOpenChange={(next) => {
@@ -16,30 +22,25 @@
 		if (!next && req) resolveConfirm(false);
 	}}
 >
-	<AlertDialog.Portal>
-		<AlertDialog.Overlay />
-		<AlertDialog.Content>
-			{#if req}
-				<AlertDialog.Header>
-					<AlertDialog.Title>{req.title}</AlertDialog.Title>
-					<AlertDialog.Description class="whitespace-pre-line">
-						{req.message}
-					</AlertDialog.Description>
-				</AlertDialog.Header>
-				<AlertDialog.Footer>
-					<AlertDialog.Cancel onclick={() => resolveConfirm(false)}>
-						{req.cancelLabel ?? t('common.cancel')}
-					</AlertDialog.Cancel>
-					<AlertDialog.Action
-						class={cn(
-							buttonVariants({ variant: req.destructive ? 'destructive' : 'default' })
-						)}
-						onclick={() => resolveConfirm(true)}
-					>
-						{req.confirmLabel ?? t('common.confirm')}
-					</AlertDialog.Action>
-				</AlertDialog.Footer>
-			{/if}
-		</AlertDialog.Content>
-	</AlertDialog.Portal>
+	<AlertDialog.Content>
+		{#if req}
+			<AlertDialog.Header>
+				<AlertDialog.Title>{req.title}</AlertDialog.Title>
+				<AlertDialog.Description class="whitespace-pre-line">
+					{req.message}
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+			<AlertDialog.Footer>
+				<AlertDialog.Cancel onclick={() => resolveConfirm(false)}>
+					{req.cancelLabel ?? t('common.cancel')}
+				</AlertDialog.Cancel>
+				<AlertDialog.Action
+					class={cn(buttonVariants({ variant: req.destructive ? 'destructive' : 'default' }))}
+					onclick={() => resolveConfirm(true)}
+				>
+					{req.confirmLabel ?? t('common.confirm')}
+				</AlertDialog.Action>
+			</AlertDialog.Footer>
+		{/if}
+	</AlertDialog.Content>
 </AlertDialog.Root>


### PR DESCRIPTION
## Summary

ConfirmDialog.svelte の outer \`<AlertDialog.Portal>\` + \`<AlertDialog.Overlay />\` 削除 (shadcn-svelte の Content 内部で portal/overlay を mount するため二重に重なっていた)。

\`\`\`diff
-<AlertDialog.Portal>
-  <AlertDialog.Overlay />
-  <AlertDialog.Content>
+<AlertDialog.Content>
   {#if req}
     ...
-  </AlertDialog.Content>
-</AlertDialog.Portal>
+</AlertDialog.Content>
\`\`\`

## 効果

- overlay 1 枚 (bg-black/50 が二重で /100 相当の暗さになっていた → 仕様通り)
- focus trap が単一 mount に
- shadcn-svelte 公式 example と一致

## Test plan

- [x] \`pnpm test\` 178 緑
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑
- [ ] 本番反映後 manual: 削除 dialog 開いて devtools で overlay element 1 枚を確認

fixes #137