### PR TITLE
fix(ui): /assignments back を SPA nav + count badge を常時表示 (fixes #138, #145)

### DIFF
--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -111,11 +111,9 @@
 								aria-hidden="true"
 							></span>
 							{p.name}
-							{#if count > 0}
-								<span class="text-xs text-muted-foreground"
-									>{t('projects.assignmentCount', { count })}</span
-								>
-							{/if}
+							<span class="text-xs text-muted-foreground"
+								>{t('projects.assignmentCount', { count })}</span
+							>
 						</span>
 						<div class="flex gap-1">
 							<Button size="xs" variant="outline" onclick={() => startEdit(p)}

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -143,11 +143,9 @@
 					<li class="flex items-center justify-between gap-2 px-3 py-2">
 						<span class="text-sm">
 							{r.name}
-							{#if count > 0}
-								<span class="ml-1 text-xs text-muted-foreground"
-									>{t('resources.assignmentCount', { count })}</span
-								>
-							{/if}
+							<span class="ml-1 text-xs text-muted-foreground"
+								>{t('resources.assignmentCount', { count })}</span
+							>
 						</span>
 						<div class="flex gap-1">
 							<Button size="xs" variant="outline" onclick={() => startEdit(r)}

--- a/web/src/routes/assignments/+page.svelte
+++ b/web/src/routes/assignments/+page.svelte
@@ -101,9 +101,7 @@
 <main class="mx-auto max-w-[1200px] px-4 py-6">
 	<div class="mb-4 flex items-center justify-between gap-2">
 		<h1 class="text-xl font-semibold">{t('assignments.listTitle')}</h1>
-		<Button variant="outline" onclick={() => (window.location.href = '/')}>
-			{t('errorPage.goHome')}
-		</Button>
+		<Button variant="outline" href="/">{t('errorPage.goHome')}</Button>
 	</div>
 
 	<div class="mb-4 grid grid-cols-1 gap-2 sm:grid-cols-5">


### PR DESCRIPTION
## Summary

UX review で発見した 2 つの小修正をまとめて。

### #138: /assignments \"ホームに戻る\" を SPA nav に

\`\`\`diff
- <Button variant=\"outline\" onclick={() => (window.location.href = '/')}>
- 　{t('errorPage.goHome')}
- </Button>
+ <Button variant=\"outline\" href=\"/\">{t('errorPage.goHome')}</Button>
\`\`\`

full reload を避けて SvelteKit の SPA navigation に。 Auth.js cookie 検証 RT / +layout.server.ts load 再実行 / asset 再 fetch が削減されて 200-500ms snappy。

### #145: assignment count badge を 0 件でも表示

ResourceManager / ProjectManager の \`{#if count > 0}\` ガードを削除。 \"(N 件のアサイン)\" を 0 件でも常時表示することで、 optimistic 追加直後の row も既存 row と同じ pattern に。

## Test plan

- [x] \`pnpm test\` 178 緑
- [x] \`pnpm build\` 緑
- [x] \`CI=1 pnpm test:e2e\` 5 緑

fixes #138, fixes #145