### PR TITLE
fix(theme): resolve mode from cookie on SSR to remove hydration race (#141)

### DIFF
--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -1,10 +1,12 @@
 import type { Locale } from '$lib/i18n/index.svelte';
+import type { Theme } from '$lib/theme';
 
 declare global {
 	namespace App {
 		// interface Error {}
 		interface Locals {
 			locale: Locale;
+			theme: Theme;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { sequence } from '@sveltejs/kit/hooks';
 import type { Handle } from '@sveltejs/kit';
 import { handle as authjsHandle } from './auth';
 import { COOKIE_NAME, pickLocaleFromAcceptLanguage, type Locale } from '$lib/i18n/index.svelte';
+import { pickTheme, THEME_COOKIE_NAME } from '$lib/theme';
 
 /**
  * locale を cookie / Accept-Language から決定して event.locals に格納する hook (#98)。
@@ -23,4 +24,17 @@ const localeHandle: Handle = async ({ event, resolve }) => {
 	});
 };
 
-export const handle: Handle = sequence(authjsHandle, localeHandle);
+/**
+ * theme (light/dark/system) を cookie から決定して event.locals に格納する hook (#141)。
+ * cookie 名は mode-watcher の localStorage key (`mode-watcher-mode`) と揃える。
+ * cookie 無し → 'system' (mode-watcher 既定と一致)。
+ *
+ * SSR で `+layout.server.ts` 経由 `<ModeWatcher defaultMode={data.theme} />` に渡し、
+ * client hydration 時の userPrefersMode 初期値が 'system' に戻る race を消す。
+ */
+const themeHandle: Handle = async ({ event, resolve }) => {
+	event.locals.theme = pickTheme(event.cookies.get(THEME_COOKIE_NAME));
+	return resolve(event);
+};
+
+export const handle: Handle = sequence(authjsHandle, localeHandle, themeHandle);

--- a/web/src/lib/components/ThemeToggle.svelte
+++ b/web/src/lib/components/ThemeToggle.svelte
@@ -4,11 +4,13 @@
 	import Moon from 'phosphor-svelte/lib/Moon';
 	import Monitor from 'phosphor-svelte/lib/Monitor';
 	import { t } from '$lib/i18n/index.svelte';
+	import { THEME_COOKIE_NAME } from '$lib/theme';
 
 	/**
 	 * テーマ切替 (light → dark → system → light、#97)。
-	 * - `mode-watcher` が cookie / localStorage 同期と `<html class="dark">` 反映を担う
-	 * - 初期値は `prefers-color-scheme` + cookie (`+layout.svelte` の `<ModeWatcher />` 経由)
+	 * - `mode-watcher` は localStorage しか書かない → SSR で初期 mode を復元するため、
+	 *   localStorage と同じ key (`mode-watcher-mode`) で cookie も併記する (#141)
+	 * - 初期値は SSR で cookie 復元 → `<ModeWatcher defaultMode={data.theme} />`
 	 * - icon は phosphor (#105 と一貫)
 	 */
 	function cycle() {
@@ -16,6 +18,15 @@
 		const next = current === 'light' ? 'dark' : current === 'dark' ? 'system' : 'light';
 		setMode(next);
 	}
+
+	// userPrefersMode を cookie にミラー (#141)。
+	// setMode 直後だけでなく、初回 hydration で localStorage 由来の mode に確定したタイミング
+	// (cookie が未書込のレガシーユーザー) でも cookie を書くため、$effect で reactive に同期する。
+	$effect(() => {
+		const current = userPrefersMode.current;
+		if (typeof document === 'undefined') return;
+		document.cookie = `${THEME_COOKIE_NAME}=${current}; path=/; max-age=31536000; samesite=lax`;
+	});
 
 	const label = $derived.by(() => {
 		const u = userPrefersMode.current;

--- a/web/src/lib/theme.test.ts
+++ b/web/src/lib/theme.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { pickTheme, THEME_COOKIE_NAME } from './theme';
+
+/**
+ * #141: SSR で theme cookie を読む純粋関数のテスト。
+ * mode-watcher の localStorage と並列で書き込んだ cookie 値を server で復元する。
+ */
+describe('pickTheme (#141)', () => {
+	it('returns light / dark / system for valid values', () => {
+		expect(pickTheme('light')).toBe('light');
+		expect(pickTheme('dark')).toBe('dark');
+		expect(pickTheme('system')).toBe('system');
+	});
+
+	it('falls back to system for missing or invalid input', () => {
+		expect(pickTheme(undefined)).toBe('system');
+		expect(pickTheme('')).toBe('system');
+		expect(pickTheme('Dark')).toBe('system');
+		expect(pickTheme('rainbow')).toBe('system');
+	});
+
+	it('uses the mode-watcher cookie name so localStorage and cookie stay aligned', () => {
+		expect(THEME_COOKIE_NAME).toBe('mode-watcher-mode');
+	});
+});

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,20 @@
+/**
+ * theme cookie helper (#141)。
+ *
+ * mode-watcher は localStorage のみで mode を持つので、SSR で初期 theme を知るには
+ * ThemeToggle 側で localStorage と同期した cookie を書く必要がある。本ファイルは
+ * その cookie 名と server 側のパース関数を提供する。
+ *
+ * cookie 名は mode-watcher の `modeStorageKey` (デフォルト `mode-watcher-mode`) と揃える
+ * — 1 つの kebab-case key で localStorage と cookie の両方を管理する。
+ */
+export type Theme = 'light' | 'dark' | 'system';
+
+export const THEME_COOKIE_NAME = 'mode-watcher-mode';
+
+export function pickTheme(cookieValue: string | null | undefined): Theme {
+	if (cookieValue === 'light' || cookieValue === 'dark' || cookieValue === 'system') {
+		return cookieValue;
+	}
+	return 'system';
+}

--- a/web/src/routes/+layout.server.ts
+++ b/web/src/routes/+layout.server.ts
@@ -5,12 +5,13 @@ import type { LayoutServerLoad } from './$types';
 export const load: LayoutServerLoad = async (event) => {
 	const session = await event.locals.auth();
 	const locale = event.locals.locale;
+	const theme = event.locals.theme;
 
 	// 未認証なら sign-in ページへ送る (#65 / #87、Clerk 撤去後)。
 	// /sign-in 系ページ自体は authenticated でも accessible (Auth.js 側で適切にハンドル)。
 	if (!session?.user?.id) {
 		if (event.url.pathname.startsWith('/sign-in') || event.url.pathname.startsWith('/auth')) {
-			return { locale, resources: [], projects: [], assignments: [] };
+			return { locale, theme, resources: [], projects: [], assignments: [] };
 		}
 		redirect(303, '/sign-in');
 	}
@@ -21,6 +22,7 @@ export const load: LayoutServerLoad = async (event) => {
 
 	return {
 		locale,
+		theme,
 		user: { id: session.user.id, email: session.user.email, name: session.user.name },
 		...data
 	};

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -17,8 +17,12 @@
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
 
-<!-- mode-watcher (#97): light / dark / system theme を <html class> + cookie で同期 -->
-<ModeWatcher />
+<!--
+  mode-watcher (#97): light / dark / system theme を <html class> + cookie で同期。
+  #141: SSR で cookie から復元した data.theme を defaultMode に渡し、hydration 時の
+  userPrefersMode 初期値が 'system' に戻る race を防ぐ。
+-->
+<ModeWatcher defaultMode={data.theme} />
 
 <Toaster richColors closeButton position="top-right" />
 

--- a/web/src/routes/sign-in/page.svelte.test.ts
+++ b/web/src/routes/sign-in/page.svelte.test.ts
@@ -15,6 +15,7 @@ import type { PageData } from './$types';
 const stubData = (): PageData => ({
 	csrfToken: 'test-csrf',
 	locale: 'ja',
+	theme: 'system',
 	resources: [],
 	projects: [],
 	assignments: []


### PR DESCRIPTION
## Summary

- mode-watcher は localStorage のみで mode を保持 → SSR で初期値が分からず、`<ModeWatcher />` の `defaultMode='system'` が hydration で一瞬適用される race が出ていた (実機 UX レビューで観測)
- ThemeToggle が setMode と並行で `mode-watcher-mode` cookie に書き出すよう変更 ($effect で reactive、既存ユーザーは初回 hydration で localStorage → cookie へ自動 migrate)
- `hooks.server.ts` に `themeHandle` を追加して `event.locals.theme` に注入 → `+layout.server.ts` 経由で `<ModeWatcher defaultMode={data.theme} />` に渡す (localeHandle と同じ SSR-aware パターン)

## Test plan

- [x] `pnpm test` 緑 (`theme.test.ts` 3 件含む 175 件)
- [x] `pnpm check` で本 PR 由来のエラー無し (auth.ts の既存エラーは別件)
- [ ] /sign-in → ThemeToggle で dark に切替 → /sign-in/error に遷移しても label が "テーマ: ダーク" のまま (race 消失)
- [ ] DevTools で cookie `mode-watcher-mode=dark` が path=/ で書き込まれていること
- [ ] cookie / localStorage 両方クリア → defaultMode='system' で初回描画

fixes #141