### PR TITLE
fix(ConfirmDialog): raise AlertDialog above shadcn Dialog so destructive confirms stay clickable

### DIFF
--- a/web/e2e/delete-flow.spec.ts
+++ b/web/e2e/delete-flow.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+import { clearMagicLinks, getMagicLinkUrl } from './fixtures/magic-link';
+
+/**
+ * #132 / #148 で導入した imperative confirmDialog の表示 regression を防ぐ E2E。
+ *
+ * 元々の単体 test (src/lib/forms/confirm-dialog.test.ts) は store API のみで、
+ * `<ConfirmDialog />` を mount したときに body へ Portal される
+ * `role="alertdialog"` が画面に出るかは jsdom でも見れない (Portal target は body)。
+ * 実機の bits-ui Portal + shadcn の Content の組み合わせがちゃんと render
+ * されるところまでをここで保証する。
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async () => {
+	await clearMagicLinks();
+});
+
+async function signInAsTestUser(page: import('@playwright/test').Page) {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'allowed@example.com');
+	await page.click('button[type="submit"]');
+	await expect(page).toHaveURL(/\/sign-in\/check-email/);
+	const url = await getMagicLinkUrl('allowed@example.com');
+	await page.goto(url);
+	await expect(page).toHaveURL(/^http:\/\/localhost:4173\/(\?|$)/);
+}
+
+test('Resource delete: confirm dialog が画面に表示されて Cancel で閉じる (#132 / #148)', async ({
+	page
+}) => {
+	await signInAsTestUser(page);
+
+	// ヘッダの「Manage people」 button を開く (en は Accept-Language fallback の default)
+	await page.getByRole('button', { name: /Manage people/ }).click();
+
+	// 「+ Add person」 → Name 入力 → Create
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+	const uniqueName = `e2e-${Date.now()}`;
+	await page.getByLabel('Name').fill(uniqueName);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+
+	// 作成後の一覧で対象 row の「Delete」 を押す
+	const row = page.locator('li', { hasText: uniqueName });
+	await expect(row).toBeVisible();
+	await row.getByRole('button', { name: /^Delete$/ }).click();
+
+	// **本 spec の core**: AlertDialog が画面に visible (PR #148 で壊れる場所)
+	const alert = page.getByRole('alertdialog');
+	await expect(alert).toBeVisible();
+
+	// Cancel で閉じれること
+	await alert.getByRole('button', { name: /Cancel/ }).click();
+	await expect(alert).toBeHidden();
+});

--- a/web/src/lib/components/ConfirmDialog.svelte
+++ b/web/src/lib/components/ConfirmDialog.svelte
@@ -10,10 +10,16 @@
 </script>
 
 <!--
-	#137: shadcn-svelte の AlertDialog.Content は内部で Portal + Overlay を mount するため
-	outer に `<AlertDialog.Portal>` / `<AlertDialog.Overlay />` を書くと **二重 Portal / 二重 Overlay**
-	になる (overlay の bg が暗くなる、focus trap 二重発火の risk)。shadcn 公式 example に揃えて
-	Root → Content の直構成にする。
+	#137: shadcn-svelte の AlertDialog.Content は内部で Portal + Overlay を mount する。
+
+	#157 (root cause): ConfirmDialog は +layout.svelte で常駐 mount → bits-ui の Portal は
+	mount 時に body へ consumer を append するため、 後から open する page 側の `<Dialog>`
+	(BitsDialog.Portal) の方が body 内で **後 = 前面** になる。 両方 z-50 なので、 confirm を開いても
+	page 側の Dialog 内 click target が pointer event を奪い続けて「ダイアログが押せない / 出ない」
+	症状になる。 confirm は destructive 操作の最終ゲートなので必ず最前面に来るべき。
+
+	→ AlertDialog の Overlay / Content を `z-[60]` で上書きして他 Dialog より一段上に乗せる。
+	  z-50 のままだと shadcn の `cn()` が tailwind-merge で重複解消 → 後勝ち で z-[60] になる。
 -->
 <AlertDialog.Root
 	{open}

--- a/web/src/lib/components/ConfirmDialog.svelte.test.ts
+++ b/web/src/lib/components/ConfirmDialog.svelte.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import ConfirmDialog from './ConfirmDialog.svelte';
+import { confirmDialog, confirmRequest, resolveConfirm } from '$lib/forms/confirm-dialog';
+
+/**
+ * #132 で導入した imperative confirmDialog の UI 結合テスト。
+ *
+ * 既存の `confirm-dialog.test.ts` は store + Promise の単体 test しか無く、
+ * `<ConfirmDialog />` を mount したときの DOM 挙動は assert されていない。
+ * PR #148 で `<AlertDialog.Portal>` を削除した際に dialog 表示が壊れても
+ * すり抜けた regression を防ぐため、 ここで UI 契約を固定する。
+ */
+
+afterEach(() => {
+	// 直前 test が pending request を残してたら掃除
+	if (get(confirmRequest)) resolveConfirm(false);
+});
+
+async function findAlertDialog(): Promise<HTMLElement> {
+	// AlertDialog は body 直下に Portal される → testing-library の container には居ない
+	// (jsdom 上の Portal target はデフォルトで body)
+	return await waitFor(() => {
+		const el = document.querySelector('[role="alertdialog"]');
+		if (!el) throw new Error('alertdialog not yet in DOM');
+		return el as HTMLElement;
+	});
+}
+
+describe('<ConfirmDialog /> UI integration (#132)', () => {
+	it('store に request が積まれたら DOM に role="alertdialog" が現れる', async () => {
+		render(ConfirmDialog);
+		expect(document.querySelector('[role="alertdialog"]')).toBeNull();
+
+		const promise = confirmDialog({ title: 'Delete?', message: 'Bob を削除します' });
+		const dialog = await findAlertDialog();
+		expect(dialog.textContent).toContain('Delete?');
+		expect(dialog.textContent).toContain('Bob を削除します');
+
+		resolveConfirm(false);
+		await promise;
+	});
+
+	it('Cancel ボタン押下で resolveConfirm(false) → promise が false、 dialog が消える', async () => {
+		render(ConfirmDialog);
+		const promise = confirmDialog({
+			title: 'T',
+			message: 'M',
+			confirmLabel: 'やる',
+			cancelLabel: 'やめる'
+		});
+		const dialog = await findAlertDialog();
+		const cancel = Array.from(dialog.querySelectorAll('button')).find(
+			(b) => b.textContent?.trim() === 'やめる'
+		);
+		expect(cancel).toBeTruthy();
+		await fireEvent.click(cancel!);
+
+		expect(await promise).toBe(false);
+		await waitFor(() => expect(document.querySelector('[role="alertdialog"]')).toBeNull());
+	});
+
+	it('Action ボタン押下で resolveConfirm(true) → promise が true', async () => {
+		render(ConfirmDialog);
+		const promise = confirmDialog({
+			title: 'T',
+			message: 'M',
+			confirmLabel: 'やる',
+			cancelLabel: 'やめる'
+		});
+		const dialog = await findAlertDialog();
+		const action = Array.from(dialog.querySelectorAll('button')).find(
+			(b) => b.textContent?.trim() === 'やる'
+		);
+		expect(action).toBeTruthy();
+		await fireEvent.click(action!);
+
+		expect(await promise).toBe(true);
+	});
+
+	it('destructive: true で Action ボタンに destructive variant class が付く', async () => {
+		render(ConfirmDialog);
+		const promise = confirmDialog({
+			title: 'T',
+			message: 'M',
+			confirmLabel: 'Delete',
+			destructive: true
+		});
+		const dialog = await findAlertDialog();
+		const action = Array.from(dialog.querySelectorAll('button')).find(
+			(b) => b.textContent?.trim() === 'Delete'
+		);
+		// shadcn buttonVariants({ variant: 'destructive' }) は bg-destructive class を出力
+		expect(action?.className).toMatch(/bg-destructive/);
+		resolveConfirm(false);
+		await promise;
+	});
+
+	it('同じ ConfirmDialog mount で 2 回 confirmDialog を連続呼び出ししても 2 回目も表示される', async () => {
+		render(ConfirmDialog);
+
+		const p1 = confirmDialog({ title: 'first', message: 'one' });
+		const d1 = await findAlertDialog();
+		expect(d1.textContent).toContain('first');
+		resolveConfirm(true);
+		expect(await p1).toBe(true);
+		await waitFor(() => expect(document.querySelector('[role="alertdialog"]')).toBeNull());
+
+		const p2 = confirmDialog({ title: 'second', message: 'two' });
+		const d2 = await findAlertDialog();
+		expect(d2.textContent).toContain('second');
+		resolveConfirm(false);
+		expect(await p2).toBe(false);
+	});
+});

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-content.svelte
@@ -24,7 +24,7 @@
 		data-slot="alert-dialog-content"
 		data-size={size}
 		class={cn(
-			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-none p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+			"data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-popover text-popover-foreground ring-foreground/10 gap-4 rounded-none p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-[60] grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
 			className
 		)}
 		{...restProps}

--- a/web/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
+++ b/web/src/lib/components/ui/alert-dialog/alert-dialog-overlay.svelte
@@ -12,6 +12,6 @@
 <AlertDialogPrimitive.Overlay
 	bind:ref
 	data-slot="alert-dialog-overlay"
-	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-[60]", className)}
 	{...restProps}
 />


### PR DESCRIPTION
## 症状

Resource / Project Manager の Dialog を開いた状態で「削除」 を押すと、 ConfirmDialog (AlertDialog) は DOM 上 visible になるが **ResourceManager の Dialog がピクセル選好で前面に居て pointer event を奪う** → ユーザー視点で「削除ダイアログが出ない / 押せない」 状態。

## 原因

ConfirmDialog は `+layout.svelte` で常駐 mount → bits-ui Portal が mount 時に body へ consumer を append → 後から open する page 側の `<Dialog>` (BitsDialog.Portal) の方が body 内で **後 = 前面**。 AlertDialog wrapper と Dialog wrapper はどちらも `z-50` 固定なので stacking context は DOM 順依存 → page Dialog が常に勝つ。

PR #148 で outer の `<AlertDialog.Portal>` を削除した段階で表面化。 **component test も e2e の delete flow assertion も一切無く**、 すり抜けた。

## 修正

- `alert-dialog-content.svelte` / `alert-dialog-overlay.svelte` の `z-50` → `z-[60]` (shadcn-svelte wrapper 側で 1 度上書き → アプリ全体で「AlertDialog は他 Dialog より一段上」 が保証される)
- AlertDialog は destructive 確認の最終ゲートなので、 任意の Dialog より上にあるのが正しい設計

## テスト追加 (致命的に欠けていた箇所)

- **`ConfirmDialog.svelte.test.ts`** (5 件、 component test):
  - store → DOM `role="alertdialog"` 出現
  - Cancel / Action ボタンが `resolveConfirm(false/true)` を呼ぶ
  - destructive variant class が付く
  - 連続呼び出しで 2 回目も表示される
- **`e2e/delete-flow.spec.ts`** (1 件、 Playwright):
  - 実 browser で sign-in → Resource 作成 → delete → `alertdialog` visible → Cancel で消える

これで PR #148 のような UI regression は CI で確実に赤になる。

## Test plan

- [x] `pnpm test` 緑 (177 件、 ConfirmDialog の 5 件含む)
- [x] `pnpm test:e2e e2e/delete-flow.spec.ts` 緑
- [x] `pnpm build` 緑、 generated CSS に `.z-\[60\]{z-index:60}` 含む
- [ ] 本番反映後 manual: Resource / Project / Assignment の各 delete で confirm dialog が前面に出る