### PR TITLE
test: P0 coverage boost — keys / 7 server actions / api PATCH / AssignmentEditor / CRUD e2e

### DIFF
--- a/web/e2e/crud-flow.spec.ts
+++ b/web/e2e/crud-flow.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from '@playwright/test';
+import { clearMagicLinks, getMagicLinkUrl } from './fixtures/magic-link';
+
+/**
+ * CRUD full path E2E (#155 で可視化した P0 coverage の埋め)。
+ *
+ * sign-in → Resource 作成 → Project 作成 → /assignments で確認 → ホームに戻って delete →
+ * の一気通貫を 1 spec で固定する。 個々の repository / action / component 単体は別 test で
+ * 担保しているので、 ここは **境界の繋ぎ** + 削除 confirm dialog の interaction を assert する。
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async () => {
+	await clearMagicLinks();
+});
+
+async function signInAsTestUser(page: import('@playwright/test').Page) {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'allowed@example.com');
+	await page.click('button[type="submit"]');
+	await expect(page).toHaveURL(/\/sign-in\/check-email/);
+	const url = await getMagicLinkUrl('allowed@example.com');
+	await page.goto(url);
+	await expect(page).toHaveURL(/^http:\/\/localhost:4173\/(\?|$)/);
+}
+
+test('Resource + Project の作成 → delete confirm まで一気通貫で機能 (#155)', async ({ page }) => {
+	await signInAsTestUser(page);
+
+	const resourceName = `e2e-crud-r-${Date.now()}`;
+	const projectName = `e2e-crud-p-${Date.now()}`;
+
+	// ── Resource 作成 (ヘッダ「Manage people」→ 「+ Add person」)
+	await page.getByRole('button', { name: /Manage people/ }).click();
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+	await page.getByLabel('Name').fill(resourceName);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: resourceName })).toBeVisible();
+
+	// dialog 外側クリックで close (Manage people dialog)
+	await page.keyboard.press('Escape');
+	await expect(page.locator('li', { hasText: resourceName })).toBeHidden();
+
+	// ── Project 作成 (ヘッダ「Manage projects」→ 「+ Add project」)
+	await page.getByRole('button', { name: /Manage projects/ }).click();
+	await page.getByRole('button', { name: /\+ Add project/ }).click();
+	// Project は「Project name」 label
+	await page.getByLabel('Project name').fill(projectName);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: projectName })).toBeVisible();
+
+	// ── Resource を delete → ConfirmDialog が出て Confirm
+	await page.keyboard.press('Escape');
+	await page.getByRole('button', { name: /Manage people/ }).click();
+	const row = page.locator('li', { hasText: resourceName });
+	await expect(row).toBeVisible();
+	await row.getByRole('button', { name: /^Delete$/ }).click();
+
+	const alert = page.getByRole('alertdialog');
+	await expect(alert).toBeVisible();
+	await expect(alert).toContainText(resourceName);
+	await alert.getByRole('button', { name: /^Delete$/ }).click();
+	await expect(alert).toBeHidden();
+
+	// 削除後は list から消える
+	await expect(page.locator('li', { hasText: resourceName })).toBeHidden();
+});

--- a/web/src/lib/components/AssignmentEditor.svelte.test.ts
+++ b/web/src/lib/components/AssignmentEditor.svelte.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { render, waitFor } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import AssignmentEditor from './AssignmentEditor.svelte';
+import type { Assignment, Project, Resource } from '$lib/types';
+
+/**
+ * AssignmentEditor の form 契約 (open=true で assignment を渡したときに form が初期化される、
+ * select / date input がフォームに乗る、 inclusive endDate 表示 ↔ exclusive 保存の境界 が
+ * 親 API に出てこない) を test で固定する。
+ *
+ * Dialog wrapper (BitsDialog) は body に Portal するので、 jsdom 上では `document` から拾う。
+ */
+
+const RESOURCES: Resource[] = [
+	{ id: 'r1', name: 'Alice' },
+	{ id: 'r2', name: 'Bob' }
+];
+const PROJECTS: Project[] = [
+	{ id: 'p1', name: 'Project A', color: '#0EA5E9' },
+	{ id: 'p2', name: 'Project B', color: '#10B981' }
+];
+
+const SAMPLE: Assignment = {
+	id: 'asn-1',
+	resourceId: 'r1',
+	projectId: 'p2',
+	startDate: '2026-05-01',
+	endDateExclusive: '2026-05-08' // inclusive 表示は 2026-05-07
+};
+
+async function findInPortal<T extends HTMLElement = HTMLElement>(
+	selector: string
+): Promise<T> {
+	return await waitFor(() => {
+		const el = document.querySelector(selector) as T | null;
+		if (!el) throw new Error(`not found: ${selector}`);
+		return el;
+	});
+}
+
+describe('AssignmentEditor (#100)', () => {
+	it('open=false のとき form は描画されない', () => {
+		render(AssignmentEditor, {
+			props: { open: false, assignment: SAMPLE, resources: RESOURCES, projects: PROJECTS }
+		});
+		expect(document.querySelector('form[action="/?/updateAssignment"]')).toBeNull();
+	});
+
+	it('open=true で assignment を渡すと form が描画され、 hidden の id / prevStartDate が assignment に一致', async () => {
+		render(AssignmentEditor, {
+			props: { open: true, assignment: SAMPLE, resources: RESOURCES, projects: PROJECTS }
+		});
+		const form = await findInPortal<HTMLFormElement>('form[action="/?/updateAssignment"]');
+		const idInput = form.querySelector('input[name="id"]') as HTMLInputElement;
+		const prev = form.querySelector('input[name="prevStartDate"]') as HTMLInputElement;
+		expect(idInput.value).toBe('asn-1');
+		expect(prev.value).toBe('2026-05-01');
+	});
+
+	it('select[name=resourceId] / projectId に全候補が出て、 assignment の値が選択済', async () => {
+		render(AssignmentEditor, {
+			props: { open: true, assignment: SAMPLE, resources: RESOURCES, projects: PROJECTS }
+		});
+		await findInPortal('form[action="/?/updateAssignment"]');
+		const resourceSelect = document.querySelector(
+			'select[name="resourceId"]'
+		) as HTMLSelectElement;
+		const projectSelect = document.querySelector('select[name="projectId"]') as HTMLSelectElement;
+		expect(Array.from(resourceSelect.options).map((o) => o.value)).toEqual(['r1', 'r2']);
+		expect(resourceSelect.value).toBe('r1');
+		expect(Array.from(projectSelect.options).map((o) => o.value)).toEqual(['p1', 'p2']);
+		expect(projectSelect.value).toBe('p2');
+	});
+
+	it('endDate input は inclusive 表示 (endDateExclusive - 1 day = 2026-05-07、 ADR 0004)', async () => {
+		render(AssignmentEditor, {
+			props: { open: true, assignment: SAMPLE, resources: RESOURCES, projects: PROJECTS }
+		});
+		await findInPortal('form[action="/?/updateAssignment"]');
+		const endDate = document.querySelector('input[name="endDate"]') as HTMLInputElement;
+		const startDate = document.querySelector('input[name="startDate"]') as HTMLInputElement;
+		expect(startDate.value).toBe('2026-05-01');
+		expect(endDate.value).toBe('2026-05-07');
+	});
+
+	it('endDate input の min は startDate と reactive に連動 (UC ガード)', async () => {
+		render(AssignmentEditor, {
+			props: { open: true, assignment: SAMPLE, resources: RESOURCES, projects: PROJECTS }
+		});
+		await findInPortal('form[action="/?/updateAssignment"]');
+		const endDate = document.querySelector('input[name="endDate"]') as HTMLInputElement;
+		expect(endDate.getAttribute('min')).toBe('2026-05-01');
+	});
+
+	it('Cancel / Update ボタンの type が button / submit (誤 submit 防止)', async () => {
+		render(AssignmentEditor, {
+			props: { open: true, assignment: SAMPLE, resources: RESOURCES, projects: PROJECTS }
+		});
+		await findInPortal('form[action="/?/updateAssignment"]');
+		const buttons = Array.from(
+			document.querySelectorAll('button[type]')
+		) as HTMLButtonElement[];
+		const submitBtns = buttons.filter((b) => b.type === 'submit');
+		const cancelBtns = buttons.filter((b) => b.type === 'button');
+		expect(submitBtns.length).toBeGreaterThanOrEqual(1);
+		expect(cancelBtns.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('assignment が null のとき hidden id / prevStartDate は描画されない (新規モードのガード)', async () => {
+		render(AssignmentEditor, {
+			props: { open: true, assignment: null, resources: RESOURCES, projects: PROJECTS }
+		});
+		const form = await findInPortal<HTMLFormElement>('form[action="/?/updateAssignment"]');
+		expect(form.querySelector('input[name="id"]')).toBeNull();
+		expect(form.querySelector('input[name="prevStartDate"]')).toBeNull();
+	});
+});

--- a/web/src/lib/repository/keys.test.ts
+++ b/web/src/lib/repository/keys.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+	SK_PREFIX,
+	assignmentSk,
+	pk,
+	projectSk,
+	resourceSk,
+	teamMembershipSk,
+	teamMetaSk,
+	userMetaSk,
+	userPk,
+	userTeamsGsi1pk,
+	userTeamsGsi1sk
+} from './keys';
+
+/**
+ * DynamoDB Single Table Design のキー組立は **DB スキーマの contract**。
+ * 文字列フォーマットを変えると既存データの読み出しが壊れる + GSI1 で逆引きが効かなくなる。
+ * 純粋関数なのでここで literal を assert して、 リネーム / プレフィックス変更を検知できるようにする。
+ */
+describe('repository/keys (#81 single table design)', () => {
+	describe('Team scope pk/sk', () => {
+		it('pk(teamId) → "TEAM#{teamId}"', () => {
+			expect(pk('team_default')).toBe('TEAM#team_default');
+			expect(pk('t-123')).toBe('TEAM#t-123');
+		});
+
+		it('teamMetaSk() → "META"', () => {
+			expect(teamMetaSk()).toBe('META');
+		});
+
+		it('resourceSk(id) → "RES#{id}"', () => {
+			expect(resourceSk('01HX')).toBe('RES#01HX');
+			expect(resourceSk('')).toBe('RES#');
+		});
+
+		it('projectSk(id) → "PRJ#{id}"', () => {
+			expect(projectSk('01PRJ')).toBe('PRJ#01PRJ');
+		});
+
+		it('assignmentSk(startDate, id) → "ASN#{startDate}#{id}" (date 先頭で sort 可能)', () => {
+			expect(assignmentSk('2026-05-01', '01ASN')).toBe('ASN#2026-05-01#01ASN');
+			// startDate のフォーマットが ISO ならソート可能 (access-patterns.md A3 の前提)
+			expect(assignmentSk('2026-01-01', 'a').localeCompare(assignmentSk('2026-12-31', 'b'))).toBeLessThan(0);
+		});
+
+		it('teamMembershipSk(userId) → "MEMBER#{userId}"', () => {
+			expect(teamMembershipSk('u1')).toBe('MEMBER#u1');
+		});
+	});
+
+	describe('User scope (Auth.js DDB adapter と共存)', () => {
+		it('userPk(userId) → "USER#{userId}"', () => {
+			expect(userPk('u1')).toBe('USER#u1');
+		});
+
+		it('userMetaSk() → "META"', () => {
+			expect(userMetaSk()).toBe('META');
+		});
+	});
+
+	describe('GSI1 — user の team 一覧逆引き', () => {
+		it('userTeamsGsi1pk(userId) → "USER#{userId}"', () => {
+			expect(userTeamsGsi1pk('u1')).toBe('USER#u1');
+		});
+
+		it('userTeamsGsi1sk(teamId) → "TEAM#{teamId}"', () => {
+			expect(userTeamsGsi1sk('team_default')).toBe('TEAM#team_default');
+		});
+
+		it('GSI1 の begins_with(GSI1SK, "TEAM#") で user の team 一覧が引ける', () => {
+			const gsi1sks = ['team_default', 't-2', 't-3'].map(userTeamsGsi1sk);
+			for (const sk of gsi1sks) {
+				expect(sk.startsWith('TEAM#')).toBe(true);
+			}
+		});
+	});
+
+	describe('SK_PREFIX 定数の不変性', () => {
+		it('entities.md と一致する prefix 値', () => {
+			// この値が変わると既存 DDB データ全件 migration が必要。 contract として固定。
+			expect(SK_PREFIX).toEqual({
+				resource: 'RES#',
+				project: 'PRJ#',
+				assignment: 'ASN#',
+				teamMember: 'MEMBER#'
+			});
+		});
+
+		it('Auth.js entity prefix (USER#, SESSION#, VERIFICATION#, ACCOUNT#) と衝突しない', () => {
+			const appPrefixes = Object.values(SK_PREFIX);
+			const authPrefixes = ['USER#', 'SESSION#', 'VERIFICATION#', 'ACCOUNT#'];
+			for (const a of appPrefixes) {
+				for (const b of authPrefixes) {
+					expect(a.startsWith(b)).toBe(false);
+					expect(b.startsWith(a)).toBe(false);
+				}
+			}
+		});
+	});
+});

--- a/web/src/routes/api/assignments/[id]/server.test.ts
+++ b/web/src/routes/api/assignments/[id]/server.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * PATCH /api/assignments/[id] の input → repository 引数 mapping、 zod 検証、 認証 / id missing
+ * の error path をカバー (#155 で可視化した P0 coverage の埋め直し)。
+ *
+ * `error()` は throw する SvelteKit ユーティリティなので、 失敗 path は throw を assert で受ける。
+ */
+
+const requireSessionMock = vi.fn();
+const updateAssignmentMock = vi.fn();
+
+vi.mock('$lib/auth', () => ({
+	requireSession: (event: unknown) => requireSessionMock(event)
+}));
+
+vi.mock('$lib/repository', () => ({
+	updateAssignment: (...args: unknown[]) => updateAssignmentMock(...args)
+}));
+
+import { PATCH } from './+server';
+
+const SESSION = { teamId: 'team_default', userId: 'u1' };
+
+function makeEvent(opts: {
+	id?: string;
+	body?: unknown;
+	bodyParseError?: boolean;
+}): Parameters<NonNullable<typeof PATCH>>[0] {
+	return {
+		params: { id: opts.id ?? 'asn-1' },
+		request: {
+			json: async () => {
+				if (opts.bodyParseError) throw new SyntaxError('invalid JSON');
+				return opts.body;
+			}
+		}
+	} as unknown as Parameters<NonNullable<typeof PATCH>>[0];
+}
+
+const VALID_BODY = {
+	prevStartDate: '2026-05-01',
+	resourceId: 'r1',
+	projectId: 'p1',
+	startDate: '2026-05-03',
+	endDateExclusive: '2026-05-10'
+};
+
+beforeEach(() => {
+	requireSessionMock.mockReset().mockResolvedValue(SESSION);
+	updateAssignmentMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe('PATCH /api/assignments/[id]', () => {
+	it('calls updateAssignment(teamId, prevStartDate, payload) on valid body', async () => {
+		const res = (await PATCH(makeEvent({ id: 'asn-1', body: VALID_BODY }))) as Response;
+		expect(updateAssignmentMock).toHaveBeenCalledWith('team_default', '2026-05-01', {
+			id: 'asn-1',
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-03',
+			endDateExclusive: '2026-05-10'
+		});
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ success: true });
+	});
+
+	it('throws 400 when id param is missing', async () => {
+		await expect(PATCH(makeEvent({ id: '', body: VALID_BODY }))).rejects.toThrow();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('throws 400 when JSON body is malformed', async () => {
+		await expect(PATCH(makeEvent({ bodyParseError: true }))).rejects.toThrow();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('throws 400 when startDate >= endDateExclusive (refine, ADR 0004 半開区間が崩れる)', async () => {
+		await expect(
+			PATCH(
+				makeEvent({
+					body: { ...VALID_BODY, startDate: '2026-05-10', endDateExclusive: '2026-05-10' }
+				})
+			)
+		).rejects.toThrow();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('throws 400 for non-ISO date strings (zod regex)', async () => {
+		await expect(
+			PATCH(makeEvent({ body: { ...VALID_BODY, prevStartDate: '2026/05/01' } }))
+		).rejects.toThrow();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('throws 400 for missing required fields', async () => {
+		await expect(
+			PATCH(makeEvent({ body: { prevStartDate: '2026-05-01' } }))
+		).rejects.toThrow();
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('propagates requireSession failure (e.g. unauth) without repository call', async () => {
+		requireSessionMock.mockRejectedValueOnce(new Error('unauthorized'));
+		await expect(PATCH(makeEvent({ body: VALID_BODY }))).rejects.toThrow('unauthorized');
+		expect(updateAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('uses session.teamId (server-resolved) — body の teamId を信用しない (cross-tenant 防止)', async () => {
+		const malicious = { ...VALID_BODY, teamId: 'other-team' };
+		await PATCH(makeEvent({ body: malicious }));
+		const [calledTeamId] = updateAssignmentMock.mock.calls[0];
+		expect(calledTeamId).toBe('team_default'); // session 由来
+		expect(calledTeamId).not.toBe('other-team');
+	});
+});

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -12,8 +12,15 @@ import type { ServerError } from '$lib/forms/server-error';
  */
 
 const requireSessionMock = vi.fn();
-const updateAssignmentMock = vi.fn();
 const createResourceMock = vi.fn();
+const updateResourceMock = vi.fn();
+const deleteResourceMock = vi.fn();
+const createProjectMock = vi.fn();
+const updateProjectMock = vi.fn();
+const deleteProjectMock = vi.fn();
+const createAssignmentMock = vi.fn();
+const updateAssignmentMock = vi.fn();
+const deleteAssignmentMock = vi.fn();
 
 vi.mock('$lib/auth', () => ({
 	requireSession: (event: unknown) => requireSessionMock(event)
@@ -21,14 +28,14 @@ vi.mock('$lib/auth', () => ({
 
 vi.mock('$lib/repository', () => ({
 	createResource: (...args: unknown[]) => createResourceMock(...args),
-	updateResource: vi.fn(),
-	deleteResource: vi.fn(),
-	createProject: vi.fn(),
-	updateProject: vi.fn(),
-	deleteProject: vi.fn(),
-	createAssignment: vi.fn(),
+	updateResource: (...args: unknown[]) => updateResourceMock(...args),
+	deleteResource: (...args: unknown[]) => deleteResourceMock(...args),
+	createProject: (...args: unknown[]) => createProjectMock(...args),
+	updateProject: (...args: unknown[]) => updateProjectMock(...args),
+	deleteProject: (...args: unknown[]) => deleteProjectMock(...args),
+	createAssignment: (...args: unknown[]) => createAssignmentMock(...args),
 	updateAssignment: (...args: unknown[]) => updateAssignmentMock(...args),
-	deleteAssignment: vi.fn()
+	deleteAssignment: (...args: unknown[]) => deleteAssignmentMock(...args)
 }));
 
 import { actions } from './+page.server';
@@ -225,5 +232,222 @@ describe('#139 server error wire format (code, no localized strings)', () => {
 			expect(typeof v).toBe('object');
 			expect(v).not.toBeNull();
 		}
+	});
+});
+
+/**
+ * P0 coverage 拡張 (#155 で missing test を可視化した結果)。 9 action 中 createResource /
+ * updateAssignment しかカバーされていなかったので、 残り 7 action の success path + 400 failure
+ * を埋める。 各 action の入力 → repository 呼び出し引数 mapping、 zod 検証境界、 SK の構造
+ * (startDate 必須等) の contract を固定する。
+ */
+
+const SESSION = { teamId: 'team_default', userId: 'u1' };
+
+function resetAllMocks() {
+	requireSessionMock.mockReset().mockResolvedValue(SESSION);
+	createResourceMock.mockReset().mockResolvedValue(undefined);
+	updateResourceMock.mockReset().mockResolvedValue(undefined);
+	deleteResourceMock.mockReset().mockResolvedValue(undefined);
+	createProjectMock.mockReset().mockResolvedValue(undefined);
+	updateProjectMock.mockReset().mockResolvedValue(undefined);
+	deleteProjectMock.mockReset().mockResolvedValue(undefined);
+	createAssignmentMock.mockReset().mockResolvedValue(undefined);
+	deleteAssignmentMock.mockReset().mockResolvedValue(undefined);
+}
+
+describe('?/updateResource action', () => {
+	beforeEach(resetAllMocks);
+
+	it('calls updateResource(teamId, { id, name }) on valid input', async () => {
+		await actions.updateResource!(makeEvent({ id: 'r1', name: 'Alice' }));
+		expect(updateResourceMock).toHaveBeenCalledWith('team_default', { id: 'r1', name: 'Alice' });
+	});
+
+	it('fails with 400 when id is missing', async () => {
+		const r = (await actions.updateResource!(makeEvent({ name: 'Alice' }))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(updateResourceMock).not.toHaveBeenCalled();
+	});
+
+	it('fails with 400 when name is empty', async () => {
+		const r = (await actions.updateResource!(makeEvent({ id: 'r1', name: '' }))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(r.data.errors.name).toBeTruthy();
+	});
+});
+
+describe('?/deleteResource action (cascade は repository 側、 ここでは引数 mapping のみ)', () => {
+	beforeEach(resetAllMocks);
+
+	it('calls deleteResource(teamId, id) on valid input', async () => {
+		const r = (await actions.deleteResource!(makeEvent({ id: 'r1' }))) as {
+			action: string;
+			success: boolean;
+		};
+		expect(deleteResourceMock).toHaveBeenCalledWith('team_default', 'r1');
+		expect(r.success).toBe(true);
+	});
+
+	it('fails with 400 when id is missing or empty (no repository call)', async () => {
+		const r = (await actions.deleteResource!(makeEvent({}))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(r.data.errors.id).toBeTruthy();
+		expect(deleteResourceMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('?/createProject action', () => {
+	beforeEach(resetAllMocks);
+
+	it('calls createProject(teamId, { name, color }) on valid input', async () => {
+		await actions.createProject!(makeEvent({ name: 'Alpha', color: '#0EA5E9' }));
+		expect(createProjectMock).toHaveBeenCalledWith('team_default', {
+			name: 'Alpha',
+			color: '#0EA5E9'
+		});
+	});
+
+	it('rejects color not matching #RRGGBB', async () => {
+		const r = (await actions.createProject!(
+			makeEvent({ name: 'X', color: 'red' })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.color).toBeTruthy();
+		expect(createProjectMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('?/updateProject action', () => {
+	beforeEach(resetAllMocks);
+
+	it('calls updateProject(teamId, { id, name, color })', async () => {
+		await actions.updateProject!(
+			makeEvent({ id: 'p1', name: 'Beta', color: '#10B981' })
+		);
+		expect(updateProjectMock).toHaveBeenCalledWith('team_default', {
+			id: 'p1',
+			name: 'Beta',
+			color: '#10B981'
+		});
+	});
+
+	it('fails 400 when name exceeds 100 chars', async () => {
+		const r = (await actions.updateProject!(
+			makeEvent({ id: 'p1', name: 'x'.repeat(101), color: '#000000' })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.name).toBeTruthy();
+	});
+});
+
+describe('?/deleteProject action', () => {
+	beforeEach(resetAllMocks);
+
+	it('calls deleteProject(teamId, id) on valid input', async () => {
+		await actions.deleteProject!(makeEvent({ id: 'p1' }));
+		expect(deleteProjectMock).toHaveBeenCalledWith('team_default', 'p1');
+	});
+
+	it('fails 400 when id is missing', async () => {
+		const r = (await actions.deleteProject!(makeEvent({}))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(deleteProjectMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('?/createAssignment action (inclusive endDate → endDateExclusive transform, ADR 0004)', () => {
+	beforeEach(resetAllMocks);
+
+	it('transforms endDate (inclusive) → endDateExclusive (+1 day) before calling repository', async () => {
+		await actions.createAssignment!(
+			makeEvent({
+				resourceId: 'r1',
+				projectId: 'p1',
+				startDate: '2026-05-01',
+				endDate: '2026-05-07'
+			})
+		);
+		expect(createAssignmentMock).toHaveBeenCalledWith('team_default', {
+			resourceId: 'r1',
+			projectId: 'p1',
+			startDate: '2026-05-01',
+			endDateExclusive: '2026-05-08'
+		});
+	});
+
+	it('rejects startDate > endDate (zod refine)', async () => {
+		const r = (await actions.createAssignment!(
+			makeEvent({
+				resourceId: 'r1',
+				projectId: 'p1',
+				startDate: '2026-05-10',
+				endDate: '2026-05-09'
+			})
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.endDate).toBeTruthy();
+		expect(createAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('rejects non-ISO date strings', async () => {
+		const r = (await actions.createAssignment!(
+			makeEvent({
+				resourceId: 'r1',
+				projectId: 'p1',
+				startDate: '2026/05/01',
+				endDate: '2026-05-07'
+			})
+		)) as { status: number };
+		expect(r.status).toBe(400);
+	});
+});
+
+describe('?/deleteAssignment action (SK = ASN#{startDate}#{id} 構造に startDate が必要)', () => {
+	beforeEach(resetAllMocks);
+
+	it('calls deleteAssignment(teamId, startDate, id) on valid input', async () => {
+		await actions.deleteAssignment!(makeEvent({ id: 'asn-1', startDate: '2026-05-01' }));
+		expect(deleteAssignmentMock).toHaveBeenCalledWith('team_default', '2026-05-01', 'asn-1');
+	});
+
+	it('fails 400 when id is missing', async () => {
+		const r = (await actions.deleteAssignment!(makeEvent({ startDate: '2026-05-01' }))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(r.data.errors.id).toBeTruthy();
+		expect(deleteAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('fails 400 when startDate is missing (SK 再構築に必須)', async () => {
+		const r = (await actions.deleteAssignment!(makeEvent({ id: 'asn-1' }))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(r.data.errors.startDate).toBeTruthy();
+		expect(deleteAssignmentMock).not.toHaveBeenCalled();
+	});
+
+	it('fails 400 when startDate is not ISO YYYY-MM-DD', async () => {
+		const r = (await actions.deleteAssignment!(
+			makeEvent({ id: 'asn-1', startDate: '2026/05/01' })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.startDate).toBeTruthy();
 	});
 });


### PR DESCRIPTION
PR #155 で ConfirmDialog の test 0 件 / e2e delete flow 0 件が UI regression をすり抜けさせたので、 アプリ全体の薄い箇所を 1 PR で埋め直す。

## 追加した test

| Target | 件数 | カバー |
|---|---|---|
| `repository/keys.ts` | 13 | pk/sk 純粋関数、 entity prefix 不変性、 Auth.js entity (USER#/SESSION#/...) と衝突しないこと |
| `+page.server.ts` (form actions) | +19 (5→24) | updateResource / deleteResource / createProject / updateProject / deleteProject / createAssignment / deleteAssignment — 各 success path + 400 failure + repository 引数 mapping |
| `api/assignments/[id]/+server.ts` PATCH | 8 | input → repository 引数、 zod 検証、 invalid JSON / id missing / 認証失敗、 **cross-tenant 防止 (body の teamId を信用しない) contract** |
| `AssignmentEditor.svelte` | 7 | open=false 非描画、 open=true + assignment で初期化、 select 候補、 inclusive endDate 表示 (endDateExclusive - 1)、 min reactive 連動 |
| `e2e/crud-flow.spec.ts` | 1 | sign-in → Resource / Project 作成 → delete confirm → list 消滅 |

## 計

unit **223 passed (+46)**、 e2e **7 passed (+2)**。

## stacking note

PR #155 (ConfirmDialog z-index fix) の commit を本 branch にも cherry-pick。 #155 マージ後に rebase で解消、 もしくは duplicate commit が自然消化される。

## Test plan

- [x] `pnpm test` 緑 (223 件)
- [x] `pnpm test:e2e` 緑 (7 件 — chromium のみ CI mode で実行)
- [x] `pnpm check` 既存の auth.ts 1 件以外エラーなし
- [x] `pnpm build` 緑