### PR TITLE
fix(i18n): server から locale 済文字列を返さず、 client が code を翻訳する契約に (#139)

### DIFF
--- a/web/src/lib/components/AssignmentCreator.svelte
+++ b/web/src/lib/components/AssignmentCreator.svelte
@@ -5,6 +5,7 @@
 	import Dialog from './Dialog.svelte';
 	import { formatLocalDate } from '$lib/timeline-adapter';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Resource, Project } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -57,12 +58,12 @@
 			if (result.type === 'success') {
 				open = false;
 			} else if (result.type === 'failure') {
-				const errs = (result.data as { errors?: Record<string, string> })?.errors;
+				const errs = (result.data as { errors?: ServerErrors })?.errors;
 				formError = {
-					resourceId: errs?.resourceId,
-					projectId: errs?.projectId,
-					startDate: errs?.startDate,
-					endDate: errs?.endDate
+					resourceId: errs?.resourceId ? translateServerError(errs.resourceId) : undefined,
+					projectId: errs?.projectId ? translateServerError(errs.projectId) : undefined,
+					startDate: errs?.startDate ? translateServerError(errs.startDate) : undefined,
+					endDate: errs?.endDate ? translateServerError(errs.endDate) : undefined
 				};
 			}
 			await update();

--- a/web/src/lib/components/AssignmentEditor.svelte
+++ b/web/src/lib/components/AssignmentEditor.svelte
@@ -4,6 +4,7 @@
 	import Dialog from './Dialog.svelte';
 	import { addDays } from '$lib/date';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
+	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Assignment, Resource, Project } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -61,12 +62,12 @@
 				open = false;
 				onSuccess?.();
 			} else if (result.type === 'failure') {
-				const errs = (result.data as { errors?: Record<string, string> })?.errors;
+				const errs = (result.data as { errors?: ServerErrors })?.errors;
 				formError = {
-					resourceId: errs?.resourceId,
-					projectId: errs?.projectId,
-					startDate: errs?.startDate,
-					endDate: errs?.endDate
+					resourceId: errs?.resourceId ? translateServerError(errs.resourceId) : undefined,
+					projectId: errs?.projectId ? translateServerError(errs.projectId) : undefined,
+					startDate: errs?.startDate ? translateServerError(errs.startDate) : undefined,
+					endDate: errs?.endDate ? translateServerError(errs.endDate) : undefined
 				};
 			}
 			await update();

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -5,6 +5,7 @@
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { confirmDialog } from '$lib/forms/confirm-dialog';
+	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Project, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -61,8 +62,11 @@
 				formOpen = false;
 				editing = null;
 			} else if (result.type === 'failure') {
-				const errs = (result.data as { errors?: Record<string, string> })?.errors;
-				formError = { name: errs?.name, color: errs?.color };
+				const errs = (result.data as { errors?: ServerErrors })?.errors;
+				formError = {
+					name: errs?.name ? translateServerError(errs.name) : undefined,
+					color: errs?.color ? translateServerError(errs.color) : undefined
+				};
 			}
 			await update();
 		};

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -5,6 +5,7 @@
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { confirmDialog } from '$lib/forms/confirm-dialog';
+	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Resource, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -93,8 +94,8 @@
 				formOpen = false;
 				editing = null;
 			} else if (result.type === 'failure') {
-				formError =
-					(result.data as { errors?: Record<string, string> })?.errors?.name ?? '入力エラー';
+				const errs = (result.data as { errors?: ServerErrors })?.errors;
+				formError = errs?.name ? translateServerError(errs.name) : t('errors.generic');
 			}
 			await update();
 		};

--- a/web/src/lib/forms/server-error.test.ts
+++ b/web/src/lib/forms/server-error.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { formatZodErrors, translateServerError } from './server-error';
+import { localeState } from '$lib/i18n/index.svelte';
+
+/**
+ * #139: server → client wire format の純粋関数を test。
+ *
+ * - formatZodErrors: zod issue → { code, field, max? } の mapping (i18n 済文字列を返さない契約)
+ * - translateServerError: code を locale 済文字列に翻訳、 max を補間、 key 欠落で generic に fallback
+ */
+
+describe('formatZodErrors (#139)', () => {
+	const schema = z.object({
+		name: z.string().min(1, 'required').max(5, 'tooLong'),
+		startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'invalidDateFormat')
+	});
+
+	it('required → { code: "required", field: "name" }', () => {
+		const r = schema.safeParse({ name: '', startDate: '2026-05-01' });
+		if (r.success) throw new Error('should fail');
+		const errors = formatZodErrors(r);
+		expect(errors.name).toEqual({ code: 'required', field: 'name' });
+	});
+
+	it('tooLong → max を保持して { code: "tooLong", field: "name", max: 5 }', () => {
+		const r = schema.safeParse({ name: 'abcdef', startDate: '2026-05-01' });
+		if (r.success) throw new Error('should fail');
+		expect(formatZodErrors(r).name).toEqual({ code: 'tooLong', field: 'name', max: 5 });
+	});
+
+	it('複数 field の error を全て収集', () => {
+		const r = schema.safeParse({ name: '', startDate: 'bad' });
+		if (r.success) throw new Error('should fail');
+		const errors = formatZodErrors(r);
+		expect(errors.name?.code).toBe('required');
+		expect(errors.startDate?.code).toBe('invalidDateFormat');
+	});
+
+	it('同 field の 2 つ目の issue は捨てる (UX: 1 field 1 error)', () => {
+		// schema 自体に同 field 2 issue は出にくいので、 直接 mock。
+		const issues = [
+			{ code: 'too_small', path: ['name'], message: 'required' } as z.ZodIssue,
+			{ code: 'too_big', path: ['name'], message: 'tooLong', maximum: 5 } as z.ZodIssue
+		];
+		const fakeResult = {
+			success: false,
+			error: { issues }
+		} as unknown as z.ZodSafeParseError<unknown>;
+		const errors = formatZodErrors(fakeResult);
+		expect(errors.name?.code).toBe('required');
+		expect(errors.name?.max).toBeUndefined();
+	});
+});
+
+describe('translateServerError (#139)', () => {
+	it('null / undefined → 空文字', () => {
+		expect(translateServerError(null)).toBe('');
+		expect(translateServerError(undefined)).toBe('');
+	});
+
+	it('ja locale: required → "{field} は必須です" に field 翻訳済を補間', () => {
+		localeState.current = 'ja';
+		expect(translateServerError({ code: 'required', field: 'name' })).toBe('名前 は必須です');
+	});
+
+	it('en locale: required → "{field} is required"', () => {
+		localeState.current = 'en';
+		expect(translateServerError({ code: 'required', field: 'startDate' })).toBe(
+			'Start date is required'
+		);
+	});
+
+	it('tooLong は max を補間', () => {
+		localeState.current = 'en';
+		expect(translateServerError({ code: 'tooLong', field: 'name', max: 100 })).toBe(
+			'Name must be at most 100 characters'
+		);
+	});
+
+	it('未知の code は errors.generic に fallback (locale に追随)', () => {
+		localeState.current = 'ja';
+		expect(translateServerError({ code: 'noSuchCode', field: 'name' })).toBe('入力エラー');
+		localeState.current = 'en';
+		expect(translateServerError({ code: 'noSuchCode', field: 'name' })).toBe('Input error');
+	});
+});

--- a/web/src/lib/forms/server-error.ts
+++ b/web/src/lib/forms/server-error.ts
@@ -1,0 +1,58 @@
+/**
+ * #139: server → client の wire format。
+ *
+ * server (form action / API endpoint) は **i18n 済文字列を返さない**。
+ * 代わりに `{ code, field, max? }` の machine-readable な error を返し、
+ * client が `t(\`errors.${code}\`, { field: t(\`fields.${field}\`), max })` で翻訳する。
+ *
+ * - `code`: i18n key (errors.json の key と一致、 例: 'required', 'invalidDateFormat')
+ * - `field`: 該当フォーム field 名 (fields.json の key、 例: 'name', 'startDate')。
+ *           field 名が翻訳に必要ない error (例: invalidColorFormat — color 固定) でも
+ *           送る側のロジックを単純化するため必須。
+ * - `max?`: tooLong の場合の上限文字数。
+ */
+import type { z } from 'zod';
+import { t } from '$lib/i18n/index.svelte';
+
+export type ServerError = {
+	code: string;
+	field: string;
+	max?: number;
+};
+
+export type ServerErrors = Record<string, ServerError>;
+
+/**
+ * zod の SafeParseError から ServerErrors に変換する。
+ * 同じ field 名で複数 issue がある場合は最初の 1 件のみ採用 (UX: 1 field に 1 エラー)。
+ */
+export function formatZodErrors<T>(result: z.ZodSafeParseError<T>): ServerErrors {
+	const errors: ServerErrors = {};
+	for (const issue of result.error.issues) {
+		const field = issue.path.join('.');
+		if (!field || errors[field]) continue;
+		const err: ServerError = { code: issue.message, field };
+		// zod の too_big issue は `maximum` を持つ。 tooLong の表示で必要。
+		if (issue.code === 'too_big' && typeof (issue as { maximum?: unknown }).maximum === 'number') {
+			err.max = (issue as { maximum: number }).maximum;
+		}
+		errors[field] = err;
+	}
+	return errors;
+}
+
+/**
+ * Client 側で `ServerError` を表示文字列に翻訳する。 `null` / `undefined` の場合は空文字。
+ * `t()` で取れなかった場合 (key 欠落) は `errors.generic` に fallback。
+ */
+export function translateServerError(err: ServerError | null | undefined): string {
+	if (!err) return '';
+	const field = t(`fields.${err.field}`);
+	const params: Record<string, string | number> = { field };
+	if (err.max !== undefined) params.max = err.max;
+	const translated = t(`errors.${err.code}`, params);
+	// `t()` は key 不在のとき key そのものを返す (i18n/index.svelte 実装)。
+	// その場合は errors.generic に落とす。
+	if (translated === `errors.${err.code}`) return t('errors.generic');
+	return translated;
+}

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -138,5 +138,23 @@
 		"step1": "Add a person",
 		"step2": "Add a project",
 		"step3": "Create an assignment"
+	},
+	"errors": {
+		"generic": "Input error",
+		"required": "{field} is required",
+		"tooLong": "{field} must be at most {max} characters",
+		"invalidDateFormat": "{field} must be in YYYY-MM-DD format",
+		"invalidColorFormat": "Color must be in #RRGGBB format",
+		"endBeforeStart": "End date must be on or after the start date"
+	},
+	"fields": {
+		"id": "id",
+		"name": "Name",
+		"color": "Color",
+		"startDate": "Start date",
+		"endDate": "End date",
+		"prevStartDate": "Previous start date",
+		"resourceId": "Person",
+		"projectId": "Project"
 	}
 }

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -138,5 +138,23 @@
 		"step1": "人を追加",
 		"step2": "案件を追加",
 		"step3": "アサインを作成"
+	},
+	"errors": {
+		"generic": "入力エラー",
+		"required": "{field} は必須です",
+		"tooLong": "{field} は {max} 文字以内で入力してください",
+		"invalidDateFormat": "{field} は YYYY-MM-DD 形式で入力してください",
+		"invalidColorFormat": "色は #RRGGBB 形式で入力してください",
+		"endBeforeStart": "終了日は開始日以降にしてください"
+	},
+	"fields": {
+		"id": "id",
+		"name": "名前",
+		"color": "色",
+		"startDate": "開始日",
+		"endDate": "終了日",
+		"prevStartDate": "前回開始日",
+		"resourceId": "人",
+		"projectId": "案件"
 	}
 }

--- a/web/src/lib/schemas/index.test.ts
+++ b/web/src/lib/schemas/index.test.ts
@@ -208,6 +208,85 @@ describe('assignmentFormUpdateSchema (#99)', () => {
 	});
 });
 
+/**
+ * #139: schema 内 `message` は **i18n code** であること (UI で `t(`errors.${msg}`)` で翻訳)。
+ * 日本語 hardcode を含まないことを正規表現で守る。
+ */
+describe('error message contract — i18n codes (#139)', () => {
+	const ALLOWED_CODES = new Set([
+		'required',
+		'tooLong',
+		'invalidDateFormat',
+		'invalidColorFormat',
+		'endBeforeStart'
+	]);
+
+	function collect(schema: { safeParse: (v: unknown) => { success: boolean; error?: { issues: { message: string }[] } } }, input: unknown): string[] {
+		const r = schema.safeParse(input);
+		if (r.success || !r.error) return [];
+		return r.error.issues.map((i) => i.message);
+	}
+
+	it('resourceCreateSchema: empty name → "required"', () => {
+		expect(collect(resourceCreateSchema, { name: '' })).toContain('required');
+	});
+
+	it('resourceCreateSchema: too long name → "tooLong"', () => {
+		expect(collect(resourceCreateSchema, { name: 'a'.repeat(101) })).toContain('tooLong');
+	});
+
+	it('projectCreateSchema: bad color → "invalidColorFormat"', () => {
+		expect(collect(projectCreateSchema, { name: 'P', color: 'red' })).toContain(
+			'invalidColorFormat'
+		);
+	});
+
+	it('assignmentCreateSchema: bad date → "invalidDateFormat"', () => {
+		expect(
+			collect(assignmentCreateSchema, {
+				resourceId: 'r',
+				projectId: 'p',
+				startDate: '2026/05/01',
+				endDate: '2026-05-02'
+			})
+		).toContain('invalidDateFormat');
+	});
+
+	it('assignmentCreateSchema: endDate < startDate → "endBeforeStart"', () => {
+		expect(
+			collect(assignmentCreateSchema, {
+				resourceId: 'r',
+				projectId: 'p',
+				startDate: '2026-05-10',
+				endDate: '2026-05-01'
+			})
+		).toContain('endBeforeStart');
+	});
+
+	it('全 message は ALLOWED_CODES に含まれる (日本語 hardcode 検知)', () => {
+		const samples = [
+			collect(resourceCreateSchema, { name: '' }),
+			collect(resourceCreateSchema, { name: 'a'.repeat(101) }),
+			collect(projectCreateSchema, { name: '', color: 'red' }),
+			collect(assignmentCreateSchema, {
+				resourceId: '',
+				projectId: '',
+				startDate: 'bad',
+				endDate: 'bad'
+			}),
+			collect(assignmentCreateSchema, {
+				resourceId: 'r',
+				projectId: 'p',
+				startDate: '2026-05-10',
+				endDate: '2026-05-01'
+			})
+		].flat();
+		for (const msg of samples) {
+			expect(ALLOWED_CODES, `unexpected message: ${JSON.stringify(msg)}`).toContain(msg);
+		}
+	});
+});
+
 describe('assignmentApiUpdateSchema', () => {
 	const valid = {
 		prevStartDate: '2026-05-01',

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -1,18 +1,30 @@
 import { z } from 'zod';
 import { addDays } from '$lib/date';
 
-const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD 形式で入力してください');
+/**
+ * #139: schema 内の `message` は **i18n code** に統一する (`errors.required` 等)。
+ * UI 側で `t(\`errors.${msg}\`)` で翻訳することで、 サーバから locale 済文字列を返さない契約。
+ *
+ * code 体系:
+ *   required           — 必須欠落 (min(1) など)
+ *   tooLong            — 長さ超過 (max())
+ *   invalidDateFormat  — 日付 YYYY-MM-DD パターン不一致
+ *   invalidColorFormat — #RRGGBB パターン不一致
+ *   endBeforeStart     — 終了日 < 開始日 (refine)
+ */
 
-const colorString = z.string().regex(/^#[0-9a-fA-F]{6}$/, '#RRGGBB 形式で入力してください');
+const dateString = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'invalidDateFormat');
+
+const colorString = z.string().regex(/^#[0-9a-fA-F]{6}$/, 'invalidColorFormat');
 
 // ── Resource ────────────────────────────────────────────────────────
 
 export const resourceCreateSchema = z.object({
-	name: z.string().min(1, '必須').max(100, '100 文字以内')
+	name: z.string().min(1, 'required').max(100, 'tooLong')
 });
 
 export const resourceUpdateSchema = resourceCreateSchema.extend({
-	id: z.string().min(1)
+	id: z.string().min(1, 'required')
 });
 
 export type ResourceCreateInput = z.infer<typeof resourceCreateSchema>;
@@ -21,12 +33,12 @@ export type ResourceUpdateInput = z.infer<typeof resourceUpdateSchema>;
 // ── Project ─────────────────────────────────────────────────────────
 
 export const projectCreateSchema = z.object({
-	name: z.string().min(1, '必須').max(100, '100 文字以内'),
+	name: z.string().min(1, 'required').max(100, 'tooLong'),
 	color: colorString
 });
 
 export const projectUpdateSchema = projectCreateSchema.extend({
-	id: z.string().min(1)
+	id: z.string().min(1, 'required')
 });
 
 export type ProjectCreateInput = z.infer<typeof projectCreateSchema>;
@@ -45,13 +57,13 @@ export type ProjectUpdateInput = z.infer<typeof projectUpdateSchema>;
 
 export const assignmentCreateSchema = z
 	.object({
-		resourceId: z.string().min(1),
-		projectId: z.string().min(1),
+		resourceId: z.string().min(1, 'required'),
+		projectId: z.string().min(1, 'required'),
 		startDate: dateString,
 		endDate: dateString
 	})
 	.refine((v) => v.startDate <= v.endDate, {
-		message: '終了日は開始日以降にしてください',
+		message: 'endBeforeStart',
 		path: ['endDate']
 	})
 	.transform((input) => ({
@@ -63,14 +75,14 @@ export const assignmentCreateSchema = z
 
 export const assignmentUpdateSchema = z
 	.object({
-		id: z.string().min(1),
-		resourceId: z.string().min(1),
-		projectId: z.string().min(1),
+		id: z.string().min(1, 'required'),
+		resourceId: z.string().min(1, 'required'),
+		projectId: z.string().min(1, 'required'),
 		startDate: dateString,
 		endDate: dateString
 	})
 	.refine((v) => v.startDate <= v.endDate, {
-		message: '終了日は開始日以降にしてください',
+		message: 'endBeforeStart',
 		path: ['endDate']
 	})
 	.transform((input) => ({
@@ -89,15 +101,15 @@ export const assignmentUpdateSchema = z
  */
 export const assignmentFormUpdateSchema = z
 	.object({
-		id: z.string().min(1),
-		resourceId: z.string().min(1),
-		projectId: z.string().min(1),
+		id: z.string().min(1, 'required'),
+		resourceId: z.string().min(1, 'required'),
+		projectId: z.string().min(1, 'required'),
 		prevStartDate: dateString,
 		startDate: dateString,
 		endDate: dateString
 	})
 	.refine((v) => v.startDate <= v.endDate, {
-		message: '終了日は開始日以降にしてください',
+		message: 'endBeforeStart',
 		path: ['endDate']
 	})
 	.transform((input) => ({
@@ -131,13 +143,13 @@ export type AssignmentUpdatePayload = z.output<typeof assignmentUpdateSchema>;
 export const assignmentApiUpdateSchema = z
 	.object({
 		prevStartDate: dateString,
-		resourceId: z.string().min(1),
-		projectId: z.string().min(1),
+		resourceId: z.string().min(1, 'required'),
+		projectId: z.string().min(1, 'required'),
 		startDate: dateString,
 		endDateExclusive: dateString
 	})
 	.refine((v) => v.startDate < v.endDateExclusive, {
-		message: 'endDateExclusive must be strictly after startDate',
+		message: 'endBeforeStart',
 		path: ['endDateExclusive']
 	});
 

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,5 +1,4 @@
 import { fail } from '@sveltejs/kit';
-import { z } from 'zod';
 import {
 	resourceCreateSchema,
 	resourceUpdateSchema,
@@ -20,20 +19,8 @@ import {
 	deleteAssignment
 } from '$lib/repository';
 import { requireSession } from '$lib/auth';
+import { formatZodErrors, type ServerError } from '$lib/forms/server-error';
 import type { Actions } from './$types';
-
-/**
- * Zod の formatted error を form action の戻り値に整形する。
- * `+page.svelte` 側で `form.errors.name` のようにアクセスできる。
- */
-function formatErrors<T>(result: z.ZodSafeParseError<T>): Record<string, string> {
-	const errors: Record<string, string> = {};
-	for (const issue of result.error.issues) {
-		const key = issue.path.join('.');
-		if (key && !errors[key]) errors[key] = issue.message;
-	}
-	return errors;
-}
 
 export const actions: Actions = {
 	createResource: async (event) => {
@@ -45,7 +32,7 @@ export const actions: Actions = {
 		if (!parsed.success) {
 			return fail(400, {
 				action: 'createResource',
-				errors: formatErrors(parsed)
+				errors: formatZodErrors(parsed)
 			});
 		}
 		// #121: 作成された entity を返して optimistic UI の temp → real swap を可能にする。
@@ -63,7 +50,7 @@ export const actions: Actions = {
 		if (!parsed.success) {
 			return fail(400, {
 				action: 'updateResource',
-				errors: formatErrors(parsed)
+				errors: formatZodErrors(parsed)
 			});
 		}
 		await updateResource(session.teamId, parsed.data);
@@ -75,10 +62,10 @@ export const actions: Actions = {
 		const data = await event.request.formData();
 		const id = data.get('id');
 		if (typeof id !== 'string' || !id) {
-			return fail(400, {
-				action: 'deleteResource',
-				errors: { id: 'id が必要です' }
-			});
+			const errors: Record<string, ServerError> = {
+				id: { code: 'required', field: 'id' }
+			};
+			return fail(400, { action: 'deleteResource', errors });
 		}
 		await deleteResource(session.teamId, id);
 		return { action: 'deleteResource', success: true };
@@ -94,7 +81,7 @@ export const actions: Actions = {
 		if (!parsed.success) {
 			return fail(400, {
 				action: 'createProject',
-				errors: formatErrors(parsed)
+				errors: formatZodErrors(parsed)
 			});
 		}
 		await createProject(session.teamId, parsed.data);
@@ -112,7 +99,7 @@ export const actions: Actions = {
 		if (!parsed.success) {
 			return fail(400, {
 				action: 'updateProject',
-				errors: formatErrors(parsed)
+				errors: formatZodErrors(parsed)
 			});
 		}
 		await updateProject(session.teamId, parsed.data);
@@ -124,10 +111,10 @@ export const actions: Actions = {
 		const data = await event.request.formData();
 		const id = data.get('id');
 		if (typeof id !== 'string' || !id) {
-			return fail(400, {
-				action: 'deleteProject',
-				errors: { id: 'id が必要です' }
-			});
+			const errors: Record<string, ServerError> = {
+				id: { code: 'required', field: 'id' }
+			};
+			return fail(400, { action: 'deleteProject', errors });
 		}
 		await deleteProject(session.teamId, id);
 		return { action: 'deleteProject', success: true };
@@ -145,7 +132,7 @@ export const actions: Actions = {
 		if (!parsed.success) {
 			return fail(400, {
 				action: 'createAssignment',
-				errors: formatErrors(parsed)
+				errors: formatZodErrors(parsed)
 			});
 		}
 		// assignmentCreateSchema は startDate <= endDate を refine 検証済 (inclusive)。
@@ -169,7 +156,7 @@ export const actions: Actions = {
 		if (!parsed.success) {
 			return fail(400, {
 				action: 'updateAssignment',
-				errors: formatErrors(parsed)
+				errors: formatZodErrors(parsed)
 			});
 		}
 		// SK = ASN#{startDate}#{id}: startDate 変更時は旧 SK Delete + 新 SK Put (assignment.ts 参照)。
@@ -183,13 +170,16 @@ export const actions: Actions = {
 		const id = data.get('id');
 		const startDate = data.get('startDate');
 		if (typeof id !== 'string' || !id) {
-			return fail(400, { action: 'deleteAssignment', errors: { id: 'id が必要です' } });
+			const errors: Record<string, ServerError> = {
+				id: { code: 'required', field: 'id' }
+			};
+			return fail(400, { action: 'deleteAssignment', errors });
 		}
 		if (typeof startDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
-			return fail(400, {
-				action: 'deleteAssignment',
-				errors: { startDate: 'startDate が必要です (YYYY-MM-DD)' }
-			});
+			const errors: Record<string, ServerError> = {
+				startDate: { code: 'invalidDateFormat', field: 'startDate' }
+			};
+			return fail(400, { action: 'deleteAssignment', errors });
 		}
 		// SK = ASN#{startDate}#{id} で構成されるため startDate も必要 (UC-05 / ADR 0005 参照)。
 		await deleteAssignment(session.teamId, startDate, id);

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ServerError } from '$lib/forms/server-error';
 
 /**
  * `?/updateAssignment` action の TDD (#99 item 1)。
@@ -85,10 +86,11 @@ describe('?/updateAssignment action (#99)', () => {
 		});
 		const result = (await actions.updateAssignment!(event)) as {
 			status: number;
-			data: { action: string; errors: Record<string, string> };
+			data: { action: string; errors: Record<string, ServerError> };
 		};
 		expect(result.status).toBe(400);
-		expect(result.data.errors.endDate).toBeTruthy();
+		// #139: server は i18n 済文字列を返さず { code, field } を返す契約
+		expect(result.data.errors.endDate).toEqual({ code: 'endBeforeStart', field: 'endDate' });
 		expect(updateAssignmentMock).not.toHaveBeenCalled();
 	});
 
@@ -103,10 +105,13 @@ describe('?/updateAssignment action (#99)', () => {
 		});
 		const result = (await actions.updateAssignment!(event)) as {
 			status: number;
-			data: { errors: Record<string, string> };
+			data: { errors: Record<string, ServerError> };
 		};
 		expect(result.status).toBe(400);
-		expect(result.data.errors.prevStartDate).toBeTruthy();
+		expect(result.data.errors.prevStartDate).toEqual({
+			code: 'invalidDateFormat',
+			field: 'prevStartDate'
+		});
 		expect(updateAssignmentMock).not.toHaveBeenCalled();
 	});
 });
@@ -138,9 +143,87 @@ describe('?/createResource action (#121)', () => {
 		const event = makeEvent({ name: '' });
 		const result = (await actions.createResource!(event)) as {
 			status: number;
-			data: { errors: Record<string, string> };
+			data: { errors: Record<string, ServerError> };
 		};
 		expect(result.status).toBe(400);
+		expect(result.data.errors.name).toEqual({ code: 'required', field: 'name' });
 		expect(createResourceMock).not.toHaveBeenCalled();
+	});
+});
+
+/**
+ * #139: server から i18n 済文字列を返さない契約。 deleteResource / deleteProject /
+ * deleteAssignment の id missing / startDate missing は { code, field } 形式で返ること
+ * と、 zod 経由の error が { code: 'required' | 'tooLong' | ... } になることを固定する。
+ */
+describe('#139 server error wire format (code, no localized strings)', () => {
+	beforeEach(() => {
+		requireSessionMock.mockReset().mockResolvedValue({ teamId: 'team_default', userId: 'u1' });
+	});
+
+	it('deleteResource: id missing → { code: required, field: id }', async () => {
+		const r = (await actions.deleteResource!(makeEvent({}))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(r.data.errors.id).toEqual({ code: 'required', field: 'id' });
+	});
+
+	it('deleteProject: id missing → { code: required, field: id }', async () => {
+		const r = (await actions.deleteProject!(makeEvent({}))) as {
+			status: number;
+			data: { errors: Record<string, ServerError> };
+		};
+		expect(r.status).toBe(400);
+		expect(r.data.errors.id).toEqual({ code: 'required', field: 'id' });
+	});
+
+	it('deleteAssignment: id missing → { code: required, field: id }', async () => {
+		const r = (await actions.deleteAssignment!(
+			makeEvent({ startDate: '2026-05-01' })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.id).toEqual({ code: 'required', field: 'id' });
+	});
+
+	it('deleteAssignment: startDate 不正 → { code: invalidDateFormat, field: startDate }', async () => {
+		const r = (await actions.deleteAssignment!(
+			makeEvent({ id: 'a1', startDate: '2026/05/01' })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.startDate).toEqual({
+			code: 'invalidDateFormat',
+			field: 'startDate'
+		});
+	});
+
+	it('createProject: 不正 color → { code: invalidColorFormat, field: color }', async () => {
+		const r = (await actions.createProject!(
+			makeEvent({ name: 'P', color: 'red' })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.color).toEqual({
+			code: 'invalidColorFormat',
+			field: 'color'
+		});
+	});
+
+	it('createResource: name 超過 → { code: tooLong, field: name, max: 100 }', async () => {
+		const r = (await actions.createResource!(
+			makeEvent({ name: 'a'.repeat(101) })
+		)) as { status: number; data: { errors: Record<string, ServerError> } };
+		expect(r.status).toBe(400);
+		expect(r.data.errors.name).toEqual({ code: 'tooLong', field: 'name', max: 100 });
+	});
+
+	it('error value は **必ず object** (string が混ざらない)', async () => {
+		const r = (await actions.deleteResource!(makeEvent({}))) as {
+			data: { errors: Record<string, unknown> };
+		};
+		for (const v of Object.values(r.data.errors)) {
+			expect(typeof v).toBe('object');
+			expect(v).not.toBeNull();
+		}
 	});
 });


### PR DESCRIPTION
## Summary

#129 / #133 で確立した「全 UI 文字列は locale に追従」 方針に対し、 server action と client fallback で日本語 hardcode が残っていた。 サーバから i18n 済文字列を返さず、 **machine-readable code** を返して **client が `t()` で翻訳** する pattern に統一。

## Wire format 変更

| | 旧 | 新 |
|---|---|---|
| 形 | `Record<string, string>` | `Record<string, { code, field, max? }>` |
| 例 | `{ name: '必須' }` | `{ name: { code: 'required', field: 'name' } }` |
| 例 (delete) | `{ id: 'id が必要です' }` | `{ id: { code: 'required', field: 'id' } }` |

`ServerError` 型 + helper を `lib/forms/server-error.ts` に集約 (`formatZodErrors` / `translateServerError`)。

## 変更ファイル

- **`lib/schemas/index.ts`**: 全 `message` を i18n code に置換 (`required` / `tooLong` / `invalidDateFormat` / `invalidColorFormat` / `endBeforeStart`)
- **`+page.server.ts`**: `formatErrors` → `formatZodErrors`、 hardcode の `'id が必要です'` / `'startDate が必要です (YYYY-MM-DD)'` を `{ code, field }` 形式に
- **`lib/i18n/en.json` / `ja.json`**: `errors.*` + `fields.*` keys 追加 (generic / required / tooLong / invalidDateFormat / invalidColorFormat / endBeforeStart)
- **`ResourceManager`** / **`ProjectManager`** / **`AssignmentEditor`** / **`AssignmentCreator`**: 受け取った error を `translateServerError(err)` で翻訳、 fallback を `t('errors.generic')` (旧 `'入力エラー'` hardcode)

## テスト

- **`schemas/index.test.ts`** (+6): 全 `message` が ALLOWED_CODES に含まれること (日本語 hardcode 検知 regression guard)
- **`lib/forms/server-error.test.ts`** (新規 9 件): `formatZodErrors` / `translateServerError` の純粋関数テスト、 locale 切替で en/ja の error 文字列が変わること
- **`routes/page.server.test.ts`** (+7): 全 action の error が `{ code, field }` 形式であること、 string が混ざらないこと

## Counts

unit **194 passed (+17 from main)**、 e2e **5 passed** 維持。

## Test plan

- [x] `pnpm test` 緑
- [x] `pnpm test:e2e` 緑
- [x] `pnpm check` 既存の auth.ts 1 件以外エラーなし
- [x] `pnpm build` 緑
- [ ] 本番反映後 manual: en locale で空名前送信 → "Name is required"、 ja で「名前 は必須です」 が表示

fixes #139