### PR TITLE
fix(optimistic UI): create 失敗時に form 入力を失わずに dialog を復活 (#140)

### DIFF
--- a/web/e2e/rollback-recovery.spec.ts
+++ b/web/e2e/rollback-recovery.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test';
+import { clearMagicLinks, getMagicLinkUrl } from './fixtures/magic-link';
+
+/**
+ * #140: optimistic create が server 400 で失敗したとき、 dialog が再 open して入力値が
+ * 保持される regression spec。 PR #131 (#121) で実装された旧設計は dialog close + 入力破棄で
+ * UX 退行していた。
+ *
+ * 400 を強制する手段: HTML5 `maxlength="100"` は user input のみを制限し、 Playwright の
+ * `fill()` は JS で setValue するため越えて入る → server の zod `max(100, 'tooLong')` が
+ * 400 を返す。
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async () => {
+	await clearMagicLinks();
+});
+
+async function signIn(page: import('@playwright/test').Page) {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'allowed@example.com');
+	await page.click('button[type="submit"]');
+	await expect(page).toHaveURL(/\/sign-in\/check-email/);
+	const url = await getMagicLinkUrl('allowed@example.com');
+	await page.goto(url);
+	await expect(page).toHaveURL(/^http:\/\/localhost:4173\/(\?|$)/);
+}
+
+test('Resource create が tooLong で 400 → dialog 再 open + 入力値が保持される (#140)', async ({
+	page
+}) => {
+	await signIn(page);
+
+	const TOO_LONG = 'a'.repeat(101);
+
+	await page.getByRole('button', { name: /Manage people/ }).click();
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+
+	// HTML5 `maxlength="100"` を一時的に外して 101 文字を入れる (server side の
+	// zod max(100, 'tooLong') を踏ませて 400 を強制)。 input イベントを dispatch して
+	// Svelte の bind:value も同期させる。
+	const name = page.getByLabel('Name');
+	await name.evaluate((el, value) => {
+		(el as HTMLInputElement).removeAttribute('maxlength');
+		const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+		setter?.call(el, value);
+		el.dispatchEvent(new Event('input', { bubbles: true }));
+	}, TOO_LONG);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+
+	// 失敗 path: dialog が再 open し、 入力値も保持
+	const dialog = page.getByRole('dialog', { name: /Add person/ });
+	await expect(dialog).toBeVisible();
+	await expect(name).toHaveValue(TOO_LONG);
+
+	// translateServerError 経由で en locale の "Name must be at most 100 characters" が表示
+	await expect(dialog).toContainText(/Name must be at most 100 characters/);
+});

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -6,6 +6,7 @@
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { confirmDialog } from '$lib/forms/confirm-dialog';
 	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
+	import { rollbackRecoverState } from '$lib/forms/optimistic-rollback';
 	import { t } from '$lib/i18n/index.svelte';
 	import type { Resource, Assignment } from '$lib/types';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -58,11 +59,12 @@
 	}
 
 	/**
-	 * Optimistic UI for create (#121):
+	 * Optimistic UI for create (#121 + #140):
 	 * - submit 前に temp ID 付きの Resource を親 state に即時追加 (dialog も即時 close)
 	 * - server success → 親で temp → real swap、`update()` は不要 (refetch 回避)
-	 * - server failure → 親で temp 削除 + 親側で toast、form は再 open しないので入力は失う設計
-	 *   (HTML5 required / maxlength でクライアント側 validation は通過済の前提)
+	 * - server failure → 親で temp 削除 + 親側で toast、
+	 *   **加えて dialog を再 open + 入力値を formName に復元 + server error を formError に**
+	 *   (#140: 旧設計は入力破棄で UX 退行していた、 #155 / #157 と整合する形で復元)
 	 * Update path (editing 時) は従来通り `update()` で invalidateAll、後続 PR で同 pattern 化候補。
 	 */
 	let pendingTemp: Resource | null = null;
@@ -86,7 +88,18 @@
 					const real = (result.data as { resource?: Resource })?.resource;
 					if (real && onConfirmCreate) onConfirmCreate(tempSnapshot, real);
 				} else {
+					// #140: rollback だけでなく form を復活させてユーザーが再入力せずに済むようにする
 					if (onRollbackCreate) onRollbackCreate(tempSnapshot);
+					const recovered = rollbackRecoverState({
+						temp: tempSnapshot,
+						failureData: result.type === 'failure' ? (result.data as { errors?: ServerErrors }) : undefined,
+						translate: translateServerError,
+						fallback: t('errors.generic'),
+						field: 'name'
+					});
+					formName = recovered.formName;
+					formError = recovered.formError;
+					formOpen = true;
 				}
 				return; // optimistic は update() 不要
 			}

--- a/web/src/lib/forms/optimistic-rollback.test.ts
+++ b/web/src/lib/forms/optimistic-rollback.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { rollbackRecoverState } from './optimistic-rollback';
+
+/**
+ * #140: optimistic create が失敗したとき、 form 入力を捨てない契約。
+ *
+ * - temp.name を formName に復元 (#121 で破棄されていた挙動の修正)
+ * - server からの該当 field error があれば translate、 無ければ fallback ('errors.generic')
+ */
+describe('rollbackRecoverState (#140)', () => {
+	const translate = (e: { code: string; field: string; max?: number }) =>
+		`translated:${e.code}:${e.field}${e.max !== undefined ? `:${e.max}` : ''}`;
+	const fallback = 'Input error';
+
+	it('temp.name を formName に復元', () => {
+		const r = rollbackRecoverState({
+			temp: { id: 't1', name: 'Bob' },
+			failureData: undefined,
+			translate,
+			fallback,
+			field: 'name'
+		});
+		expect(r.formName).toBe('Bob');
+	});
+
+	it('temp.name が undefined のとき formName は空文字 (defensive)', () => {
+		const r = rollbackRecoverState({
+			temp: { id: 't1' } as { id: string; name?: string },
+			failureData: undefined,
+			translate,
+			fallback,
+			field: 'name'
+		});
+		expect(r.formName).toBe('');
+	});
+
+	it('server から該当 field error が来ていれば translate', () => {
+		const r = rollbackRecoverState({
+			temp: { id: 't1', name: 'Bob' },
+			failureData: {
+				errors: { name: { code: 'tooLong', field: 'name', max: 100 } }
+			},
+			translate,
+			fallback,
+			field: 'name'
+		});
+		expect(r.formError).toBe('translated:tooLong:name:100');
+	});
+
+	it('failureData が undefined (network error / 500) → fallback', () => {
+		const r = rollbackRecoverState({
+			temp: { id: 't1', name: 'Bob' },
+			failureData: undefined,
+			translate,
+			fallback,
+			field: 'name'
+		});
+		expect(r.formError).toBe(fallback);
+	});
+
+	it('failureData.errors に対象 field なし → fallback', () => {
+		const r = rollbackRecoverState({
+			temp: { id: 't1', name: 'Bob' },
+			failureData: {
+				errors: { other: { code: 'required', field: 'other' } }
+			},
+			translate,
+			fallback,
+			field: 'name'
+		});
+		expect(r.formError).toBe(fallback);
+	});
+
+	it('field 引数の差し替え可能性 (将来の Project name / color 適用)', () => {
+		const r = rollbackRecoverState({
+			temp: { id: 't1', name: 'P1' },
+			failureData: {
+				errors: { color: { code: 'invalidColorFormat', field: 'color' } }
+			},
+			translate,
+			fallback,
+			field: 'color'
+		});
+		expect(r.formError).toBe('translated:invalidColorFormat:color');
+	});
+});

--- a/web/src/lib/forms/optimistic-rollback.ts
+++ b/web/src/lib/forms/optimistic-rollback.ts
@@ -1,0 +1,50 @@
+/**
+ * #140: optimistic create が server で失敗したとき、 dialog を即 close + form 入力を捨てる
+ * のではなく、 **入力値を保持して dialog を再 open** + **server からの error message を表示** する。
+ *
+ * ロジックを純粋関数として切り出し、 ResourceManager / ProjectManager / AssignmentCreator
+ * の rollback path で共通に呼べるようにする (将来 helper 化の起点)。
+ */
+import type { ServerError, ServerErrors } from './server-error';
+
+export type RollbackRecoverInput<T extends { name?: string }> = {
+	/** optimistic で生成した temp entity (rollback で元に戻す値の source) */
+	temp: T;
+	/** server から返ってきた failure data (`result.data`) */
+	failureData: { errors?: ServerErrors } | undefined;
+	/**
+	 * `ServerError` を locale 済文字列に変換する関数。 component から
+	 * `translateServerError` を渡す ($lib/i18n の reactive state に依存するため
+	 * 純粋関数からは直接呼べない、 引数で受け取って合成性を保つ)。
+	 */
+	translate: (e: ServerError) => string;
+	/**
+	 * 該当 field の error が無いとき (network error 等) に表示する fallback。
+	 * 通常 `t('errors.generic')` を渡す。
+	 */
+	fallback: string;
+	/** error を引く form field 名 (例: 'name')。 */
+	field: string;
+};
+
+export type RollbackRecoverOutput = {
+	formName: string;
+	formError: string;
+};
+
+/**
+ * Rollback 時に form を復元する state を計算する純粋関数。
+ *
+ * - `formName`: temp.name (= ユーザーの最後の入力) を返す。 temp.name が undefined なら空文字。
+ * - `formError`: server から該当 field の error code が来ていれば translate、 来ていなければ fallback。
+ */
+export function rollbackRecoverState<T extends { name?: string }>(
+	opts: RollbackRecoverInput<T>
+): RollbackRecoverOutput {
+	const errs = opts.failureData?.errors;
+	const fieldErr = errs?.[opts.field];
+	return {
+		formName: opts.temp.name ?? '',
+		formError: fieldErr ? opts.translate(fieldErr) : opts.fallback
+	};
+}


### PR DESCRIPTION
## Summary

PR #131 (#121) の optimistic Resource create は失敗時に dialog を再 open せず入力した name も捨てていた (UX 退行)。 失敗してもユーザーが入力を 1 文字も再入力しなくて済むよう、 rollback path で:

- 親に `onRollbackCreate` で temp を取り消してもらう (既存挙動)
- **加えて `formName` を `temp.name` に復元、 dialog を再 open、 server からの error code を `translateServerError` で翻訳して `formError` に表示**

ロジックは `lib/forms/optimistic-rollback.ts` に純粋関数 `rollbackRecoverState` で抽出 (#139 の `translateServerError` と組合せ、 ProjectManager / AssignmentCreator への横展開を見据えた起点)。

## 変更ファイル

- **`lib/forms/optimistic-rollback.ts`** 新規: 純粋関数 + **6 件 unit test** (temp.name 復元、 field error → translate、 fallback → generic、 field 切替可能)
- **`lib/components/ResourceManager.svelte`**: rollback path で `formName` / `formError` / `formOpen` を復元
- **`e2e/rollback-recovery.spec.ts`** 新規: `maxlength="100"` を一時的に外して 101 文字を送る → server `tooLong` → dialog 再 open + 入力値保持 + i18n 済 error 表示を assert

## Counts

unit **200 + 6 = 206 passed**、 e2e **5 + 1 = 6 passed**。

## Stacking note

PR #157 (#139 i18n) の 1 commit を本 branch に cherry-pick (`translateServerError` / `errors.*` keys に依存)。 #157 マージ後に rebase で衝突解消、 もしくは duplicate commit が自然消化される。

## Test plan

- [x] `pnpm test` 緑 (206 件)
- [x] `pnpm test:e2e` 緑 (6 件)
- [x] `pnpm build` 緑
- [ ] 本番反映後 manual: 名前に 101 文字相当を入れて submit → dialog が残り、 入力値も維持、 error が翻訳されて表示

fixes #140