### PR TITLE
fix(/assignments): mobile (<sm) で 6 列 table が見切れる → card layout に切替 (#142)

### DIFF
--- a/web/e2e/assignments-mobile.spec.ts
+++ b/web/e2e/assignments-mobile.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test';
+import { clearMagicLinks, getMagicLinkUrl } from './fixtures/magic-link';
+
+/**
+ * #142: /assignments を 375px 幅で開いたとき 6 列 table が右端で見切れていた問題の regression spec。
+ *
+ * 修正: `<sm` で card layout (`<ul>`)、 `>=sm` で従来 table を表示。 切替が tailwind の
+ * `.sm:hidden` / `.hidden.sm:block` で行われていることを viewport を切り替えて assert する。
+ *
+ * 0 件状態ではどちらの container も描画されないため、 一気通貫で Resource / Project /
+ * Assignment を 1 件作ってから /assignments を開く。
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async () => {
+	await clearMagicLinks();
+});
+
+async function signIn(page: import('@playwright/test').Page) {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'allowed@example.com');
+	await page.click('button[type="submit"]');
+	await expect(page).toHaveURL(/\/sign-in\/check-email/);
+	const url = await getMagicLinkUrl('allowed@example.com');
+	await page.goto(url);
+	await expect(page).toHaveURL(/^http:\/\/localhost:4173\/(\?|$)/);
+}
+
+async function createOneAssignment(page: import('@playwright/test').Page, suffix: string) {
+	// Resource 作成
+	await page.getByRole('button', { name: /Manage people/ }).click();
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+	await page.getByLabel('Name').fill(`r-${suffix}`);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: `r-${suffix}` })).toBeVisible();
+	await page.keyboard.press('Escape');
+
+	// Project 作成
+	await page.getByRole('button', { name: /Manage projects/ }).click();
+	await page.getByRole('button', { name: /\+ Add project/ }).click();
+	await page.getByLabel('Project name').fill(`p-${suffix}`);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: `p-${suffix}` })).toBeVisible();
+	await page.keyboard.press('Escape');
+
+	// Assignment 作成 (AssignmentCreator は label でなく select/date input、 デフォルト値で submit)
+	await page.getByRole('button', { name: /Add assignment/ }).click();
+	await page.getByRole('button', { name: /^Create$/ }).last().click();
+}
+
+test('viewport breakpoint で /assignments が card / table を切り替える (#142)', async ({ page }) => {
+	// header の Manage / Add button は mobile (<sm) でテキストが hidden され accessible name が
+	// 空になるため、 fixture 作成は **desktop viewport** で行う。 viewport breakpoint の挙動だけ
+	// /assignments で確認するのが本 spec のスコープ。
+	await page.setViewportSize({ width: 1280, height: 800 });
+	await signIn(page);
+	await createOneAssignment(page, `${Date.now()}`);
+
+	// ── desktop viewport: table が見え、 card list は hidden ──
+	await page.goto('/assignments');
+	const table = page.locator('table');
+	const cardList = page.getByRole('list', { name: /Assignments/ });
+	await expect(table).toBeVisible();
+	await expect(cardList).toBeHidden();
+
+	// ── mobile viewport (375px): card list が見え、 table は hidden ──
+	await page.setViewportSize({ width: 375, height: 800 });
+	await expect(cardList).toBeVisible();
+	await expect(table).toBeHidden();
+
+	// edit / delete はカード内で visible (viewport 越え clipping なし)
+	const firstItem = cardList.locator('li').first();
+	const editBtn = firstItem.getByRole('button', { name: /^Edit$/ });
+	const deleteBtn = firstItem.getByRole('button', { name: /^Delete$/ });
+	await expect(editBtn).toBeVisible();
+	await expect(deleteBtn).toBeVisible();
+	// viewport 内 (x + width <= 375) であることを座標で確認
+	const editBox = await editBtn.boundingBox();
+	const deleteBox = await deleteBtn.boundingBox();
+	expect(editBox).not.toBeNull();
+	expect(deleteBox).not.toBeNull();
+	if (editBox) expect(editBox.x + editBox.width).toBeLessThanOrEqual(375);
+	if (deleteBox) expect(deleteBox.x + deleteBox.width).toBeLessThanOrEqual(375);
+});

--- a/web/src/routes/assignments/+page.svelte
+++ b/web/src/routes/assignments/+page.svelte
@@ -153,12 +153,68 @@
 		</button>
 	</div>
 
+	{#snippet rowActions(a: Assignment, resource: typeof resources[number] | undefined, project: typeof projects[number] | undefined)}
+		<div class="flex justify-end gap-1">
+			<Button size="xs" variant="outline" onclick={() => openEditor(a)}>
+				{t('common.edit')}
+			</Button>
+			<form
+				method="POST"
+				action="/?/deleteAssignment"
+				use:enhance={makeDeleteSubmit({
+					label: `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`
+				})}
+			>
+				<input type="hidden" name="id" value={a.id} />
+				<input type="hidden" name="startDate" value={a.startDate} />
+				<Button size="xs" variant="destructive" type="submit">
+					{t('common.delete')}
+				</Button>
+			</form>
+		</div>
+	{/snippet}
+
 	{#if filtered.length === 0}
 		<div class="rounded border border-border bg-card px-4 py-8 text-center text-sm text-muted-foreground">
 			{t('assignments.noMatches')}
 		</div>
 	{:else}
-		<div class="overflow-x-auto rounded border border-border">
+		<!-- #142: mobile (<sm) は table 6 列が 375px 幅で見切れるため card layout に切替。
+		     desktop (>=sm) は従来 table を維持。 共通の edit/delete UI は rowActions snippet で. -->
+		<ul class="space-y-2 sm:hidden" aria-label={t('assignments.list')}>
+			{#each filtered as a (a.id)}
+				{@const resource = resourceMap.get(a.resourceId)}
+				{@const project = projectMap.get(a.projectId)}
+				<li class="rounded border border-border bg-card p-3">
+					<div class="mb-2 flex items-start justify-between gap-2">
+						<div class="flex min-w-0 flex-col gap-0.5">
+							<span class="truncate text-sm font-semibold">
+								{resource?.name ?? t('assignments.deletedResource')}
+							</span>
+							<span class="inline-flex items-center gap-2 text-xs">
+								<span
+									class="inline-block h-3 w-3 shrink-0 rounded-sm border border-black/10"
+									style="background-color: {project?.color ?? '#999'}"
+									aria-hidden="true"
+								></span>
+								<span class="truncate">{project?.name ?? t('assignments.deletedProject')}</span>
+							</span>
+						</div>
+						{@render rowActions(a, resource, project)}
+					</div>
+					<dl class="grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs text-muted-foreground">
+						<dt>{t('assignments.startDate')}</dt>
+						<dd class="font-mono">{a.startDate}</dd>
+						<dt>{t('assignments.endDate')}</dt>
+						<dd class="font-mono">{displayEndDate(a)}</dd>
+						<dt>{t('assignments.durationDays')}</dt>
+						<dd class="font-mono">{duration(a)}</dd>
+					</dl>
+				</li>
+			{/each}
+		</ul>
+
+		<div class="hidden overflow-x-auto rounded border border-border sm:block">
 			<Table.Root>
 				<Table.Header>
 					<Table.Row>
@@ -189,26 +245,7 @@
 							<Table.Cell class="font-mono text-xs">{a.startDate}</Table.Cell>
 							<Table.Cell class="font-mono text-xs">{displayEndDate(a)}</Table.Cell>
 							<Table.Cell class="text-right font-mono text-xs">{duration(a)}</Table.Cell>
-							<Table.Cell class="text-right">
-								<div class="flex justify-end gap-1">
-									<Button size="xs" variant="outline" onclick={() => openEditor(a)}>
-										{t('common.edit')}
-									</Button>
-									<form
-										method="POST"
-										action="/?/deleteAssignment"
-										use:enhance={makeDeleteSubmit({
-											label: `${resource?.name ?? '?'} × ${project?.name ?? '?'} (${a.startDate} 〜 ${displayEndDate(a)})`
-										})}
-									>
-										<input type="hidden" name="id" value={a.id} />
-										<input type="hidden" name="startDate" value={a.startDate} />
-										<Button size="xs" variant="destructive" type="submit">
-											{t('common.delete')}
-										</Button>
-									</form>
-								</div>
-							</Table.Cell>
+							<Table.Cell class="text-right">{@render rowActions(a, resource, project)}</Table.Cell>
 						</Table.Row>
 					{/each}
 				</Table.Body>


### PR DESCRIPTION
## Summary

実機 UX review (Playwright mobile screenshot) で発見: 375px 幅では 6 列 table の右端「編集 / 削除」 列がクリップされていた。 `overflow-x-auto` で横 scroll 可能だが scrollbar が出ず気付きにくい UX 不良。

## 修正

- **\`<sm\` (mobile)** → \`<ul>\` ベースの card layout、 各 li に resource / project / 期間 / edit-delete actions を配置
- **\`>=sm\` (desktop)** → 従来 table を維持
- 共通の edit / delete UI (button + form + hidden inputs) は **Svelte 5 snippet** \`{#snippet rowActions}\` で抽出して mobile / desktop の両方から \`{@render}\` で 1 回宣言 → 重複ゼロ
- \`aria-label="Assignments"\` を \`<ul>\` に付与 (Playwright e2e で取れる + screen reader にもリスト境界を伝える)

## e2e regression

\`e2e/assignments-mobile.spec.ts\`:
- desktop (1280) で fixture 作成 (mobile では header button の text が \`hidden sm:inline\` で accessible name が空になり tap 不能 — ヘッダ a11y は別 issue)
- /assignments を開いた状態で viewport を 375px に切替
- card list visible / table hidden を assert
- edit / delete button の **boundingBox.x + width が 375px 以下** (viewport 内完全収まり) を座標 assert (regression の本質をピン留め)

## Counts

unit **172 passed** (regression なし)、 e2e **6 passed** (+1 mobile spec)。

## Test plan

- [x] \`pnpm test\` 緑
- [x] \`pnpm test:e2e\` 緑 (mobile + desktop viewport check 通過)
- [x] \`pnpm check\` 既存の auth.ts 1 件以外エラーなし
- [x] \`pnpm build\` 緑
- [ ] 本番反映後 manual: iPhone Safari (375 / 390 / 414 px) で /assignments を開き、 edit / delete が常に visible

fixes #142