### PR TITLE
feat(ui): bump ui-components to 0.7.0 + wire i18n labels + auto-fit rail (#33, #34)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.6.0",
+		"@tommykey-apps/ui-components": "^0.7.0",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.6.0
-        version: 0.6.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.7.0
+        version: 0.7.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1328,8 +1328,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.6.0':
-    resolution: {integrity: sha512-YGUTw7DObqURDJ+yTxDnfvZ5BU1hBrscHzPJXZ7yJr8n2fydzsGjMhkK2M1zCTsLZ/5kg7BDX4bTxshdNxJW4A==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.6.0/68a83d9befaf02936a7e200ac1d0aeaba3556e46}
+  '@tommykey-apps/ui-components@0.7.0':
+    resolution: {integrity: sha512-+/OB9fsHaO3LYVIhfmxi18HABA6hPTvcnO03yMcz/jVp3zbXeNZnprWctWXO9HnPRllGRzPSkSo9k+x2+gBXFg==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.7.0/1227faace2afe5bd1d31d0072c4c0edb361270de}
     peerDependencies:
       bits-ui: ^2.18.0
       svelte: ^5.0.0
@@ -4078,7 +4078,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.6.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.7.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       bits-ui: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       date-fns: 4.1.0

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -23,7 +23,16 @@
 		"zoomDay": "Day",
 		"zoomWeek": "Week",
 		"zoomMonth": "Month",
-		"zoomYear": "Year"
+		"zoomYear": "Year",
+		"barResizeStart": "Resize start date",
+		"barResizeEnd": "Resize end date",
+		"canvasRegion": "Timeline canvas",
+		"statusMoved": "Moved: {range}",
+		"statusResizeStart": "Start date changed: {range}",
+		"statusResizeEnd": "End date changed: {range}",
+		"statusKeyMoved": "Moved by keyboard: {range}",
+		"statusKeyResizeStart": "Start date changed by keyboard: {range}",
+		"statusKeyResizeEnd": "End date changed by keyboard: {range}"
 	},
 	"resources": {
 		"manage": "Manage people",

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -23,7 +23,16 @@
 		"zoomDay": "日",
 		"zoomWeek": "週",
 		"zoomMonth": "月",
-		"zoomYear": "年"
+		"zoomYear": "年",
+		"barResizeStart": "開始日リサイズ",
+		"barResizeEnd": "終了日リサイズ",
+		"canvasRegion": "タイムライン",
+		"statusMoved": "移動: {range}",
+		"statusResizeStart": "開始日変更: {range}",
+		"statusResizeEnd": "終了日変更: {range}",
+		"statusKeyMoved": "キー移動: {range}",
+		"statusKeyResizeStart": "キー開始日変更: {range}",
+		"statusKeyResizeEnd": "キー終了日変更: {range}"
 	},
 	"resources": {
 		"manage": "人を管理",

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -150,6 +150,22 @@
 			assignments={timelineAssignments}
 			bind:viewportStart
 			{zoom}
+			resourceColWidth="auto"
+			labels={{
+				bar: {
+					resizeStart: t('timeline.barResizeStart'),
+					resizeEnd: t('timeline.barResizeEnd')
+				},
+				canvas: { region: t('timeline.canvasRegion') },
+				status: {
+					move: (range) => t('timeline.statusMoved', { range }),
+					resizeStart: (range) => t('timeline.statusResizeStart', { range }),
+					resizeEnd: (range) => t('timeline.statusResizeEnd', { range }),
+					keyMove: (range) => t('timeline.statusKeyMoved', { range }),
+					keyResizeStart: (range) => t('timeline.statusKeyResizeStart', { range }),
+					keyResizeEnd: (range) => t('timeline.statusKeyResizeEnd', { range })
+				}
+			}}
 			onMove={handleUpdate}
 			onResize={handleUpdate}
 		/>


### PR DESCRIPTION
## Summary

ui-components **0.7.0** で公開された 2 つの新機能を取り込む follow-up:

- **#33 (i18n labels)**: \`<ResourceTimeline labels={...}>\` で resource-planner の locale に追従。 ライブラリ default の英語 hardcode (Bar resize handle aria-label / canvas region / 6 種類の status template) をすべて i18n key 経由に
- **#34 (auto-fit)**: \`resourceColWidth=\"auto\"\` で resource rail を最長 name に fit させる。 短名で余白少なく、 長名で省略されにくい。 CSS Grid \`fit-content\` の CSS-only 解決

## 変更ファイル

- \`web/package.json\` / \`pnpm-lock.yaml\`: \`@tommykey-apps/ui-components\` **0.6.0 → 0.7.0**
- \`web/src/lib/i18n/{en,ja}.json\` の \`timeline\` セクションに **9 key 追加**:
  - \`barResizeStart\` / \`barResizeEnd\`
  - \`canvasRegion\`
  - \`status{Moved,ResizeStart,ResizeEnd,KeyMoved,KeyResizeStart,KeyResizeEnd}\` ({range} プレースホルダ補間)
- \`web/src/routes/+page.svelte\` の \`<ResourceTimeline>\` に \`labels={...}\` + \`resourceColWidth=\"auto\"\`

## Counts

unit **276 passed** (+3 from main 273)、 e2e **6 passed** 維持。

## Test plan

- [x] \`pnpm install\` 緑、 ui-components 0.7.0 解決
- [x] \`pnpm test\` 緑
- [x] \`pnpm build\` 緑
- [x] \`pnpm check\` で本 PR 由来のエラー無し
- [ ] 本番反映後 manual:
  - en locale で resize handle / drag 後の aria-live が英語
  - ja locale で同 a11y が日本語
  - 短名のみの ResourceTimeline で rail が約 100px (auto-fit min)
  - 長名混在で rail が最長に揃う (約 200-400px)
  - 6 ヶ月 bar の label が sticky で viewport 追従 (#32 の効果)