### PR TITLE
fix(home): rollback resourceColWidth to 200px + add home layout regression spec (fixes #162)

### DIFF
--- a/web/e2e/home-layout.spec.ts
+++ b/web/e2e/home-layout.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from '@playwright/test';
+import { clearMagicLinks, getMagicLinkUrl } from './fixtures/magic-link';
+
+/**
+ * Home (/) を sign-in 後に開いた時の **visual layout regression** を守る spec。
+ *
+ * 経緯: ui-components 0.6.0 → 0.7.0 bump で `<ResourceTimeline resourceColWidth="auto">`
+ * を opt-in した結果、 sticky な resource rail が CSS Grid の column sizing と相互作用
+ * して **column 1 が 1px に潰れる** 本番事故が起きた。 unit / build / check / 既存 e2e は
+ * 全て緑だったが、 home の実 layout を assert する e2e が存在しなかったため検知できず。
+ *
+ * 本 spec の責務:
+ *   - timeline / resource rail / bar が **viewport 内で見える幅** を持っていること
+ *   - rail が極端に縮んでない (= 1px 等の collapse) こと
+ *   - bar の label が rail の上に重なってない (= rail と bar が disjoint な x 範囲)
+ *
+ * これらは visual diff (Percy 等) 無しで bounding box の数値検査だけで成立する。
+ */
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeEach(async () => {
+	await clearMagicLinks();
+});
+
+async function signIn(page: import('@playwright/test').Page) {
+	await page.goto('/sign-in');
+	await page.fill('input[name="email"]', 'allowed@example.com');
+	await page.click('button[type="submit"]');
+	await expect(page).toHaveURL(/\/sign-in\/check-email/);
+	const url = await getMagicLinkUrl('allowed@example.com');
+	await page.goto(url);
+	await expect(page).toHaveURL(/^http:\/\/localhost:4173\/(\?|$)/);
+}
+
+async function bootstrap1Assignment(page: import('@playwright/test').Page, suffix: string) {
+	// crud-flow.spec.ts と同じ pattern (EN locale 前提、 CI default の Accept-Language)
+	await page.getByRole('button', { name: /Manage people/ }).click();
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+	await page.locator('input[name="name"]').fill(`r-${suffix}`);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: `r-${suffix}` })).toBeVisible();
+	await page.keyboard.press('Escape');
+
+	await page.getByRole('button', { name: /Manage projects/ }).click();
+	await page.getByRole('button', { name: /\+ Add project/ }).click();
+	await page.locator('input[name="name"]').fill(`p-${suffix}`);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: `p-${suffix}` })).toBeVisible();
+	await page.keyboard.press('Escape');
+
+	await page.getByRole('button', { name: /Add assignment/ }).click();
+	await page.getByRole('button', { name: /^Create$/ }).last().click();
+}
+
+test('home: ResourceTimeline の rail が collapse せず、 bar も visible', async ({ page }) => {
+	await signIn(page);
+	await bootstrap1Assignment(page, `layout-${Date.now()}`);
+	await page.goto('/?d=2026-05-12&z=day');
+
+	// timeline 全体
+	const timeline = page.locator('div.timeline, [class~="timeline"]').first();
+	await expect(timeline).toBeVisible();
+
+	// resource rail: 元の固定幅 200px (#34 rollback) または auto-fit の minmax 100 → 100px 以上
+	// 1px に潰れたら fail。 spec の本質は「collapse 検出」
+	const rail = page.locator('aside.resources, [class~="resources"]').first();
+	await expect(rail).toBeVisible();
+	const railBox = await rail.boundingBox();
+	expect(railBox).not.toBeNull();
+	expect(
+		railBox!.width,
+		`resource rail width=${railBox!.width}px (#34 collapse regression — expected ~200px)`
+	).toBeGreaterThan(50);
+
+	// bar: 1 件以上見えてること + label が読める幅
+	const firstBar = page.locator('div.bar, [class~="bar"]').first();
+	await expect(firstBar).toBeVisible();
+	const barBox = await firstBar.boundingBox();
+	expect(barBox).not.toBeNull();
+	expect(barBox!.width).toBeGreaterThan(20);
+
+	// header の col 2 (canvas) が rail の右側に位置 (= column 1 = rail が collapse してない結果)
+	const headers = page.locator('div.headers, [class~="headers"]').first();
+	const headersBox = await headers.boundingBox();
+	expect(headersBox).not.toBeNull();
+	expect(
+		headersBox!.x,
+		`headers.x=${headersBox!.x} but rail.right=${railBox!.x + railBox!.width}: ` +
+			'rail と canvas (headers) が重なっている = column 1 が collapse'
+	).toBeGreaterThanOrEqual(railBox!.x + railBox!.width - 5);
+});

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -145,12 +145,18 @@
 			ariaLabels={{ prev: t('timeline.prevAria'), next: t('timeline.nextAria') }}
 		/>
 
+		<!--
+			#34 (resourceColWidth="auto") は本番で resource rail を 1px に潰し、 bar が rail
+			領域に侵食する重大な layout bug を発生させた (sticky element + CSS Grid `minmax +
+			fit-content` の interaction で min track が効かない)。 ui-components 側で改修される
+			まで固定幅に戻す。 home-layout.spec.ts が regression を守る。
+		-->
 		<ResourceTimeline
 			{resources}
 			assignments={timelineAssignments}
 			bind:viewportStart
 			{zoom}
-			resourceColWidth="auto"
+			resourceColWidth={200}
 			labels={{
 				bar: {
 					resizeStart: t('timeline.barResizeStart'),


### PR DESCRIPTION
## Summary

PR #161 で取り込んだ \`<ResourceTimeline resourceColWidth=\"auto\">\` (ui-components 0.7.0 #34) が、 sticky element + CSS Grid \`minmax(min, fit-content)\` + min-width:0 の interaction で **column 1 を 1px に潰す重大な layout regression** を発生させた。

Playwright MCP で本番再現確認:
\`\`\`
grid-template-columns: \"1px 896px\"   ← column 1 = 1px !!
rail.width = 1px
\`\`\`

期待は \`minmax(100px, fit-content(400px))\` で min 100px だが、 sticky element の min-content への寄与で grid track が **track 0** に折り畳まれる挙動 (実装上の spec/intent 不整合)。

## 修正

- **\`web/src/routes/+page.svelte\`**: \`resourceColWidth=\"auto\"\` → \`resourceColWidth={200}\` (固定幅、 #161 以前の挙動に rollback)
- **\`web/e2e/home-layout.spec.ts\` 新規**: sign-in → fixture → home goto → rail width が collapse してないことを assert。 「rail width <= 50px」 を直接検出

## test で検知できなかった理由

unit / build / check / 既存 e2e (sign-in / smoke / delete-flow / crud-flow / rollback / assignments-mobile) すべて緑だったが、 **home (/) を実 layout で開く e2e が 1 件も無かった**。

user 指摘:
> こんな開いた瞬間にわかるバグが検知できなかったのは消費アプリ側の visual テストが足りない

その通り。 今回追加した \`home-layout.spec.ts\` が同 regression を CI で確実に赤にする。

## Counts

- unit **290 passed**
- e2e **10 passed** (新 \`home-layout.spec.ts\` 含む)
- \`pnpm check\` 既存 auth.ts 1 件以外緑

## TDD cycle 確認

- RED: \`resourceColWidth=\"auto\"\` 状態で新 e2e が rail.width=1 を検出 → fail
- GREEN: \`resourceColWidth={200}\` に rollback → 全 spec 緑

## Follow-up (別 issue で対応予定)

- ui-components #32 (sticky label) を revert: \`.bar { overflow: hidden }\` + \`.label { position: sticky }\` は CSS spec 的に containing block 内に閉じ込められ viewport まで届かない → CSS-only では成立不可
- ui-components #34 (auto-fit) を fix or revert: \`.resources\` に explicit width を復活、 grid sizing を rethink

fixes #162