### PR TITLE
feat(ui): bump ui-components 0.7.0 → 0.8.0 + tooltip-always-on e2e (#39)

### DIFF
--- a/web/e2e/home-layout.spec.ts
+++ b/web/e2e/home-layout.spec.ts
@@ -90,3 +90,23 @@ test('home: ResourceTimeline の rail が collapse せず、 bar も visible', a
 			'rail と canvas (headers) が重なっている = column 1 が collapse'
 	).toBeGreaterThanOrEqual(railBox!.x + railBox!.width - 5);
 });
+
+/**
+ * ui-components 0.8.0 で #32 sticky label が revert され、 hover tooltip が常時 enabled に
+ * なった (#39)。 旧仕様 (ellipsis 切れ時のみ tooltip) からの behavior change を CI で守る。
+ */
+test('home: hover で bar の tooltip が常時表示される (ui-components 0.8.0 #39)', async ({
+	page
+}) => {
+	await signIn(page);
+	await bootstrap1Assignment(page, `tooltip-${Date.now()}`);
+	await page.goto('/?d=2026-05-12&z=day');
+
+	const firstBar = page.locator('div.bar, [class~="bar"]').first();
+	await expect(firstBar).toBeVisible();
+	await firstBar.hover();
+
+	// bits-ui floating-ui の wrapper + .ui-bar-tooltip を await
+	const tooltip = page.locator('.ui-bar-tooltip').first();
+	await expect(tooltip).toBeVisible({ timeout: 1000 });
+});

--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.7.0",
+		"@tommykey-apps/ui-components": "^0.8.0",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.7.0
-        version: 0.7.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.8.0
+        version: 0.8.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1328,8 +1328,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.7.0':
-    resolution: {integrity: sha512-+/OB9fsHaO3LYVIhfmxi18HABA6hPTvcnO03yMcz/jVp3zbXeNZnprWctWXO9HnPRllGRzPSkSo9k+x2+gBXFg==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.7.0/1227faace2afe5bd1d31d0072c4c0edb361270de}
+  '@tommykey-apps/ui-components@0.8.0':
+    resolution: {integrity: sha512-DB60bZ/ZU4k3Yt2HyjXVcNxjJ8oFXGd/Z+KhCOs5Yp2h8TSpZgFjpIYPx94jWCM+R9H1t5YoXMjF9zwr7Qgp8w==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.8.0/57f5c5ea786241c6917823cb0735d073d1e06101}
     peerDependencies:
       bits-ui: ^2.18.0
       svelte: ^5.0.0
@@ -4078,7 +4078,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.7.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.8.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       bits-ui: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       date-fns: 4.1.0


### PR DESCRIPTION
## Summary

ui-components 0.8.0 で:
- **#32 sticky label を revert** (CSS spec 的に成立しない、 \`.bar { overflow: hidden }\` の containing block 制約で viewport まで届かない)
- **hover tooltip を常時 enabled** に (= 旧仕様 \`disabled={!labelTruncated}\` を撤回)。 Linear / Asana / Microsoft Project Web と同じ always-on UX、 long bar で画面外に流れた label も hover で確認可能

resource-planner 側 follow-up:
- \`@tommykey-apps/ui-components\` を **0.7.0 → 0.8.0** に bump
- **consumer code 変更不要** (labels props / resourceColWidth=200 はそのまま)
- \`e2e/home-layout.spec.ts\` に **「hover で tooltip が常時表示される」 spec** を追加 (旧仕様への regression 防止)

## Counts

- unit **290 passed** (regression なし)
- e2e **11 passed** (+1 tooltip always-on)
- \`pnpm check\` 既存 auth.ts のみ

## Test plan

- [x] \`pnpm test\` 緑
- [x] \`pnpm test:e2e\` 緑 (新 hover tooltip spec 含む)
- [x] \`pnpm build\` 緑
- [ ] 本番反映後 manual: home で bar に hover → tooltip が常時表示
- [ ] \`#162\` の本番修復確認 (rail 200px、 bar が rail に侵食しない)

## 関連

- \`tommykey-apps/resource-planner#162\` (home rail collapse、 #163 で immediate rollback、 本 PR が long-term fix)
- \`tommykey-apps/ui-components#39\` (sticky revert + tooltip 常時)