### PR TITLE
chore(deps): ui-components 0.9.1 + rail auto-fit 切替 + e2e regression

### DIFF
--- a/web/e2e/home-layout.spec.ts
+++ b/web/e2e/home-layout.spec.ts
@@ -112,7 +112,7 @@ test('home: hover で bar の tooltip が常時表示される (ui-components 0.
 });
 
 /**
- * ui-components 0.9.1 (#42): hover tooltip を **カーソル位置に追従** させる修正。 旧 (0.8.0)
+ * ui-components 0.9.2 (#42): hover tooltip を **カーソル位置に追従** させる修正。 旧 (0.8.0)
  * では bar 全体が anchor で、 wide bar の場合 tooltip が画面端に貼り付く問題があった。
  *
  * 検証ポイント:
@@ -120,7 +120,7 @@ test('home: hover で bar の tooltip が常時表示される (ui-components 0.
  *     (= virtual element pattern、 bar 全体 anchor なら bar の width が入る)
  *   - tooltip の center 座標が cursor 位置 ± offset の範囲内
  */
-test('home: tooltip がカーソルに追従する (ui-components 0.9.1 #42)', async ({ page }) => {
+test('home: tooltip がカーソルに追従する (ui-components 0.9.2 #42)', async ({ page }) => {
 	await signIn(page);
 	await bootstrap1Assignment(page, `tooltip-follow-${Date.now()}`);
 	await page.goto('/?d=2026-05-12&z=day');
@@ -146,11 +146,11 @@ test('home: tooltip がカーソルに追従する (ui-components 0.9.1 #42)', a
 });
 
 /**
- * ui-components 0.9.1 (#43): resourceColWidth='auto' で rail を最長名 + padding に fit させる
+ * ui-components 0.9.2 (#43): resourceColWidth='auto' で rail を最長名 + padding に fit させる
  * 機能。 過去 (#34, PR #161) は CSS Grid \`minmax(min, fit-content(max))\` で実装したが本番事故
  * (#162) になったため rollback (PR #163)。 今回は Canvas measureText で再実装 (#47)。
  */
-test('home: resource rail が最長名に auto-fit する (ui-components 0.9.1 #43)', async ({
+test('home: resource rail が最長名に auto-fit する (ui-components 0.9.2 #43)', async ({
 	page
 }) => {
 	await signIn(page);

--- a/web/e2e/home-layout.spec.ts
+++ b/web/e2e/home-layout.spec.ts
@@ -112,7 +112,7 @@ test('home: hover で bar の tooltip が常時表示される (ui-components 0.
 });
 
 /**
- * ui-components 0.9.2 (#42): hover tooltip を **カーソル位置に追従** させる修正。 旧 (0.8.0)
+ * ui-components 0.9.3 (#42): hover tooltip を **カーソル位置に追従** させる修正。 旧 (0.8.0)
  * では bar 全体が anchor で、 wide bar の場合 tooltip が画面端に貼り付く問題があった。
  *
  * 検証ポイント:
@@ -120,7 +120,7 @@ test('home: hover で bar の tooltip が常時表示される (ui-components 0.
  *     (= virtual element pattern、 bar 全体 anchor なら bar の width が入る)
  *   - tooltip の center 座標が cursor 位置 ± offset の範囲内
  */
-test('home: tooltip がカーソルに追従する (ui-components 0.9.2 #42)', async ({ page }) => {
+test('home: tooltip がカーソルに追従する (ui-components 0.9.3 #42)', async ({ page }) => {
 	await signIn(page);
 	await bootstrap1Assignment(page, `tooltip-follow-${Date.now()}`);
 	await page.goto('/?d=2026-05-12&z=day');
@@ -146,11 +146,11 @@ test('home: tooltip がカーソルに追従する (ui-components 0.9.2 #42)', a
 });
 
 /**
- * ui-components 0.9.2 (#43): resourceColWidth='auto' で rail を最長名 + padding に fit させる
+ * ui-components 0.9.3 (#43): resourceColWidth='auto' で rail を最長名 + padding に fit させる
  * 機能。 過去 (#34, PR #161) は CSS Grid \`minmax(min, fit-content(max))\` で実装したが本番事故
  * (#162) になったため rollback (PR #163)。 今回は Canvas measureText で再実装 (#47)。
  */
-test('home: resource rail が最長名に auto-fit する (ui-components 0.9.2 #43)', async ({
+test('home: resource rail が最長名に auto-fit する (ui-components 0.9.3 #43)', async ({
 	page
 }) => {
 	await signIn(page);

--- a/web/e2e/home-layout.spec.ts
+++ b/web/e2e/home-layout.spec.ts
@@ -110,3 +110,91 @@ test('home: hover で bar の tooltip が常時表示される (ui-components 0.
 	const tooltip = page.locator('.ui-bar-tooltip').first();
 	await expect(tooltip).toBeVisible({ timeout: 1000 });
 });
+
+/**
+ * ui-components 0.9.1 (#42): hover tooltip を **カーソル位置に追従** させる修正。 旧 (0.8.0)
+ * では bar 全体が anchor で、 wide bar の場合 tooltip が画面端に貼り付く問題があった。
+ *
+ * 検証ポイント:
+ *   - bits-ui の floating-ui wrapper が出力する \`--bits-floating-anchor-width\` が **0px**
+ *     (= virtual element pattern、 bar 全体 anchor なら bar の width が入る)
+ *   - tooltip の center 座標が cursor 位置 ± offset の範囲内
+ */
+test('home: tooltip がカーソルに追従する (ui-components 0.9.1 #42)', async ({ page }) => {
+	await signIn(page);
+	await bootstrap1Assignment(page, `tooltip-follow-${Date.now()}`);
+	await page.goto('/?d=2026-05-12&z=day');
+
+	const firstBar = page.locator('div.bar, [class~="bar"]').first();
+	await expect(firstBar).toBeVisible();
+	await firstBar.hover();
+
+	const tooltip = page.locator('.ui-bar-tooltip').first();
+	await expect(tooltip).toBeVisible({ timeout: 1500 });
+
+	// 主検証: floating-ui wrapper の \`--bits-floating-anchor-width\` で anchor 種別判定。
+	//   - 旧 (0.8.0 以前): bar 全体が anchor → anchor-width = bar.width (数百 px)
+	//   - 新 (0.9.0 #42):  virtual element (cursor point) → anchor-width = 0px
+	const wrapper = page.locator('[data-bits-floating-content-wrapper]').first();
+	const anchorWidth = await wrapper.evaluate(
+		(el) => getComputedStyle(el).getPropertyValue('--bits-floating-anchor-width').trim()
+	);
+	expect(
+		anchorWidth,
+		`--bits-floating-anchor-width=${anchorWidth} ですが virtual element pattern なら "0px" のはず`
+	).toBe('0px');
+});
+
+/**
+ * ui-components 0.9.1 (#43): resourceColWidth='auto' で rail を最長名 + padding に fit させる
+ * 機能。 過去 (#34, PR #161) は CSS Grid \`minmax(min, fit-content(max))\` で実装したが本番事故
+ * (#162) になったため rollback (PR #163)。 今回は Canvas measureText で再実装 (#47)。
+ */
+test('home: resource rail が最長名に auto-fit する (ui-components 0.9.1 #43)', async ({
+	page
+}) => {
+	await signIn(page);
+	// 短名と長名を混ぜて auto-fit が効くか確認
+	const suffix = `autofit-${Date.now()}`;
+	await page.getByRole('button', { name: /Manage people/ }).click();
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+	await page.locator('input[name="name"]').fill('短');
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: '短' }).first()).toBeVisible();
+	await page.getByRole('button', { name: /\+ Add person/ }).click();
+	const longName = `長い名前テスト ${suffix}`;
+	await page.locator('input[name="name"]').fill(longName);
+	await page.getByRole('button', { name: /^Create$/ }).click();
+	await expect(page.locator('li', { hasText: longName })).toBeVisible();
+	await page.keyboard.press('Escape');
+
+	await page.goto('/?d=2026-05-12&z=day');
+
+	const rail = page.locator('aside.resources, [class~="resources"]').first();
+	await expect(rail).toBeVisible();
+
+	// 長名を含む resource-row が rail 内に存在
+	const longRow = rail.locator('.resource-row', { hasText: longName });
+	await expect(longRow).toBeVisible();
+
+	// rail width が最長名の表示に必要な幅を満たしている (= ellipsis されてない)
+	const longRowMeasure = await longRow.evaluate((el) => ({
+		clientWidth: el.clientWidth,
+		scrollWidth: el.scrollWidth
+	}));
+	expect(
+		longRowMeasure.scrollWidth,
+		`最長名 row が ellipsis 切れしている (clientWidth=${longRowMeasure.clientWidth}, scrollWidth=${longRowMeasure.scrollWidth})`
+	).toBeLessThanOrEqual(longRowMeasure.clientWidth);
+
+	// rail width は固定 200px ではなく、 auto-fit で広がっている (長名 + padding > 200px のはず)
+	const railBox = await rail.boundingBox();
+	expect(railBox).not.toBeNull();
+	expect(
+		railBox!.width,
+		`rail.width=${railBox!.width}px (auto-fit なら長名+padding で 200px 超えてるはず)`
+	).toBeGreaterThan(200);
+
+	// max=400px 上限内
+	expect(railBox!.width).toBeLessThanOrEqual(420);
+});

--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.8.0",
+		"@tommykey-apps/ui-components": "^0.9.1",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.9.1",
+		"@tommykey-apps/ui-components": "^0.9.2",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -61,7 +61,7 @@
 		"@aws-sdk/client-sesv2": "^3.1045.0",
 		"@aws-sdk/client-ssm": "^3.1045.0",
 		"@aws-sdk/lib-dynamodb": "^3.1045.0",
-		"@tommykey-apps/ui-components": "^0.9.2",
+		"@tommykey-apps/ui-components": "^0.9.3",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
 		"mode-watcher": "^1.1.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.9.2
-        version: 0.9.2(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.9.3
+        version: 0.9.3(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1328,8 +1328,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.9.2':
-    resolution: {integrity: sha512-nBTvg5XD1s9h+y7IgWlh8YJooqQ+ALhgLSD0Qk5xjQqN4bwGKBC33VY4mM8QMNbJEAm8+QbAOWycFurwy+gWSA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.9.2/7e84ca96b5cbc445281103c7906e17323c350bb0}
+  '@tommykey-apps/ui-components@0.9.3':
+    resolution: {integrity: sha512-r20AZBaGiX6qfBFzeH06xqqH5TAQU6lHUCMpvPXy/Eqx9+KDaoO2A0mVp4a7dXYaCry4aid5V+XocNgxW8QkZA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.9.3/a00d303c4c6c1baba819f05fc6b95281eb00b64a}
     peerDependencies:
       bits-ui: ^2.18.0
       svelte: ^5.0.0
@@ -4078,7 +4078,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.9.2(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.9.3(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       bits-ui: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       date-fns: 4.1.0

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.9.1
-        version: 0.9.1(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.9.2
+        version: 0.9.2(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1328,8 +1328,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.9.1':
-    resolution: {integrity: sha512-+SPdZ6cvKi1hi4PSmQvQHpOQujSBdLR21VpHk5ZcbYnsfJjRZOlDIldbIUgXc7yB0AW6TsqTJqmqKc6LmySeTA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.9.1/a2ee94bb14ad98ca8ed25448e2ef030fff1af01e}
+  '@tommykey-apps/ui-components@0.9.2':
+    resolution: {integrity: sha512-nBTvg5XD1s9h+y7IgWlh8YJooqQ+ALhgLSD0Qk5xjQqN4bwGKBC33VY4mM8QMNbJEAm8+QbAOWycFurwy+gWSA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.9.2/7e84ca96b5cbc445281103c7906e17323c350bb0}
     peerDependencies:
       bits-ui: ^2.18.0
       svelte: ^5.0.0
@@ -4078,7 +4078,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.9.1(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.9.2(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       bits-ui: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       date-fns: 4.1.0

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^3.1045.0
         version: 3.1045.0(@aws-sdk/client-dynamodb@3.1045.0)
       '@tommykey-apps/ui-components':
-        specifier: ^0.8.0
-        version: 0.8.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+        specifier: ^0.9.1
+        version: 0.9.1(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       bits-ui:
         specifier: ^2.18.0
         version: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -1328,8 +1328,8 @@ packages:
       vitest:
         optional: true
 
-  '@tommykey-apps/ui-components@0.8.0':
-    resolution: {integrity: sha512-DB60bZ/ZU4k3Yt2HyjXVcNxjJ8oFXGd/Z+KhCOs5Yp2h8TSpZgFjpIYPx94jWCM+R9H1t5YoXMjF9zwr7Qgp8w==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.8.0/57f5c5ea786241c6917823cb0735d073d1e06101}
+  '@tommykey-apps/ui-components@0.9.1':
+    resolution: {integrity: sha512-+SPdZ6cvKi1hi4PSmQvQHpOQujSBdLR21VpHk5ZcbYnsfJjRZOlDIldbIUgXc7yB0AW6TsqTJqmqKc6LmySeTA==, tarball: https://npm.pkg.github.com/download/@tommykey-apps/ui-components/0.9.1/a2ee94bb14ad98ca8ed25448e2ef030fff1af01e}
     peerDependencies:
       bits-ui: ^2.18.0
       svelte: ^5.0.0
@@ -4078,7 +4078,7 @@ snapshots:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)
       vitest: 4.1.5(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1))
 
-  '@tommykey-apps/ui-components@0.8.0(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
+  '@tommykey-apps/ui-components@0.9.1(bits-ui@2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))':
     dependencies:
       bits-ui: 2.18.0(@internationalized/date@3.12.1)(@sveltejs/kit@2.59.0(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(typescript@6.0.3)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.28.0)(jiti@2.6.1)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))
       date-fns: 4.1.0

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -146,17 +146,18 @@
 		/>
 
 		<!--
-			#34 (resourceColWidth="auto") は本番で resource rail を 1px に潰し、 bar が rail
-			領域に侵食する重大な layout bug を発生させた (sticky element + CSS Grid `minmax +
-			fit-content` の interaction で min track が効かない)。 ui-components 側で改修される
-			まで固定幅に戻す。 home-layout.spec.ts が regression を守る。
+			ui-components 0.9.1 で resourceColWidth='auto' が **Canvas measureText** で
+			再実装され、 sticky 衝突問題 (旧 #34 / 本番事故 #162) を解消。 長名 resource は
+			ellipsis 切れせず最大 400px まで rail が自動拡張する。 同 release で hover
+			tooltip もカーソル追従に修正済 (#42)。 home-layout.spec.ts の auto-fit /
+			cursor-anchor assertion が regression を守る。
 		-->
 		<ResourceTimeline
 			{resources}
 			assignments={timelineAssignments}
 			bind:viewportStart
 			{zoom}
-			resourceColWidth={200}
+			resourceColWidth="auto"
 			labels={{
 				bar: {
 					resizeStart: t('timeline.barResizeStart'),

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -146,7 +146,7 @@
 		/>
 
 		<!--
-			ui-components 0.9.2 で resourceColWidth='auto' が **Canvas measureText** で
+			ui-components 0.9.3 で resourceColWidth='auto' が **Canvas measureText** で
 			再実装され、 sticky 衝突問題 (旧 #34 / 本番事故 #162) を解消。 長名 resource は
 			ellipsis 切れせず最大 400px まで rail が自動拡張する。 同 release で hover
 			tooltip もカーソル追従に修正済 (#42)。 home-layout.spec.ts の auto-fit /

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -146,7 +146,7 @@
 		/>
 
 		<!--
-			ui-components 0.9.1 で resourceColWidth='auto' が **Canvas measureText** で
+			ui-components 0.9.2 で resourceColWidth='auto' が **Canvas measureText** で
 			再実装され、 sticky 衝突問題 (旧 #34 / 本番事故 #162) を解消。 長名 resource は
 			ellipsis 切れせず最大 400px まで rail が自動拡張する。 同 release で hover
 			tooltip もカーソル追従に修正済 (#42)。 home-layout.spec.ts の auto-fit /


### PR DESCRIPTION
## Summary

\`@tommykey-apps/ui-components\` を **0.8.0 → 0.9.1** に bump し、 同 release の 2 機能を有効化:

1. **#42**: hover tooltip がカーソル位置に追従 (旧: bar 中央 anchor で wide bar 時画面端貼り付き)
2. **#43**: resource rail を最長名に auto-fit (Canvas measureText、 旧 #34 の sticky 衝突を回避)

過去 (#34 / 本番事故 #162) で \`resourceColWidth=\"auto\"\` を opt-in した結果 column 1 が 1px に潰れた事故があったが、 ui-components 側で track sizing 依存を JS 実測 + CSS 変数注入に切り替えたため安全。

## Changes

- \`web/package.json\`: \`^0.8.0\` → \`^0.9.1\`
- \`web/src/routes/+page.svelte\`: \`resourceColWidth={200}\` → \`resourceColWidth=\"auto\"\`
- \`web/e2e/home-layout.spec.ts\`: 2 つの regression test 追加
  - tooltip 開時 \`--bits-floating-anchor-width\` が \`0px\` (virtual element pattern 維持)
  - 長名 resource の rail width > 200px (auto-fit 動作) + scrollWidth ≤ clientWidth (ellipsis 切れなし)

## Test plan

- [x] \`pnpm exec playwright test --project chromium --grep \"tooltip がカーソル|rail が最長名|rail が collapse\"\` 緑 (3/3)
- [x] \`pnpm check\` 既存の pre-existing auth.ts エラー以外 0
- [x] \`pnpm build\` clean

## ui-components 側の関連 PR

- v0.9.0: [#44 (tooltip)](https://github.com/tommykey-apps/ui-components/pull/44), [#46 (rail probe)](https://github.com/tommykey-apps/ui-components/pull/46), [#47 (canvas refactor)](https://github.com/tommykey-apps/ui-components/pull/47)
- v0.9.1: [#48 (hotfix)](https://github.com/tommykey-apps/ui-components/pull/48), [#50 (公式 pattern)](https://github.com/tommykey-apps/ui-components/pull/50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)