### PR TITLE
chore: コーディング後 audit を自動推奨する Claude Code hook + CI audit

### DIFF
--- a/.claude/hooks/post-edit-touch.sh
+++ b/.claude/hooks/post-edit-touch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# PostToolUse hook (Edit / Write): 編集されたファイルを `.claude/state/dirty-files.log`
+# に記録し、 dirty.flag を touch する。 後で stop-audit-gate.sh や /audit skill が
+# 状態を確認するために使う。
+#
+# `.claude/state/` 配下や build 出力 / node_modules への書き込みは無視 (audit 対象外)。
+#
+# refs: https://code.claude.com/docs/en/hooks
+set -euo pipefail
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+[ -z "$file_path" ] && exit 0
+
+# 監査対象外: build 出力 / node_modules / .claude/state 自身
+case "$file_path" in
+  */node_modules/*|*/.svelte-kit/*|*/dist/*|*/build/*|*/.claude/state/*)
+    exit 0 ;;
+esac
+
+# Source 拡張子のみ (Markdown / yaml 等は audit ターゲットでないので除外)
+case "$file_path" in
+  *.ts|*.tsx|*.js|*.jsx|*.svelte|*.css) ;;
+  *) exit 0 ;;
+esac
+
+# project root は hook 配置場所から逆算
+project_root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+state_dir="$project_root/.claude/state"
+mkdir -p "$state_dir"
+
+echo "$file_path" >> "$state_dir/dirty-files.log"
+touch "$state_dir/dirty.flag"
+
+exit 0

--- a/.claude/hooks/stop-audit-gate.sh
+++ b/.claude/hooks/stop-audit-gate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Stop hook: 直前ターンでソース変更があったら次ターンの additionalContext に
+# 「`/audit` を走らせて」 と通知する。 強制 block はしない (推奨)。
+#
+# `.claude/state/dirty.flag` の有無で判定。 `/audit` skill 完了時に flag が
+# 削除されるので、 audit 済なら再警告しない。
+#
+# refs: https://code.claude.com/docs/en/hooks
+set -euo pipefail
+
+project_root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+state_dir="$project_root/.claude/state"
+flag="$state_dir/dirty.flag"
+log="$state_dir/dirty-files.log"
+
+[ -f "$flag" ] || exit 0
+
+# 直近変更ファイル一覧 (dedup、最大 20 件)
+files=""
+if [ -f "$log" ]; then
+  files=$(sort -u "$log" 2>/dev/null | head -20 | sed 's|^|- |')
+fi
+[ -z "$files" ] && exit 0
+
+# additionalContext で次ターンの Claude に通知
+msg=$(printf '直前のターンでソース変更がありました。 \`/audit\` の実行を推奨します (型 / test / knip / jscpd / madge + 必要に応じて code-reviewer agent)。\n\n変更ファイル:\n%s\n\n(audit を skip したい場合は `.claude/state/dirty.flag` を `rm` で削除)' "$files")
+
+jq -n --arg ctx "$msg" '{
+  hookSpecificOutput: {
+    hookEventName: "Stop",
+    additionalContext: $ctx
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,27 @@
 					}
 				]
 			}
+		],
+		"PostToolUse": [
+			{
+				"matcher": "Edit|Write",
+				"hooks": [
+					{
+						"type": "command",
+						"command": ".claude/hooks/post-edit-touch.sh"
+					}
+				]
+			}
+		],
+		"Stop": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": ".claude/hooks/stop-audit-gate.sh"
+					}
+				]
+			}
 		]
 	}
 }

--- a/.claude/state/.gitignore
+++ b/.claude/state/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,0 +1,45 @@
+name: Audit
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# ローカルの `/audit` 推奨をバイパスされても CI で同じ品質ゲートを通す。
+# 失敗しても merge ブロックはしない (warning レベル、 別の job で main CI を維持)。
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm install --frozen-lockfile
+
+      - name: knip (unused exports / files / dependencies)
+        run: pnpm dlx knip --no-config-hints --reporter symbols
+        continue-on-error: true
+
+      - name: jscpd (duplicate code detection)
+        run: pnpm dlx jscpd src --min-tokens 50 --reporters consoleSummary
+        continue-on-error: true
+
+      - name: madge (circular dependencies)
+        run: pnpm dlx madge --circular --extensions ts,svelte,js src
+        continue-on-error: true


### PR DESCRIPTION
## Summary

[tommykey-apps/ui-components#76](https://github.com/tommykey-apps/ui-components/pull/76) と同じ自動化セットアップを resource-planner にも適用。

レビューで「コード品質 audit (knip / jscpd / madge 等の静的解析 + reviewer agent) を走らせてない」 と指摘を受けたので、 今後同じ漏れを防ぐ仕組み。

## 仕組み (4 層)

| 層 | 役割 |
|---|---|
| **PostToolUse hook** (\`Edit\|Write\`) | 編集ファイルを \`.claude/state/dirty-files.log\` に記録 + \`dirty.flag\` touch |
| **Stop hook** | dirty なら次ターンの \`additionalContext\` に「\`/audit\` 推奨」を soft 通知 (強制 block ではない) |
| **\`/audit\` skill** (user-level) | \`pnpm check\` / \`pnpm test\` / \`knip\` / \`jscpd\` / \`madge\` → 必要なら \`code-reviewer\` agent → dirty クリア |
| **CI audit workflow** | ローカルバイパスを防ぐ、 PR 時に同じ静的解析、 \`continue-on-error\` で main CI と分離 |

## resource-planner 固有

- CI workflow は \`defaults.run.working-directory: web\` で \`web/\` 配下で実行
- \`@tommykey-apps/ui-components\` private package 取得のため \`GITHUB_TOKEN\` を install step に渡す

## 新規ファイル

- \`.claude/hooks/post-edit-touch.sh\`
- \`.claude/hooks/stop-audit-gate.sh\`
- \`.claude/state/.gitignore\`
- \`.github/workflows/audit.yaml\`

## 関連

- user-level: \`~/.claude/agents/code-reviewer.md\` + \`~/.claude/skills/audit/SKILL.md\`
- ui-components: [#76](https://github.com/tommykey-apps/ui-components/pull/76)

🤖 Generated with [Claude Code](https://claude.com/claude-code)