### PR TITLE
fix(audit): knip 検出 dead code を削除 + knip.json で false positive 除外 (closes #191)

### DIFF
--- a/web/knip.json
+++ b/web/knip.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "https://unpkg.com/knip@5/schema.json",
+	"entry": [
+		"src/auth.ts",
+		"src/lambda/*.ts",
+		"src/routes/**/+*.{ts,svelte}",
+		"e2e/**/*.ts"
+	],
+	"project": ["src/**/*.{ts,svelte}"],
+	"ignore": [
+		"src/lib/index.ts"
+	],
+	"ignoreDependencies": [
+		"@fontsource-variable/jetbrains-mono",
+		"tw-animate-css"
+	],
+	"ignoreExportsUsedInFile": true
+}

--- a/web/src/lib/components/AssignmentCreator.svelte
+++ b/web/src/lib/components/AssignmentCreator.svelte
@@ -3,7 +3,7 @@
 	import Plus from 'phosphor-svelte/lib/Plus';
 	import { Button } from './ui/button';
 	import Dialog from './Dialog.svelte';
-	import { formatLocalDate } from '$lib/timeline-adapter';
+	import { formatLocalDate } from '$lib/date';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
 	import { t } from '$lib/i18n/index.svelte';

--- a/web/src/lib/i18n/index.svelte.ts
+++ b/web/src/lib/i18n/index.svelte.ts
@@ -65,14 +65,6 @@ class LocaleState {
 
 export const localeState = new LocaleState();
 
-export function getLocale(): Locale {
-	return localeState.current;
-}
-
-export function setLocale(next: Locale): void {
-	localeState.set(next);
-}
-
 export function initLocale(serverLocale?: Locale | null): void {
 	localeState.init(serverLocale);
 }

--- a/web/src/lib/repository/team.ts
+++ b/web/src/lib/repository/team.ts
@@ -114,29 +114,3 @@ export async function getUserTeamIds(userId: string): Promise<string[]> {
 	} while (lastKey);
 	return teamIds;
 }
-
-/** Team のメンバー一覧 (team-centric)。 */
-export async function getTeamMembers(teamId: string): Promise<TeamMembership[]> {
-	const members: TeamMembership[] = [];
-	let lastKey: QueryCommandInput['ExclusiveStartKey'];
-	do {
-		const out = await ddb.send(
-			new QueryCommand({
-				TableName: TABLE,
-				KeyConditionExpression: 'pk = :pk AND begins_with(sk, :m)',
-				ExpressionAttributeValues: { ':pk': pk(teamId), ':m': 'MEMBER#' },
-				ExclusiveStartKey: lastKey
-			})
-		);
-		for (const item of out.Items ?? []) {
-			members.push({
-				teamId: item.teamId,
-				userId: item.userId,
-				role: item.role,
-				joinedAt: item.joinedAt
-			});
-		}
-		lastKey = out.LastEvaluatedKey;
-	} while (lastKey);
-	return members;
-}

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -123,10 +123,6 @@ export const assignmentFormUpdateSchema = z
 		}
 	}));
 
-/** フォーム生 shape (UX inclusive)。`+page.svelte` のフォームバインディングで使う。 */
-export type AssignmentCreateInput = z.input<typeof assignmentCreateSchema>;
-export type AssignmentUpdateInput = z.input<typeof assignmentUpdateSchema>;
-
 /** Post-transform shape (storage)。repository が受け取る型。 */
 export type AssignmentCreatePayload = z.output<typeof assignmentCreateSchema>;
 export type AssignmentUpdatePayload = z.output<typeof assignmentUpdateSchema>;
@@ -153,4 +149,3 @@ export const assignmentApiUpdateSchema = z
 		path: ['endDateExclusive']
 	});
 
-export type AssignmentApiUpdateInput = z.infer<typeof assignmentApiUpdateSchema>;

--- a/web/src/lib/timeline-adapter.ts
+++ b/web/src/lib/timeline-adapter.ts
@@ -40,6 +40,3 @@ export function fromTimelineAssignment(t: TimelineAssignment, prev: DbAssignment
 		endDateExclusive: formatLocalDate(t.endDate)
 	};
 }
-
-// 後方互換: AssignmentCreator など既存コードが直接 import している。`lib/date.ts` から re-export。
-export { parseLocalDate, formatLocalDate } from './date';


### PR DESCRIPTION
## Summary

Issue [#191](https://github.com/tommykey-apps/resource-planner/issues/191) で起票した静的解析 findings (knip / jscpd / madge) のうち、 **knip 由来の dead code** を削除 + false positive を \`knip.json\` で除外。 修正後 \`pnpm dlx knip\` は exit 0 で出力ゼロ (完全 clean)。

## 削除した dead code

| 場所 | 内容 |
|---|---|
| \`web/src/lib/timeline-adapter.ts:45\` | \`parseLocalDate\` / \`formatLocalDate\` の dead re-export (consumer は全員 \`\$lib/date\` から直接 import、 唯一の例外 \`AssignmentCreator.svelte\` も同 PR で修正) |
| \`web/src/lib/i18n/index.svelte.ts\` | 未使用の \`getLocale\` / \`setLocale\` (locale 切替は \`LocaleSwitcher.svelte\` が \`localeState\` を直接 mutate) |
| \`web/src/lib/repository/team.ts\` | 未使用の \`getTeamMembers\` (multi-team 化時に再追加、 YAGNI) |
| \`web/src/lib/schemas/index.ts\` | 未使用 input/infer types: \`AssignmentCreateInput\` / \`AssignmentUpdateInput\` / \`AssignmentApiUpdateInput\` |

## 新規 \`web/knip.json\`

false positives を除外:
- \`ignore: [\"src/lib/index.ts\"]\` — SvelteKit default barrel (中身空)
- \`ignoreDependencies: [\"@fontsource-variable/jetbrains-mono\", \"tw-animate-css\"]\` — CSS \`@import\` 経由で使用 (knip は CSS スキャンしない)
- \`ignoreExportsUsedInFile: true\` — \`SuppressionReason\` 等の同ファイル内利用を許容
- \`entry\`: auth.ts / lambda / routes / e2e (knip 自動検出されない entry を明示)

## Verification

- \`pnpm check\`: pre-existing \`auth.ts:67\` / \`+page.svelte\` unused CSS 以外 0
- \`pnpm test\`: **290 passed** (flaky bits-ui body-scroll-lock 由来の uncaught exception は #165 時代から既知、 本 PR 影響外)
- \`pnpm dlx knip\`: **exit 0、 出力ゼロ (完全 clean)**

## 残課題 (#191 でカバーしていない部分)

issue #191 内で「既存 issue と重複」 とリンクした jscpd findings:
- schema refine+transform 重複 (#173)
- repository/{project,resource}.ts 重複 (#172)
- +page.server.ts form action 重複 (#171)

これらは別 PR で別途対応 (本 PR scope 外)。

## Refs
- Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)