### PR TITLE
feat(csp): kit.csp 単一統合 + OWASP baseline CSP + 他 security header (PR-N0)

### DIFF
--- a/web/e2e/csp.spec.ts
+++ b/web/e2e/csp.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * PR-N0: CSP header (kit.csp 単一統合) の regression test。
+ *
+ * 設計判断:
+ * - `svelte.config.js` の `kit.csp` 単一で全 directive を出す (hooks.server.ts では touch しない)
+ * - `mode: 'auto'` で SSR page に nonce を SvelteKit が自動付与
+ * - `style-src 'unsafe-inline'` は Svelte transition / Tailwind 都合で当面残す (nonce 化は別 issue)
+ *
+ * OWASP CSP Cheat Sheet baseline:
+ * - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
+ * - `default-src 'self'` / `object-src 'none'` / `base-uri 'self'` / `form-action 'self'` / `frame-ancestors 'none'` を必須
+ *
+ * Playwright response header は **lowercase normalize** される ([Playwright docs](https://playwright.dev/docs/api/class-response#response-headers))。
+ */
+
+test('CSP header includes OWASP baseline directives on SSR page (sign-in)', async ({ page }) => {
+	const response = await page.goto('/sign-in');
+	expect(response).not.toBeNull();
+	const csp = response!.headers()['content-security-policy'];
+	expect(csp).toBeTruthy();
+
+	expect(csp).toContain("default-src 'self'");
+	expect(csp).toContain("object-src 'none'");
+	expect(csp).toContain("base-uri 'self'");
+	expect(csp).toContain("form-action 'self'");
+	expect(csp).toContain("frame-ancestors 'none'");
+	// SvelteKit kit.csp.mode='auto' が SSR で自動付与する nonce
+	expect(csp).toMatch(/script-src[^;]*'nonce-/);
+});
+
+test('CSP excludes unsafe-eval', async ({ page }) => {
+	const response = await page.goto('/sign-in');
+	const csp = response!.headers()['content-security-policy'] ?? '';
+	expect(csp).not.toContain("'unsafe-eval'");
+});
+
+test('CSP includes style-src unsafe-inline (Svelte transition / Tailwind 都合、 将来 nonce 化)', async ({
+	page
+}) => {
+	const response = await page.goto('/sign-in');
+	const csp = response!.headers()['content-security-policy'] ?? '';
+	expect(csp).toMatch(/style-src[^;]*'unsafe-inline'/);
+});
+
+test('Other security headers (X-Content-Type-Options / Referrer-Policy / Permissions-Policy)', async ({
+	page
+}) => {
+	const response = await page.goto('/sign-in');
+	const headers = response!.headers();
+	// hooks.server.ts の securityHeadersHandle で set
+	expect(headers['x-content-type-options']).toBe('nosniff');
+	expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+	expect(headers['permissions-policy']).toContain('camera=()');
+});

--- a/web/src/hooks.server.ts
+++ b/web/src/hooks.server.ts
@@ -37,4 +37,35 @@ const themeHandle: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
-export const handle: Handle = sequence(authjsHandle, localeHandle, themeHandle);
+/**
+ * security header (PR-N0)。 OWASP 推奨の baseline を付与。
+ *
+ * CSP は `svelte.config.js` の `kit.csp` 一本化のため本 hook では touch しない
+ * (hook で set すると kit.csp と上書き衝突)。 本 hook で扱うのは CSP 以外の
+ * security header のみ:
+ *
+ * - X-Content-Type-Options: MIME type sniffing 抑止
+ * - Referrer-Policy: cross-origin Referer 抑制
+ * - Permissions-Policy: camera/microphone/geolocation 等 API を完全 block
+ *
+ * 注: HSTS (Strict-Transport-Security) は CloudFront 側で設定する想定 (別 issue)、
+ * 本 hook では set しない (重複避け)。
+ *
+ * Refs:
+ * - https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html
+ * - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Permissions-Policy
+ */
+const securityHeadersHandle: Handle = async ({ event, resolve }) => {
+	const response = await resolve(event);
+	response.headers.set('X-Content-Type-Options', 'nosniff');
+	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+	return response;
+};
+
+export const handle: Handle = sequence(
+	authjsHandle,
+	localeHandle,
+	themeHandle,
+	securityHeadersHandle
+);

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -6,7 +6,37 @@ const config = {
 		runes: ({ filename }) => (filename.split(/[/\\]/).includes('node_modules') ? undefined : true)
 	},
 	kit: {
-		adapter: adapter({ out: 'build', precompress: true })
+		adapter: adapter({ out: 'build', precompress: true }),
+		// PR-N0: CSP は kit.csp 単一統合 (hooks.server.ts では touch しない)。
+		// 理由: hook で response.headers.set すると kit.csp と完全上書き衝突する
+		// (SvelteKit `csp.js` の最終 headers.set 順序依存)。 append でも browser
+		// intersection 評価で予期しない挙動になる。
+		//
+		// mode:'auto' で SSR page は nonce、 prerender page は hash を自動付与。
+		// adapter-node + 全 SSR route の前提で nonce ベース動作。
+		//
+		// directive 値は bare 'self' (TS string literal の quote のみ)。
+		// SvelteKit が出力時に CSP 正式 syntax 'self' にラップする。
+		//
+		// Refs:
+		// - https://svelte.dev/docs/kit/configuration#csp
+		// - https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
+		// - https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy
+		csp: {
+			mode: 'auto',
+			directives: {
+				'default-src': ['self'],
+				'script-src': ['self'], // SvelteKit が hydration script に nonce 自動付与
+				'style-src': ['self', 'unsafe-inline'], // Svelte transition / Tailwind 都合 (将来 nonce 化検討)
+				'img-src': ['self', 'data:'],
+				'font-src': ['self', 'data:'],
+				'connect-src': ['self'],
+				'object-src': ['none'], // OWASP 必須
+				'base-uri': ['self'], // OWASP 必須 (<base> tag injection 対策)
+				'form-action': ['self'], // OWASP 必須
+				'frame-ancestors': ['none'] // clickjacking 完全 block
+			}
+		}
 	}
 };
 


### PR DESCRIPTION
## Summary

#187 markdown 機能 (PR-N2/N4) の前提として、 `{@html}` 利用前に **CSP で XSS attack surface を最小化** する。 詳細は plan / ADR 0010 (PR-N1 で起票) 参照。

## 設計判断 (詳細調査の結果)

### CSP は `kit.csp` 単一統合
- handle hook で `headers.set('Content-Security-Policy', ...)` すると kit.csp と **完全上書き衝突** ([SvelteKit csp.js](https://github.com/sveltejs/kit/blob/main/packages/kit/src/runtime/server/page/csp.js))
- `kit.csp.mode: 'auto'` で SvelteKit が SSR page の hydration script に **nonce 自動付与**
- directive 値は **bare `['self']`** (TS literal quote のみ、 `["'self'"]` は誤り)
- directives に `'self'` 自動付与なし → 全 directive に明示

### OWASP CSP baseline 準拠
- [OWASP CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
- 必須 directive: `object-src 'none'` / `base-uri 'self'` / `form-action 'self'` / `frame-ancestors 'none'`
- `style-src 'unsafe-inline'` は Svelte transition / Tailwind 都合で残置 (将来 nonce 化は別 issue)

### 他 security header
- `X-Content-Type-Options: nosniff` (MIME sniffing 抑止)
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- HSTS は CloudFront 側で設定する想定 (別 issue、 重複避け本 PR では set しない)

## Changes

| ファイル | 変更 |
|---|---|
| `web/svelte.config.js` | `kit.csp.directives` で OWASP baseline 全 directive 設定 |
| `web/src/hooks.server.ts` | `securityHeadersHandle` で CSP 以外の security header set、 sequence に追加 |
| `web/e2e/csp.spec.ts` | 新規 (TDD): CSP 全 directive + nonce + 他 security header の regression test、 4 case |

## Verification

- `pnpm exec playwright test --project=chromium e2e/csp.spec.ts`: **4/4 緑**
- `pnpm exec playwright test --project=chromium --workers=1` 既存 17 e2e: **全緑** (並列実行は magic-link fixture flaky で別問題)
- `pnpm test` 290 passed (既存と同じ)
- `pnpm check` pre-existing auth.ts:67 以外 0 error

## Refs
- [SvelteKit kit.csp](https://svelte.dev/docs/kit/configuration#csp)
- [OWASP CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
- [OWASP HTTP Headers Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html)
- [MDN CSP Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy)

## Out of scope
- `style-src` の nonce 化 (将来 issue)
- HSTS / CSP `report-uri` (別 issue / CloudFront 側設定)
- 個別 page の prerender 化検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)