### PR TITLE
feat(project): description / tags / links を Project に追加 (PR-N1, refs #187)

### DIFF
--- a/docs/adr/0010-project-metadata.md
+++ b/docs/adr/0010-project-metadata.md
@@ -1,0 +1,179 @@
+# 0010. Project に詳細情報 (description / tags / links) を **同 item の attribute** として追加する
+
+- **Status**: Accepted
+- **Date**: 2026-05-13
+- **Deciders**: @tommykey0925
+
+## Context
+
+`Project` は現状 `{ id, name, color }` の 3 項目のみで、 「使用技術 / 案件説明 / 関連リンク」 を
+アプリ内で記入・参照できない (issue #187)。 要員計画の現場で都度別資料を開く負担がある。
+
+データモデルの選択肢:
+
+| 案 | 説明 | Read | Write | 1 item size |
+|---|---|---|---|---|
+| (A) Project entity に attribute 追加 | `PRJ#{id}` に description / tags / links を直接追加 | 既存 query で完結 | 既存 PutItem / UpdateItem で完結 | ~37KB / 400KB |
+| (B) 別 entity (`PRJDETAIL#{id}`) | 一覧表示と切り分けて読む | BatchGetItem / 別 GSI 必要 | 別途 PutItem | 分離 |
+
+`+layout.server.ts` の load は既に `pk = TEAM#X` で全件 Query しているため、 案 A の overhead は
+`marshall` で attribute が増えるだけ。 案 B は read が 2 段 (`listProjects` → 詳細 BatchGet) になり、
+SSR で markdown render する設計 (本 ADR の Decision、 後述) と合わない。
+
+実装上の制約 (調査で確認):
+
+- DynamoDB UpdateExpression は SET と REMOVE を同一 expression 内で **異なる attribute** に並べる
+  場合のみ並走可能。 同名 attribute path が SET/REMOVE で重複すると `ValidationException` で reject される
+  ([AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html))
+- `removeUndefinedValues: true` (`web/src/lib/db/client.ts`) は marshall で `undefined` 属性を消すが、
+  **空配列 `[]` は `L: []` で保存される**ため、 「未設定 = 削除」 を担保するには空判定で REMOVE を出す必要がある
+- `marked` v18 sync API + `isomorphic-dompurify` (内部 `dompurify@^3.4.2` / CVE-2024-45801 / -47875 /
+  CVE-2025-26791 修正済) は SSR / CSR / vitest jsdom 全環境で動作
+- DOMPurify default 設定では `<img>` / `<style>` が許可されている → 明示的に `FORBID_TAGS` で除外しないと
+  description で `<img onerror>` 等の XSS attack vector を残してしまう
+
+## Decision
+
+**(A) Project entity の attribute 拡張を採用する。**
+
+```
+PRJ#{id}
+  id: string
+  name: string
+  color: string         // #RRGGBB
+  description?: string  // markdown raw、 max 10,000 chars
+  tags?: string[]       // List, max 20 件 / 各 30 chars
+  links?: ProjectLink[] // List of Map, max 10 件
+```
+
+`ProjectLink = { label?: string; url: string }`。 url は `http(s)` のみ許可。
+
+### 「未設定 = REMOVE で attribute 削除」 semantics
+
+`updateProject` は attribute 単位で SET と REMOVE を mutual exclusion で出し分ける。
+description 空文字 / tags 空配列 / links 空配列 はいずれも REMOVE 側に回す:
+
+```
+SET #name = :name, color = :color, description = :description REMOVE tags, links
+```
+
+DynamoDB の REMOVE は **存在しない attribute に対しては no-op** ([AWS docs 引用](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html#Expressions.UpdateExpressions.REMOVE) "If the attributes don't exist, nothing happens") なので、 旧 item にも安全。
+`createProject` は spread 短絡で 「非空のみ Item に入れる」 ことで、 後段 query 期待値 (`attribute_exists(description)` 等) を REMOVE 動作と整合させる。
+
+### description は SSR で markdown render
+
+`+layout.server.ts` の load 内で `renderMarkdown(p.description)` を呼び、 `descriptionHtml` を
+client に渡す (PR-N4 で実装)。 client 側は `{@html descriptionHtml}` を表示するだけ。 理由:
+
+- `$effect` 内 `await import('marked')` は SSR で実行されないため初回描画で description が空になる
+- `isomorphic-dompurify` で server 側でも sanitize できる、 Lambda warm state での render は 1ms 未満
+- 初回 modal open で markdown が即見える (lazy await なし)
+
+### XSS 対策 (二段防御)
+
+1. **markdown render 層** (PR-N2): `marked` v18 sync + `isomorphic-dompurify`。
+   - `FORBID_TAGS`: `img`, `style`, `iframe`, `object`, `embed`, `form`, `input`, `button`, `script`, `svg`
+   - `FORBID_ATTR`: `style`, `onerror`, `onload`, `onclick`
+   - `ALLOWED_URI_REGEXP`: `^(?:https?|mailto):/i`
+   - `SAFE_FOR_TEMPLATES` を **使わない** (CVE-2025-26791 発火条件)
+2. **CSP 層** (PR-N0 で実装済): `script-src 'self' 'nonce-...'` で inline script 流入を block。
+
+`<a>` の `target` 属性は DOMPurify default で strip される (tabnabbing 対策) ため、 markdown 内
+リンクは同タブ遷移になる。 `ProjectDetailView` (PR-N4) の links 一覧は別途 `<a target="_blank"
+rel="noopener noreferrer">` で開く。
+
+### tags は **List of String** で保存する (Set ではない)
+
+`List<String>` (DDB `L`) を採用、 `String Set` (DDB `SS`) ではない。 理由:
+
+- DDB String Set は **空 Set 不可** で、 「ゼロ件のとき item 全体を削除しないと表現できない」 制約がある
+- List なら順序保持、 入力順 (`'TypeScript, AWS' → ['TypeScript', 'AWS']`) が UI 表示と一致
+- TS の `string[]` に素直に対応、 marshall/unmarshall に型注釈不要
+- dedup / NFC normalize は schema 層で実施するため Set のユニーク保証は不要
+
+### 「同 item 採用の境界」 (将来 split が必要になる条件)
+
+現サイズ ~37KB / DDB 1 item 上限 400KB の **10%**。 以下に該当したら別 entity 化を別 ADR で再検討:
+
+- description 10,000 chars × UTF-8 / 案件 × 全 attribute 平均で 1 item 80KB を超える
+- assignments 一覧 SSR で project 詳細を render する都合、 一覧 read overhead が体感悪化する
+  (現状 Project は teamId 内全件 Query で 1 request、 size 増は read latency に直結)
+
+## Consequences
+
+### Positive
+
+- **read 1 request で完結**: `+layout.server.ts` の既存 Query (`pk = TEAM#X`) で詳細も載る、
+  別 GSI / BatchGet 不要
+- **write 1 request で完結**: PutItem / UpdateItem 1 回で project + 詳細を atomic に書ける
+- **後方互換**: 既存 item は description / tags / links 属性なし、 TS optional + `?? []` で読める。 マイグレーション不要
+- **REMOVE semantics 一貫**: 空文字 / 空配列 / undefined は全て attribute 削除に正規化、
+  「保存されているけど空」 状態が存在しない
+- **二段防御**: markdown render の sanitize と PR-N0 で投入した CSP nonce で、 XSS attack chain を 2 層で遮断
+
+### Negative
+
+- **item size 増**: description 10KB × 案件数 で 1 item が膨らむ。 80KB 想定 (現サイズの ~2x) を
+  超えたら別 entity 分離を検討
+- **schema migration を諦める**: optional attribute なので Java/PG 流の migration はせず、
+  unmarshall 側で `?? []` で吸収。 「全 item に description がある」 と仮定するコードを書くと壊れる
+- **SSR render コスト**: Lambda cold start で `marked + isomorphic-dompurify` 初回 import に
+  +100-300ms。 warm state なら 1ms 未満で許容範囲
+- **DynamoDB Stream を将来使うと payload が膨らむ**: 現状 Stream 未使用、 将来オフロード処理 (検索 index 等)
+  を組むときに 1 record サイズが増える点に注意
+
+### Neutral
+
+- **DDB List/Map の partial update を行わない**: tags / links は全置換のみ (1 件追加でも List 全体を書き換える)。
+  現運用では編集モーダルで毎回 form 全体を送るため partial update 要件なし
+
+## Alternatives considered
+
+- **(B) 別 entity (`PRJDETAIL#{id}`)**: read が 2 段になり SSR markdown render 設計と合わない。
+  size 80KB を超えた将来時点で再検討
+- **(C) tags を `String Set` (`SS`) で保存**: 空 Set 不可で「ゼロ件 = item 削除」 表現になり、
+  REMOVE semantics が壊れる
+- **(D) description を MDX / 独自記法**: 業界標準の markdown から外れる学習コスト > 機能差分の価値
+- **(E) `dompurify` を直接 import**: SSR で `globalThis.window` が無く動かない。 vitest 4 + jsdom v29
+  でも `globalThis.window !== self` 既知問題あり ([vitest #9279](https://github.com/vitest-dev/vitest/issues/9279))。
+  `isomorphic-dompurify` を採用
+
+## Out of scope
+
+以下は本 ADR と PR スコープ外。 必要になった時点で別 ADR / issue で扱う:
+
+- markdown **table** / **image** / **input** (`<img>` `<input>` `<table>` のうち table のみ ALLOWED に追加検討余地、 現状 `<table>` ALLOWED, `<img>`/`<input>` FORBID)
+- tags / links の chip preview / drag reorder / `<datalist>` autocomplete
+- timeline tooltip に description を出す
+- status / 顧客 / PM 名 等の構造化フィールド (本 ADR の 「list of attribute」 拡張で吸収可能、 PR 1 つで足せる)
+- CSP `style-src` の nonce 化 (現状 `'unsafe-inline'`)
+- Edit / Preview tab (Linear / Jira 風 split editor)
+- markdown editor toolbar (GitHub 風 bold / italic ボタン)
+- superforms 導入 (本 plan では SvelteKit 標準 enhance + hidden input JSON で nested 表現)
+
+## Implementation notes
+
+- `web/src/lib/types.ts`: `Project` に description / tags / links を optional 追加、 `ProjectLink` 型を新規 export
+- `web/src/lib/schemas/index.ts`: `descriptionSchema` / `tagsCsvSchema` / `linkObjectSchema` /
+  `linksJsonSchema` を追加、 `projectCreateSchema` / `projectUpdateSchema` を transform pipeline で再構築
+- `web/src/lib/repository/project.ts`: `createProject` は optional spread、
+  `updateProject` は SET / REMOVE を attribute 単位で mutual exclusion
+- `docs/db/entities.md`: Project section に新フィールド行を追加
+- 既存 `web/src/routes/+page.server.ts` の `createProject` / `updateProject` action は本 PR では
+  **触らない** (form 拡張は PR-N3 で実装)。 既存 form 経由で送られた missing field は schema 内で
+  undefined / [] に正規化され、 repository が REMOVE を発行するが、 旧 item に該当 attribute が
+  存在しないため no-op で済む (DDB REMOVE idempotent on non-existing)
+
+## References
+
+- [DynamoDB Update Expressions (SET / REMOVE)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html)
+- [DynamoDB item size limits](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Constraints.html)
+- [marked using_advanced](https://marked.js.org/using_advanced)
+- [cure53 DOMPurify](https://github.com/cure53/DOMPurify), [Default TAGs allow-list](https://github.com/cure53/DOMPurify/wiki/Default-TAGs-ATTRIBUTEs-allow-list-&-blocklist)
+- [Zod v4 API](https://zod.dev/api), [Zod v4 error customization](https://zod.dev/error-customization)
+- [OWASP CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)
+- [OWASP XSS Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [Alex DeBrie — DynamoDB limits and item size](https://www.alexdebrie.com/posts/dynamodb-limits/)
+- 関連 issue: [#187](https://github.com/tommykey-apps/resource-planner/issues/187)
+- 関連 PR: PR-N0 (#193, CSP 一段目)、 PR-N2 以降 (markdown render / form / SSR)
+- 関連 ADR: [ADR 0001 (型駆動)](0001-typescript-types-as-api-spec.md)、 [ADR 0004 (schema 1 箇所変換)](0004-end-date-exclusive-with-form-transform.md)、 [ADR 0006 (cascade)](0006-cascade-delete-strategy.md)、 [ADR 0007 (TDD)](0007-tdd-with-vitest-and-playwright.md)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -16,6 +16,7 @@ resource-planner の設計判断を Michael Nygard 形式で記録する。
 | [0007](0007-tdd-with-vitest-and-playwright.md) | TDD で開発する: Vitest + Playwright | Accepted | 2026-05-09 |
 | [0008](0008-auth-migration-clerk-to-authjs.md) | 認証を Clerk → Auth.js + Email Magic Link に移行する | Accepted | 2026-05-09 |
 | [0009](0009-org-to-team-redesign.md) | マルチテナント単位を Clerk Org → 自前 Team モデルに再設計する | Accepted | 2026-05-09 |
+| [0010](0010-project-metadata.md) | Project に詳細情報 (description / tags / links) を同 item 内 attribute で追加する | Accepted | 2026-05-13 |
 
 ## テンプレ
 

--- a/docs/db/entities.md
+++ b/docs/db/entities.md
@@ -82,8 +82,30 @@ DynamoDB シングルテーブル `resource-planner` には 3 種類のエンテ
 | `id` | str (UUID 想定) | project の主キー |
 | `name` | str | プロジェクト名 |
 | `color` | str (`#RRGGBB`) | タイムラインでの表示色 |
+| `description` | str (optional) | 案件説明 markdown raw (最大 10,000 文字、 ADR 0010)。 未設定なら attribute なし |
+| `tags` | list of str (optional) | 使用技術タグ (最大 20 件 / 各 30 文字、 NFC normalize + dedup、 ADR 0010)。 未設定なら attribute なし |
+| `links` | list of map (optional) | 関連リンク (最大 10 件、 http(s) のみ)。 各要素 `{ label?: str, url: str }` (ADR 0010)。 未設定なら attribute なし |
 
-サンプルアイテム:
+> **REMOVE semantics**: description 空文字 / tags 空配列 / links 空配列 は repository 層で 「未設定」 に正規化し、 attribute ごと REMOVE する。 「保存されているけど空」 状態は意図的に作らない (ADR 0010)。
+
+サンプルアイテム (詳細あり):
+```json
+{
+  "pk": "TEAM#team_default",
+  "sk": "PRJ#01HABC...",
+  "id": "01HABC...",
+  "name": "Acme 移行案件",
+  "color": "#4D72F3",
+  "description": "## 概要\n基幹システム刷新。\n\n## 使用技術\n- TypeScript\n- AWS Lambda",
+  "tags": ["TypeScript", "AWS Lambda", "DynamoDB"],
+  "links": [
+    { "label": "案件 Wiki", "url": "https://wiki.example.com/acme" },
+    { "url": "https://example.com/spec.pdf" }
+  ]
+}
+```
+
+サンプルアイテム (詳細なし、 後方互換):
 ```json
 {
   "pk": "TEAM#team_default",

--- a/web/src/lib/repository/project.test.ts
+++ b/web/src/lib/repository/project.test.ts
@@ -19,12 +19,21 @@ beforeEach(() => {
 });
 
 describe('createProject', () => {
-	it('sends PutCommand with id/name/color and attribute_not_exists guard', async () => {
+	it('stores id/name/color only when description/tags/links empty', async () => {
 		ddbMock.on(PutCommand).resolves({});
 
-		const result = await createProject(TEAM, { name: 'Project A', color: '#ff0000' });
+		const result = await createProject(TEAM, {
+			name: 'Project A',
+			color: '#ff0000',
+			description: undefined,
+			tags: [],
+			links: []
+		});
 
 		expect(result).toMatchObject({ name: 'Project A', color: '#ff0000' });
+		expect(result).not.toHaveProperty('description');
+		expect(result).not.toHaveProperty('tags');
+		expect(result).not.toHaveProperty('links');
 		const input = ddbMock.commandCalls(PutCommand)[0].args[0].input;
 		expect(input.TableName).toBe(TABLE);
 		expect(input.ConditionExpression).toBe('attribute_not_exists(sk)');
@@ -35,24 +44,134 @@ describe('createProject', () => {
 			name: 'Project A',
 			color: '#ff0000'
 		});
+		expect(input.Item).not.toHaveProperty('description');
+		expect(input.Item).not.toHaveProperty('tags');
+		expect(input.Item).not.toHaveProperty('links');
+	});
+
+	it('stores description/tags/links when provided', async () => {
+		ddbMock.on(PutCommand).resolves({});
+
+		const links = [{ label: 'Wiki', url: 'https://example.com/wiki' }];
+		const result = await createProject(TEAM, {
+			name: 'Project B',
+			color: '#00ff00',
+			description: '## Tech\n- TypeScript',
+			tags: ['TypeScript', 'AWS'],
+			links
+		});
+
+		expect(result).toMatchObject({
+			name: 'Project B',
+			color: '#00ff00',
+			description: '## Tech\n- TypeScript',
+			tags: ['TypeScript', 'AWS'],
+			links
+		});
+		const input = ddbMock.commandCalls(PutCommand)[0].args[0].input;
+		expect(input.Item).toMatchObject({
+			description: '## Tech\n- TypeScript',
+			tags: ['TypeScript', 'AWS'],
+			links
+		});
 	});
 });
 
 describe('updateProject', () => {
-	it('sends UpdateCommand with #name + color in SET, attribute_exists guard', async () => {
+	it('SETs name/color and REMOVEs description/tags/links when all detail empty', async () => {
 		ddbMock.on(UpdateCommand).resolves({});
 
-		await updateProject(TEAM, { id: 'prj-1', name: 'Renamed', color: '#00ff00' });
+		await updateProject(TEAM, {
+			id: 'prj-1',
+			name: 'Renamed',
+			color: '#00ff00',
+			description: undefined,
+			tags: [],
+			links: []
+		});
 
 		const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
 		expect(input.Key).toEqual({ pk: `TEAM#${TEAM}`, sk: 'PRJ#prj-1' });
-		expect(input.UpdateExpression).toBe('SET #name = :name, color = :color');
+		expect(input.UpdateExpression).toBe(
+			'SET #name = :name, color = :color REMOVE description, tags, links'
+		);
 		expect(input.ExpressionAttributeNames).toEqual({ '#name': 'name' });
 		expect(input.ExpressionAttributeValues).toEqual({
 			':name': 'Renamed',
 			':color': '#00ff00'
 		});
 		expect(input.ConditionExpression).toBe('attribute_exists(sk)');
+	});
+
+	it('SETs all attributes when description/tags/links provided', async () => {
+		ddbMock.on(UpdateCommand).resolves({});
+
+		const links = [{ url: 'https://example.com' }];
+		await updateProject(TEAM, {
+			id: 'prj-1',
+			name: 'Renamed',
+			color: '#00ff00',
+			description: 'desc',
+			tags: ['t1'],
+			links
+		});
+
+		const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+		expect(input.UpdateExpression).toBe(
+			'SET #name = :name, color = :color, description = :description, tags = :tags, links = :links'
+		);
+		expect(input.ExpressionAttributeValues).toEqual({
+			':name': 'Renamed',
+			':color': '#00ff00',
+			':description': 'desc',
+			':tags': ['t1'],
+			':links': links
+		});
+	});
+
+	it('mixes SET and REMOVE per-attribute (description SET, tags+links REMOVE)', async () => {
+		ddbMock.on(UpdateCommand).resolves({});
+
+		await updateProject(TEAM, {
+			id: 'prj-1',
+			name: 'Renamed',
+			color: '#00ff00',
+			description: 'desc only',
+			tags: [],
+			links: []
+		});
+
+		const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+		expect(input.UpdateExpression).toBe(
+			'SET #name = :name, color = :color, description = :description REMOVE tags, links'
+		);
+		expect(input.ExpressionAttributeValues).toEqual({
+			':name': 'Renamed',
+			':color': '#00ff00',
+			':description': 'desc only'
+		});
+	});
+
+	it('treats empty-string description as REMOVE (defense in depth)', async () => {
+		ddbMock.on(UpdateCommand).resolves({});
+
+		await updateProject(TEAM, {
+			id: 'prj-1',
+			name: 'Renamed',
+			color: '#00ff00',
+			description: '',
+			tags: [],
+			links: []
+		});
+
+		const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input;
+		expect(input.UpdateExpression).toBe(
+			'SET #name = :name, color = :color REMOVE description, tags, links'
+		);
+		expect(input.ExpressionAttributeValues).toEqual({
+			':name': 'Renamed',
+			':color': '#00ff00'
+		});
 	});
 });
 

--- a/web/src/lib/repository/project.ts
+++ b/web/src/lib/repository/project.ts
@@ -14,7 +14,16 @@ const TRANSACT_MAX_ITEMS = 100;
 
 export async function createProject(teamId: string, input: ProjectCreateInput): Promise<Project> {
 	const id = newId();
-	const item: Project = { id, name: input.name, color: input.color };
+	// 空 detail は item から除外して保存 (REMOVE 相当)。 後段 updateProject の
+	// REMOVE 動作と整合させ、 `attribute_exists(description)` 等の Query 期待値を一貫させる。
+	const item: Project = {
+		id,
+		name: input.name,
+		color: input.color,
+		...(input.description ? { description: input.description } : {}),
+		...(input.tags.length > 0 ? { tags: input.tags } : {}),
+		...(input.links.length > 0 ? { links: input.links } : {})
+	};
 	await ddb.send(
 		new PutCommand({
 			TableName: TABLE,
@@ -25,14 +34,54 @@ export async function createProject(teamId: string, input: ProjectCreateInput): 
 	return item;
 }
 
+/**
+ * description/tags/links は 「空 → REMOVE / 非空 → SET」 を attribute 単位で出し分ける (ADR 0010)。
+ *
+ * DynamoDB UpdateExpression 公式仕様:
+ * - SET と REMOVE は同一 expression 内で **異なる attribute** に並べる場合のみ並走可能
+ *   ([AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html))
+ * - 同名 attribute path が SET と REMOVE で重複すると `ValidationException: Two document paths
+ *   overlap` で reject される
+ * - keyword は 1 expression 内で 1 回まで、 actions は comma 区切り、 keyword 間は space 区切り
+ *   (e.g. `SET a = :a, b = :b REMOVE c, d`)
+ */
 export async function updateProject(teamId: string, input: ProjectUpdateInput): Promise<void> {
+	const sets: string[] = ['#name = :name', 'color = :color'];
+	const removes: string[] = [];
+	const names: Record<string, string> = { '#name': 'name' };
+	const values: Record<string, unknown> = { ':name': input.name, ':color': input.color };
+
+	if (input.description && input.description.length > 0) {
+		sets.push('description = :description');
+		values[':description'] = input.description;
+	} else {
+		removes.push('description');
+	}
+
+	if (input.tags.length > 0) {
+		sets.push('tags = :tags');
+		values[':tags'] = input.tags;
+	} else {
+		removes.push('tags');
+	}
+
+	if (input.links.length > 0) {
+		sets.push('links = :links');
+		values[':links'] = input.links;
+	} else {
+		removes.push('links');
+	}
+
+	const expr =
+		`SET ${sets.join(', ')}` + (removes.length > 0 ? ` REMOVE ${removes.join(', ')}` : '');
+
 	await ddb.send(
 		new UpdateCommand({
 			TableName: TABLE,
 			Key: { pk: pk(teamId), sk: projectSk(input.id) },
-			UpdateExpression: 'SET #name = :name, color = :color',
-			ExpressionAttributeNames: { '#name': 'name' },
-			ExpressionAttributeValues: { ':name': input.name, ':color': input.color },
+			UpdateExpression: expr,
+			ExpressionAttributeNames: names,
+			ExpressionAttributeValues: values,
 			ConditionExpression: 'attribute_exists(sk)'
 		})
 	);

--- a/web/src/lib/schemas/index.test.ts
+++ b/web/src/lib/schemas/index.test.ts
@@ -70,6 +70,118 @@ describe('projectUpdateSchema', () => {
 	});
 });
 
+describe('projectCreateSchema — detail fields (#187)', () => {
+	const base = { name: 'P1', color: '#abcdef' };
+
+	it('defaults description to undefined, tags/links to [] when omitted', () => {
+		const r = projectCreateSchema.safeParse(base);
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data).toEqual({
+			name: 'P1',
+			color: '#abcdef',
+			description: undefined,
+			tags: [],
+			links: []
+		});
+	});
+
+	it('normalizes empty/whitespace description to undefined', () => {
+		const r = projectCreateSchema.safeParse({ ...base, description: '   ' });
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data.description).toBeUndefined();
+	});
+
+	it('accepts description up to 10,000 chars', () => {
+		expect(
+			projectCreateSchema.safeParse({ ...base, description: 'a'.repeat(10_000) }).success
+		).toBe(true);
+		expect(
+			projectCreateSchema.safeParse({ ...base, description: 'a'.repeat(10_001) }).success
+		).toBe(false);
+	});
+
+	it('parses tags CSV with trim + NFC normalize + dedup', () => {
+		const r = projectCreateSchema.safeParse({ ...base, tags: ' TypeScript ,  AWS,TypeScript ,, ' });
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data.tags).toEqual(['TypeScript', 'AWS']);
+	});
+
+	it('rejects more than 20 tags (tooMany)', () => {
+		const tags = Array.from({ length: 21 }, (_, i) => `t${i}`).join(',');
+		expect(projectCreateSchema.safeParse({ ...base, tags }).success).toBe(false);
+	});
+
+	it('rejects a single tag longer than 30 chars (tooLong)', () => {
+		expect(projectCreateSchema.safeParse({ ...base, tags: 'a'.repeat(31) }).success).toBe(false);
+	});
+
+	it('parses linksJson and rejects javascript: URL (invalidUrl)', () => {
+		const ok = projectCreateSchema.safeParse({
+			...base,
+			linksJson: JSON.stringify([{ label: 'Wiki', url: 'https://example.com/wiki' }])
+		});
+		expect(ok.success).toBe(true);
+		if (!ok.success) return;
+		expect(ok.data.links).toEqual([{ label: 'Wiki', url: 'https://example.com/wiki' }]);
+
+		const bad = projectCreateSchema.safeParse({
+			...base,
+			linksJson: JSON.stringify([{ url: 'javascript:alert(1)' }])
+		});
+		expect(bad.success).toBe(false);
+	});
+
+	it('rejects more than 10 links (tooMany)', () => {
+		const links = Array.from({ length: 11 }, (_, i) => ({ url: `https://example.com/${i}` }));
+		const r = projectCreateSchema.safeParse({ ...base, linksJson: JSON.stringify(links) });
+		expect(r.success).toBe(false);
+	});
+
+	it('normalizes invalid linksJson string to [] (parse fallback then validation)', () => {
+		const r = projectCreateSchema.safeParse({ ...base, linksJson: '{not json' });
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data.links).toEqual([]);
+	});
+
+	it('renames linksJson → links in output (transform)', () => {
+		const r = projectCreateSchema.safeParse({
+			...base,
+			linksJson: JSON.stringify([{ url: 'https://example.com' }])
+		});
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data).not.toHaveProperty('linksJson');
+		expect(r.data.links).toBeDefined();
+	});
+});
+
+describe('projectUpdateSchema — detail fields (#187)', () => {
+	it('carries id alongside detail fields', () => {
+		const r = projectUpdateSchema.safeParse({
+			id: 'p1',
+			name: 'P1',
+			color: '#abcdef',
+			description: 'desc',
+			tags: 'a,b',
+			linksJson: JSON.stringify([{ url: 'https://example.com' }])
+		});
+		expect(r.success).toBe(true);
+		if (!r.success) return;
+		expect(r.data).toEqual({
+			id: 'p1',
+			name: 'P1',
+			color: '#abcdef',
+			description: 'desc',
+			tags: ['a', 'b'],
+			links: [{ label: undefined, url: 'https://example.com' }]
+		});
+	});
+});
+
 describe('assignmentCreateSchema', () => {
 	const valid = {
 		resourceId: 'r1',
@@ -216,8 +328,10 @@ describe('error message contract — i18n codes (#139)', () => {
 	const ALLOWED_CODES = new Set([
 		'required',
 		'tooLong',
+		'tooMany',
 		'invalidDateFormat',
 		'invalidColorFormat',
+		'invalidUrl',
 		'endBeforeStart'
 	]);
 
@@ -263,11 +377,41 @@ describe('error message contract — i18n codes (#139)', () => {
 		).toContain('endBeforeStart');
 	});
 
+	it('projectCreateSchema: too many tags → "tooMany" (#187)', () => {
+		const tags = Array.from({ length: 21 }, (_, i) => `t${i}`).join(',');
+		expect(collect(projectCreateSchema, { name: 'P', color: '#abcdef', tags })).toContain('tooMany');
+	});
+
+	it('projectCreateSchema: bad link url → "invalidUrl" (#187)', () => {
+		expect(
+			collect(projectCreateSchema, {
+				name: 'P',
+				color: '#abcdef',
+				linksJson: JSON.stringify([{ url: 'javascript:alert(1)' }])
+			})
+		).toContain('invalidUrl');
+	});
+
 	it('全 message は ALLOWED_CODES に含まれる (日本語 hardcode 検知)', () => {
 		const samples = [
 			collect(resourceCreateSchema, { name: '' }),
 			collect(resourceCreateSchema, { name: 'a'.repeat(101) }),
 			collect(projectCreateSchema, { name: '', color: 'red' }),
+			collect(projectCreateSchema, {
+				name: 'P',
+				color: '#abcdef',
+				description: 'a'.repeat(10_001)
+			}),
+			collect(projectCreateSchema, {
+				name: 'P',
+				color: '#abcdef',
+				tags: Array.from({ length: 21 }, (_, i) => `t${i}`).join(',')
+			}),
+			collect(projectCreateSchema, {
+				name: 'P',
+				color: '#abcdef',
+				linksJson: JSON.stringify([{ url: 'javascript:alert(1)' }])
+			}),
 			collect(assignmentCreateSchema, {
 				resourceId: '',
 				projectId: '',

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { addDays } from '$lib/date';
+import type { ProjectLink } from '$lib/types';
 
 /**
  * #139: schema 内の `message` は **i18n code** に統一する (`errors.required` 等)。
@@ -8,8 +9,10 @@ import { addDays } from '$lib/date';
  * code 体系:
  *   required           — 必須欠落 (min(1) など)
  *   tooLong            — 長さ超過 (max())
+ *   tooMany            — 件数超過 (max(N) on array, #187)
  *   invalidDateFormat  — 日付 YYYY-MM-DD パターン不一致
  *   invalidColorFormat — #RRGGBB パターン不一致
+ *   invalidUrl         — URL が http(s) でない / 形式不正 (#187)
  *   endBeforeStart     — 終了日 < 開始日 (refine)
  */
 
@@ -32,14 +35,116 @@ export type ResourceUpdateInput = z.infer<typeof resourceUpdateSchema>;
 
 // ── Project ─────────────────────────────────────────────────────────
 
-export const projectCreateSchema = z.object({
-	name: z.string().min(1, 'required').max(100, 'tooLong'),
-	color: colorString
+/**
+ * description: 空文字 → undefined に正規化して max(10_000) で長さ制限 (ADR 0010)。
+ * `<textarea>` は空でも空文字を返すので preprocess で undefined に揃え、 repository 側で
+ * 「未設定 = attribute REMOVE」 を一貫させる (Zod v4 preprocess pattern)。
+ */
+const descriptionSchema = z.preprocess(
+	(v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+	z.string().max(10_000, 'tooLong').optional()
+);
+
+/**
+ * tags: カンマ区切り raw string → trim + NFC normalize + dedup で `string[]` に変換 (ADR 0010)。
+ * NFC normalize は 「ｶ (半角)」 と 「カ (全角)」 等の表記揺れを統一する Unicode 正規化
+ * (UAX#15)。 dedup は順序保持のまま重複を弾く。
+ *
+ * Zod v4 `.transform().pipe()` で 「raw 入力 → 中間 array → array 検証」 を 1 schema に閉じる。
+ */
+const tagsCsvSchema = z
+	.string()
+	.optional()
+	.transform((s) => {
+		if (!s) return [];
+		const seen = new Set<string>();
+		const result: string[] = [];
+		for (const raw of s.split(',')) {
+			const t = raw.trim().normalize('NFC');
+			if (!t || seen.has(t)) continue;
+			seen.add(t);
+			result.push(t);
+		}
+		return result;
+	})
+	.pipe(z.array(z.string().min(1, 'required').max(30, 'tooLong')).max(20, 'tooMany'));
+
+/**
+ * link 1 件: label は省略可 (空文字なら undefined)、 url は http(s) のみ許可 (ADR 0010)。
+ * `javascript:` / `data:` URL は XSS ベクトルになるため明示的に拒否 (OWASP)。
+ */
+const linkObjectSchema = z.object({
+	label: z.preprocess(
+		(v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+		z.string().max(50, 'tooLong').optional()
+	),
+	url: z.preprocess(
+		(v) => (typeof v === 'string' ? v.trim() : v),
+		z.url('invalidUrl').refine((u) => /^https?:\/\//.test(u), 'invalidUrl')
+	)
 });
 
-export const projectUpdateSchema = projectCreateSchema.extend({
-	id: z.string().min(1, 'required')
+/**
+ * links: hidden input に JSON.stringify した文字列で送信 (BP B8、 SvelteKit form action と
+ * nested data の妥協)。 server 側で JSON.parse → array validation を 1 schema で行う。
+ * parse 失敗時は `[]` に正規化 (中身を後段 pipe で検証)。
+ */
+const linksJsonSchema = z
+	.string()
+	.optional()
+	.transform((s) => {
+		if (!s) return [];
+		try {
+			const parsed: unknown = JSON.parse(s);
+			return Array.isArray(parsed) ? parsed : [];
+		} catch {
+			return [];
+		}
+	})
+	.pipe(z.array(linkObjectSchema).max(10, 'tooMany'));
+
+/**
+ * create / update 共通 shape。 Zod v4 では `.transform()` 後に `.extend()` できないため、
+ * base object を const 化して両 schema で再利用する。
+ */
+const projectBaseShape = {
+	name: z.string().min(1, 'required').max(100, 'tooLong'),
+	color: colorString,
+	description: descriptionSchema,
+	tags: tagsCsvSchema,
+	linksJson: linksJsonSchema
+} as const;
+
+interface ProjectInputShape {
+	name: string;
+	color: string;
+	description?: string;
+	tags: string[];
+	linksJson: ProjectLink[];
+}
+
+interface ProjectOutput {
+	name: string;
+	color: string;
+	description?: string;
+	tags: string[];
+	links: ProjectLink[];
+}
+
+/** transform で linksJson → links rename + 一貫した output 型を生成 (ADR 0001 型駆動)。 */
+const projectTransform = (input: ProjectInputShape): ProjectOutput => ({
+	name: input.name,
+	color: input.color,
+	description: input.description,
+	tags: input.tags,
+	links: input.linksJson
 });
+
+export const projectCreateSchema = z.object(projectBaseShape).transform(projectTransform);
+
+export const projectUpdateSchema = z
+	.object({ id: z.string().min(1, 'required'), ...projectBaseShape })
+	.transform((input) => ({ ...projectTransform(input), id: input.id }));
 
 export type ProjectCreateInput = z.infer<typeof projectCreateSchema>;
 export type ProjectUpdateInput = z.infer<typeof projectUpdateSchema>;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -39,6 +39,19 @@ export interface Project {
 	id: string;
 	name: string;
 	color: string; // #RRGGBB
+	/** markdown 本文 (1 万字以内、 cure53 DOMPurify で sanitize、 ADR 0010)。 */
+	description?: string;
+	/** 使用技術タグ (各 30 字以内 / 20 件以内、 NFC normalize + dedup、 ADR 0010)。 */
+	tags?: string[];
+	/** 関連リンク (http(s) のみ / 10 件以内、 ADR 0010)。 */
+	links?: ProjectLink[];
+}
+
+export interface ProjectLink {
+	/** 表示ラベル (50 字以内、 省略時は url を表示)。 */
+	label?: string;
+	/** http(s) URL。 */
+	url: string;
 }
 
 export interface Assignment {

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -309,11 +309,16 @@ describe('?/deleteResource action (cascade は repository 側、 ここでは引
 describe('?/createProject action', () => {
 	beforeEach(resetAllMocks);
 
-	it('calls createProject(teamId, { name, color }) on valid input', async () => {
+	it('calls createProject(teamId, { name, color, ...empty detail }) on valid input', async () => {
 		await actions.createProject!(makeEvent({ name: 'Alpha', color: '#0EA5E9' }));
+		// #187: schema 拡張で description/tags/links が transform output に含まれる
+		// (form omit 時は undefined / [])。 repository 側で空判定して REMOVE / 除外。
 		expect(createProjectMock).toHaveBeenCalledWith('team_default', {
 			name: 'Alpha',
-			color: '#0EA5E9'
+			color: '#0EA5E9',
+			description: undefined,
+			tags: [],
+			links: []
 		});
 	});
 
@@ -330,14 +335,18 @@ describe('?/createProject action', () => {
 describe('?/updateProject action', () => {
 	beforeEach(resetAllMocks);
 
-	it('calls updateProject(teamId, { id, name, color })', async () => {
+	it('calls updateProject(teamId, { id, name, color, ...empty detail })', async () => {
 		await actions.updateProject!(
 			makeEvent({ id: 'p1', name: 'Beta', color: '#10B981' })
 		);
+		// #187: schema 拡張で description/tags/links が transform output に含まれる。
 		expect(updateProjectMock).toHaveBeenCalledWith('team_default', {
 			id: 'p1',
 			name: 'Beta',
-			color: '#10B981'
+			color: '#10B981',
+			description: undefined,
+			tags: [],
+			links: []
 		});
 	});
 


### PR DESCRIPTION
## Summary

Project に詳細情報 (description / tags / links) を **同 item の attribute** として追加するデータ層拡張。 form / markdown render / detail view は後続 PR (N2-N5)。

- ADR 0010 で 「同 item 追加」 を決定 (read 1 request / 後方互換 / size 80KB 上限で別 entity に分離する境界を明文化)
- `Project` に description / tags / links を optional 追加、 `ProjectLink = { label?, url }` を新規 export
- schema:
  - `descriptionSchema` (preprocess で empty → undefined、 max 10,000 chars)
  - `tagsCsvSchema` (CSV → trim + NFC normalize + dedup → `string[]`、 max 20 件 / 各 30 chars)
  - `linksJsonSchema` (hidden input JSON → `ProjectLink[]`、 http(s) のみ、 max 10 件)
  - i18n code 体系に `tooMany` / `invalidUrl` 追加
- repository:
  - `createProject`: 空 detail は spread 短絡で Item から除外 → REMOVE semantics と整合
  - `updateProject`: SET / REMOVE を attribute 単位で mutual exclusion (DDB 公式: keyword は 1 expression 内で 1 回、 同 attribute path overlap で `ValidationException`)
- docs: ADR 0010 / index、 `entities.md` の Project 行追加 + REMOVE semantics 注記
- 既存 `+page.server.ts` は本 PR では **touch しない** (form 拡張は PR-N3)

## 公式 docs を確認した上で書いた

user 指示 「コーディングも自分でロジック考えるよりはベストプラクティス調べて準拠して欲しい」 を遵守:

- [DynamoDB Update Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html) — SET/REMOVE 各 keyword は 1 回まで、 同 attribute path overlap は ValidationException
- [Zod v4 API](https://zod.dev/api) — `z.url()` / `z.preprocess(fn, schema)` / `.optional().transform()` の正式仕様確認
- [Zod v4 error customization](https://zod.dev/error-customization) — string shorthand `min(1, 'required')` も v4 で有効。 既存 schema との style 統一でこちらを採用
- [Alex DeBrie — DynamoDB limits](https://www.alexdebrie.com/posts/dynamodb-limits/) — 1 item 400KB の業界事例 (本 ADR の 「80KB で分離検討」 根拠)

## Test plan

- [x] `pnpm test src/lib/repository/project.test.ts src/lib/schemas/index.test.ts` 53/53 緑 (新規 28 + 既存 25)
- [x] `pnpm test` 全体 307 緑 / 6 skip (既存 page.server.test.ts の updateProject/createProject mock 期待値も新 transform output に同期)
- [x] `pnpm check` pre-existing `auth.ts:67` のみ (本 PR は新規 error 0)
- [x] `pnpm build` clean (4.47s、 publint warning なし)
- [x] CI audit / test / build-web / terraform-plan
- [ ] DDB Local で手動 PutItem / UpdateItem 確認 (next PR で form 経由で踏むため割愛可)

## ADR / 関連

- [ADR 0010](docs/adr/0010-project-metadata.md) — Decision / Out of scope / Implementation notes
- refs #187
- 後続: PR-N2 (markdown.ts) → PR-N3 (form 拡張) → PR-N4 (DetailView + SSR) → PR-N5 (e2e)