### PR TITLE
fix: use correct JSON Schema Store URL for Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://code.claude.com/settings.schema.json",
+	"$schema": "https://json.schemastore.org/claude-code-settings.json",
 	"hooks": {
 		"PreToolUse": [
 			{


### PR DESCRIPTION
## Summary
- Claude Code 起動時に $schema URL エラーが出ていた
- 存在しない `code.claude.com/settings.schema.json` を正しい JSON Schema Store URL に修正

## Changes
- `.claude/settings.json`: `$schema` URL を `https://json.schemastore.org/claude-code-settings.json` に変更

## References
- https://github.com/anthropics/claude-code/issues/11795