### PR TITLE
fix(repository): queryAllByTeam が Project の description/tags/links を読み捨てる問題を修正 (fixes #196)

### DIFF
--- a/docs/adr/0010-project-metadata.md
+++ b/docs/adr/0010-project-metadata.md
@@ -164,6 +164,50 @@ rel="noopener noreferrer">` で開く。
   undefined / [] に正規化され、 repository が REMOVE を発行するが、 旧 item に該当 attribute が
   存在しないため no-op で済む (DDB REMOVE idempotent on non-existing)
 
+### DDB read path 規約: `as <Entity>` 全体キャスト禁止 (#196 で確定)
+
+`queryAllByTeam` 等の read path で DDB Item から domain object を組み立てるとき、 **`as <Entity>` の
+全体キャストは禁止**。 個別 field の `as string` / `as string[]` 等に **localize** すること。
+
+```ts
+// ❌ 駄目: optional フィールド追加時に型 error で気づけない (#194 で発生)
+data.projects.push({ id: item.id, name: item.name, color: item.color } as Project);
+
+// ✅ 良い: 個別 cast + optional は spread + 条件分岐
+const project: Project = {
+  id: item.id as string,
+  name: item.name as string,
+  color: item.color as string,
+  ...(typeof item.description === 'string' && item.description.length > 0
+    ? { description: item.description }
+    : {}),
+  ...(Array.isArray(item.tags) && item.tags.length > 0 ? { tags: item.tags as string[] } : {}),
+  ...(Array.isArray(item.links) && item.links.length > 0
+    ? { links: item.links as ProjectLink[] }
+    : {})
+};
+```
+
+理由:
+
+- 全体キャストは TypeScript の missing-property 検出を握り潰す。 PR-N1 (#194) で `Project` に
+  optional 追加した際、 read path の `as Project` cast が「description / tags / links 読み忘れ」 を
+  hide してしまい、 「保存されるが load 時に常に undefined」 という Critical bug を生んだ (#196)
+- 個別 cast + spread に localize すれば、 将来 optional 追加時に **TS error で即座に気づける** ように
+  なる (個別 field を増やし忘れたら型 が `Project` に narrow できない)
+- spread 条件分岐は write 側の REMOVE semantics と整合: write で REMOVE → DDB に attribute key なし
+  → read で spread が key 自体を出さない (round-trip 一貫)
+
+この規約は Resource / Assignment の将来 optional 追加にも適用する。 また同 PR (#196 fix) で
+`web/src/lib/repository/index.test.ts` に「optional あり / 全 absent / empty list / partial」 の
+4 ケースを追加し、 `integration.test.ts` で DDB Local round-trip も検証。 同 pattern を新 entity 追加時にも踏むこと。
+
+注: write 側 (`createProject` の `input.description ? ... : ...`) は schema 層で空文字を `undefined`
+に正規化するため truthy チェック 1 つで十分。 read 側で `typeof === 'string' && length > 0` の
+二重 guard を入れているのは、 migration ツールや管理コンソールで DDB に直接空文字が書き込まれた
+場合の defense in depth であり、 通常 flow では `length > 0` 部分は到達しない (write/read で
+条件が非対称に見えるのはこの理由)。
+
 ## References
 
 - [DynamoDB Update Expressions (SET / REMOVE)](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html)

--- a/web/src/lib/repository/index.test.ts
+++ b/web/src/lib/repository/index.test.ts
@@ -92,4 +92,94 @@ describe('queryAllByTeam', () => {
 		expect(data.projects).toHaveLength(0);
 		expect(data.assignments).toHaveLength(0);
 	});
+
+	// Project optional fields (description / tags / links) round-trip (refs #196)
+	it('returns project with description/tags/links when DDB item has them', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [
+				{
+					sk: 'PRJ#p1',
+					id: 'p1',
+					name: 'Project A',
+					color: '#ff0000',
+					description: 'Test description',
+					tags: ['ts', 'aws'],
+					links: [{ url: 'https://example.com', label: 'Wiki' }]
+				}
+			]
+		});
+
+		const data = await queryAllByTeam(TEAM);
+
+		expect(data.projects).toHaveLength(1);
+		expect(data.projects[0]).toEqual({
+			id: 'p1',
+			name: 'Project A',
+			color: '#ff0000',
+			description: 'Test description',
+			tags: ['ts', 'aws'],
+			links: [{ url: 'https://example.com', label: 'Wiki' }]
+		});
+	});
+
+	it('omits optional fields for legacy item (back-compat: id/name/color only)', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [{ sk: 'PRJ#p1', id: 'p1', name: 'Legacy Project', color: '#00ff00' }]
+		});
+
+		const data = await queryAllByTeam(TEAM);
+
+		expect(data.projects[0]).toEqual({ id: 'p1', name: 'Legacy Project', color: '#00ff00' });
+		expect(data.projects[0]).not.toHaveProperty('description');
+		expect(data.projects[0]).not.toHaveProperty('tags');
+		expect(data.projects[0]).not.toHaveProperty('links');
+	});
+
+	it('skips empty list attributes from result (defense: write-side uses REMOVE)', async () => {
+		// 万が一 write が REMOVE せず empty list `[]` を保存していても、 read 側で取り除く
+		ddbMock.on(QueryCommand).resolves({
+			Items: [
+				{
+					sk: 'PRJ#p1',
+					id: 'p1',
+					name: 'Project A',
+					color: '#ff0000',
+					tags: [],
+					links: []
+				}
+			]
+		});
+
+		const data = await queryAllByTeam(TEAM);
+
+		expect(data.projects[0]).toEqual({ id: 'p1', name: 'Project A', color: '#ff0000' });
+		expect(data.projects[0]).not.toHaveProperty('tags');
+		expect(data.projects[0]).not.toHaveProperty('links');
+	});
+
+	it('returns partial optional fields when only some are present', async () => {
+		ddbMock.on(QueryCommand).resolves({
+			Items: [
+				{
+					sk: 'PRJ#p1',
+					id: 'p1',
+					name: 'Project A',
+					color: '#ff0000',
+					description: 'desc only'
+					// tags / links absent
+				}
+			]
+		});
+
+		const data = await queryAllByTeam(TEAM);
+
+		expect(data.projects[0]).toEqual({
+			id: 'p1',
+			name: 'Project A',
+			color: '#ff0000',
+			description: 'desc only'
+		});
+		expect(data.projects[0]).not.toHaveProperty('tags');
+		expect(data.projects[0]).not.toHaveProperty('links');
+	});
 });

--- a/web/src/lib/repository/index.ts
+++ b/web/src/lib/repository/index.ts
@@ -1,7 +1,7 @@
 import { QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { ddb, TABLE } from '$lib/db/client';
 import { pk, SK_PREFIX } from './keys';
-import type { TeamData, Resource, Project, Assignment } from '$lib/types';
+import type { TeamData, Resource, Project, ProjectLink, Assignment } from '$lib/types';
 
 export * from './resource';
 export * from './project';
@@ -33,21 +33,44 @@ export async function queryAllByTeam(teamId: string): Promise<TeamData> {
 		for (const item of out.Items ?? []) {
 			const sk = item.sk as string;
 			if (sk.startsWith(SK_PREFIX.resource)) {
-				data.resources.push({ id: item.id, name: item.name } as Resource);
+				// ADR 0010 「DDB read path 規約」: `as <Entity>` 全体キャスト禁止、 個別 cast に localize。
+				// Resource は現状 required field のみだが、 将来 optional 追加時に TS error で
+				// 気づけるよう同 pattern を踏む。
+				const resource: Resource = {
+					id: item.id as string,
+					name: item.name as string
+				};
+				data.resources.push(resource);
 			} else if (sk.startsWith(SK_PREFIX.project)) {
-				data.projects.push({
-					id: item.id,
-					name: item.name,
-					color: item.color
-				} as Project);
+				// optional 属性 (description / tags / links) は spread + 条件分岐で type-safe に
+				// 取り出す (#196)。 `as Project` 全体キャストは TS error を握り潰すので避け、
+				// 個別 `as string` 等に localize して 「次回 field 追加時に型 error で気づける」
+				// よう保つ。 ADR 0010 「DDB read path 規約」 参照。
+				const project: Project = {
+					id: item.id as string,
+					name: item.name as string,
+					color: item.color as string,
+					...(typeof item.description === 'string' && item.description.length > 0
+						? { description: item.description }
+						: {}),
+					...(Array.isArray(item.tags) && item.tags.length > 0
+						? { tags: item.tags as string[] }
+						: {}),
+					...(Array.isArray(item.links) && item.links.length > 0
+						? { links: item.links as ProjectLink[] }
+						: {})
+				};
+				data.projects.push(project);
 			} else if (sk.startsWith(SK_PREFIX.assignment)) {
-				data.assignments.push({
-					id: item.id,
-					resourceId: item.resourceId,
-					projectId: item.projectId,
-					startDate: item.startDate,
-					endDateExclusive: item.endDateExclusive
-				} as Assignment);
+				// ADR 0010 「DDB read path 規約」: `as <Entity>` 全体キャスト禁止、 個別 cast に localize。
+				const assignment: Assignment = {
+					id: item.id as string,
+					resourceId: item.resourceId as string,
+					projectId: item.projectId as string,
+					startDate: item.startDate as string,
+					endDateExclusive: item.endDateExclusive as string
+				};
+				data.assignments.push(assignment);
 			}
 			// META / MEMBER# は無視 (App data only)
 		}

--- a/web/src/lib/repository/integration.test.ts
+++ b/web/src/lib/repository/integration.test.ts
@@ -1,6 +1,7 @@
 import { ulid } from 'ulid';
 import { describe, expect, it } from 'vitest';
 import { createAssignment } from './assignment';
+import { createProject, deleteProject, updateProject } from './project';
 import { createResource, deleteResource, updateResource } from './resource';
 import { queryAllByTeam } from './index';
 import { addMembership, getOrCreateDefaultTeam, getTeam, getUserTeamIds } from './team';
@@ -104,6 +105,69 @@ describe.runIf(process.env.AWS_ENDPOINT_URL)('repository integration (DDB Local)
 		// user-centric (GSI1): user の所属 team 一覧
 		const teams = await getUserTeamIds(userId);
 		expect(teams).toContain(teamId);
+	});
+
+	it('Project optional fields round-trip: create(full) → query → update(REMOVE) → query (refs #196)', async () => {
+		const teamId = `test-${ulid()}`;
+		const p = await createProject(teamId, {
+			name: 'P with detail',
+			color: '#0000ff',
+			description: 'markdown body',
+			tags: ['ts', 'aws'],
+			links: [{ url: 'https://example.com', label: 'Wiki' }]
+		});
+
+		// queryAllByTeam should return all optional fields preserved
+		let data = await queryAllByTeam(teamId);
+		expect(data.projects).toHaveLength(1);
+		expect(data.projects[0]).toEqual({
+			id: p.id,
+			name: 'P with detail',
+			color: '#0000ff',
+			description: 'markdown body',
+			tags: ['ts', 'aws'],
+			links: [{ url: 'https://example.com', label: 'Wiki' }]
+		});
+
+		// update with empty detail → REMOVE semantics
+		await updateProject(teamId, {
+			id: p.id,
+			name: 'P with detail',
+			color: '#0000ff',
+			description: undefined,
+			tags: [],
+			links: []
+		});
+
+		data = await queryAllByTeam(teamId);
+		expect(data.projects[0]).toEqual({
+			id: p.id,
+			name: 'P with detail',
+			color: '#0000ff'
+		});
+		expect(data.projects[0]).not.toHaveProperty('description');
+		expect(data.projects[0]).not.toHaveProperty('tags');
+		expect(data.projects[0]).not.toHaveProperty('links');
+
+		// cleanup
+		await deleteProject(teamId, p.id);
+	});
+
+	it('Project create with empty detail omits attributes from item (refs #196)', async () => {
+		const teamId = `test-${ulid()}`;
+		const p = await createProject(teamId, {
+			name: 'P minimal',
+			color: '#abcdef',
+			description: undefined,
+			tags: [],
+			links: []
+		});
+
+		const data = await queryAllByTeam(teamId);
+		expect(data.projects[0]).toEqual({ id: p.id, name: 'P minimal', color: '#abcdef' });
+
+		// cleanup
+		await deleteProject(teamId, p.id);
 	});
 
 	it('getOrCreateDefaultTeam is idempotent', async () => {


### PR DESCRIPTION
## Summary

PR-N1 (#194) で Project に description / tags / links を optional 追加したが、 `web/src/lib/repository/index.ts:38-42` の `queryAllByTeam` が新 attribute を読まずに `as Project` で握り潰す Critical bug を修正。 DDB に保存はされるが、 load 時に常に undefined になる「書けるが読めない」状態だった。

## Changes

- **`web/src/lib/repository/index.ts`**: Project 読み出しを spread + 条件分岐に書き換え、 description / tags / links を type-safe に取り出す
  - 同時に Resource / Assignment も `as <Entity>` 全体キャスト → 個別 `as string` cast に localize (ADR 0010 規約準拠)
- **`web/src/lib/repository/index.test.ts`** (TDD R1): 4 ケース追加
  - attribute 全部あり → 戻り値も全保持
  - legacy item (id / name / color のみ) → 後方互換、 optional は absent
  - empty list 保存時 (`tags: []`) → 戻り値 absent (defense)
  - partial (description のみ) → ある分だけ含まれる
- **`web/src/lib/repository/integration.test.ts`** (TDD R3): DDB Local round-trip 2 ケース追加
  - create(全 detail あり) → query → update(REMOVE) → query
  - create(全 detail 空) → query → optional 全 absent
- **`docs/adr/0010-project-metadata.md`**: 「DDB read path 規約: `as <Entity>` 全体キャスト禁止」 を Implementation notes に明記、 Resource / Assignment にも適用、 write/read の condition 非対称 (defense in depth) の理由を補足

## TDD 順序 (R5 RED → GREEN を踏んだ証跡)

1. `repository/index.test.ts` に 「attribute あり」 1 ケースだけ書く → `pnpm test` で **fail (RED) を目視**
2. test を `git add` (warn-untested hook を満たす)
3. `repository/index.ts` を spread に書き換え → **GREEN**
4. 残り 3 ケース追加 → 全 GREEN
5. integration test 2 ケース追加、 DDB Local で round-trip 緑

## 検証

- ✅ `pnpm test` 319/319 緑 (unit + integration、 +12 ケース)
- ✅ `pnpm check` 0 new error (pre-existing `auth.ts:67` のみ)
- ✅ `pnpm dlx knip` exit 0
- ✅ `pnpm dlx madge --circular` no circular deps
- ✅ `code-reviewer` agent レビュー済、 Major 指摘 (Resource / Assignment も同 pattern 化、 ADR に condition 非対称の注釈) を本コミットで反映済

## 影響範囲

- 後方互換性 ✅: legacy item (description / tags / links なし) は test case で確認
- Project consumer (`+layout.server.ts` load / `+page.svelte`) には変化なし (optional フィールドが「読めるようになる」 だけ)
- PR-N4 (DetailView + SSR) の blocking dependency を解消

## 公式 docs

- [@aws-sdk/lib-dynamodb unmarshall](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/) — attribute なし → object key なし
- [DDB Update Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.UpdateExpressions.html) — REMOVE on non-existing は no-op
- [Zod v4 transform pipeline](https://zod.dev/api) — write 側で空文字 → undefined 正規化

## 関連

- fixes #196
- refs #187 (元 feature request)
- refs #194 (PR-N1)
- unblocks PR-N4 (DetailView + SSR)