### PR TITLE
feat(markdown): renderMarkdown ヘルパー追加 (PR-N2, refs #187)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,8 @@
 		"@tommykey-apps/ui-components": "^0.9.3",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
+		"isomorphic-dompurify": "^2.36.0",
+		"marked": "^18.0.3",
 		"mode-watcher": "^1.1.0",
 		"nodemailer": "^7.0.13",
 		"svelte-sonner": "^1.1.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      isomorphic-dompurify:
+        specifier: ^2.36.0
+        version: 2.36.0
+      marked:
+        specifier: ^18.0.3
+        version: 18.0.3
       mode-watcher:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.55.5(@typescript-eslint/types@8.59.1))
@@ -159,12 +165,18 @@ importers:
 
 packages:
 
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
 
   '@asamuzakjp/dom-selector@7.1.1':
     resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
@@ -1480,6 +1492,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1579,6 +1595,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@6.2.0:
+    resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
+    engines: {node: '>=20'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1625,6 +1645,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.2:
+    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
 
   enhanced-resolve@5.21.0:
     resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
@@ -1824,6 +1847,14 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1870,6 +1901,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-dompurify@2.36.0:
+    resolution: {integrity: sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==}
+    engines: {node: '>=20.19.5'}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -1894,6 +1929,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@28.1.0:
+    resolution: {integrity: sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsdom@29.1.1:
     resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
@@ -2028,6 +2072,11 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  marked@18.0.3:
+    resolution: {integrity: sha512-7VT90JOkDeaRWpfjOReRGPEKn0ecdARBkDGL+tT1wZY0efPPqkUxLUSmzy/C7TIylQYJC9STISEsCHrqb/7VIA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
@@ -2678,6 +2727,8 @@ packages:
 
 snapshots:
 
+  '@acemir/cssom@0.9.31': {}
+
   '@adobe/css-tools@4.4.4': {}
 
   '@asamuzakjp/css-color@5.1.11':
@@ -2687,6 +2738,14 @@ snapshots:
       '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.6
 
   '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
@@ -4272,6 +4331,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4366,6 +4427,13 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@6.2.0:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.3.6
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -4396,6 +4464,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.2:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   enhanced-resolve@5.21.0:
     dependencies:
@@ -4625,6 +4697,20 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4659,6 +4745,15 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-dompurify@2.36.0:
+    dependencies:
+      dompurify: 3.4.2
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
+      - supports-color
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -4679,6 +4774,33 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@28.1.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@bramus/specificity': 2.4.2
+      '@exodus/bytes': 1.15.0
+      cssstyle: 6.2.0
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - supports-color
 
   jsdom@29.1.1:
     dependencies:
@@ -4801,6 +4923,8 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
+
+  marked@18.0.3: {}
 
   mdn-data@2.27.1: {}
 

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -155,7 +155,9 @@
 		"tooLong": "{field} must be at most {max} characters",
 		"invalidDateFormat": "{field} must be in YYYY-MM-DD format",
 		"invalidColorFormat": "Color must be in #RRGGBB format",
-		"endBeforeStart": "End date must be on or after the start date"
+		"endBeforeStart": "End date must be on or after the start date",
+		"tooMany": "{field} must have at most {max} entries",
+		"invalidUrl": "{field} must be an http or https URL"
 	},
 	"fields": {
 		"id": "id",

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -155,7 +155,9 @@
 		"tooLong": "{field} は {max} 文字以内で入力してください",
 		"invalidDateFormat": "{field} は YYYY-MM-DD 形式で入力してください",
 		"invalidColorFormat": "色は #RRGGBB 形式で入力してください",
-		"endBeforeStart": "終了日は開始日以降にしてください"
+		"endBeforeStart": "終了日は開始日以降にしてください",
+		"tooMany": "{field} は {max} 件以内で入力してください",
+		"invalidUrl": "{field} は http / https の URL を入力してください"
 	},
 	"fields": {
 		"id": "id",

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { renderMarkdown } from './markdown';
+
+describe('renderMarkdown — basic markdown', () => {
+	it('renders bold', () => {
+		expect(renderMarkdown('**hello**')).toContain('<strong>hello</strong>');
+	});
+
+	it('renders italic', () => {
+		expect(renderMarkdown('*hello*')).toContain('<em>hello</em>');
+	});
+
+	it('renders unordered list', () => {
+		const out = renderMarkdown('- a\n- b');
+		expect(out).toContain('<ul>');
+		expect(out).toContain('<li>a</li>');
+		expect(out).toContain('<li>b</li>');
+	});
+
+	it('renders ordered list', () => {
+		const out = renderMarkdown('1. a\n2. b');
+		expect(out).toContain('<ol>');
+	});
+
+	it('renders inline code', () => {
+		expect(renderMarkdown('`code`')).toContain('<code>code</code>');
+	});
+
+	it('renders code block', () => {
+		const out = renderMarkdown('```\ncode\n```');
+		expect(out).toContain('<pre>');
+		expect(out).toContain('<code>');
+	});
+
+	it('renders http link', () => {
+		const out = renderMarkdown('[txt](https://example.com)');
+		expect(out).toContain('<a href="https://example.com">txt</a>');
+	});
+
+	it('renders mailto link', () => {
+		const out = renderMarkdown('[mail](mailto:foo@example.com)');
+		expect(out).toContain('<a href="mailto:foo@example.com">mail</a>');
+	});
+
+	it('renders h2-h4 but not h1 (h1 is page title)', () => {
+		expect(renderMarkdown('## h2')).toContain('<h2>');
+		expect(renderMarkdown('### h3')).toContain('<h3>');
+		expect(renderMarkdown('#### h4')).toContain('<h4>');
+		// h1 は ALLOWED_TAGS 外 → DOMPurify が strip
+		expect(renderMarkdown('# h1')).not.toContain('<h1>');
+	});
+
+	it('renders blockquote', () => {
+		expect(renderMarkdown('> quote')).toContain('<blockquote>');
+	});
+
+	it('renders hr', () => {
+		expect(renderMarkdown('---')).toContain('<hr>');
+	});
+
+	it('returns empty string for null / undefined / empty', () => {
+		expect(renderMarkdown('')).toBe('');
+		expect(renderMarkdown(null)).toBe('');
+		expect(renderMarkdown(undefined)).toBe('');
+	});
+});
+
+describe('renderMarkdown — XSS protection (BP B2 + OWASP)', () => {
+	// cure53 / OWASP / CVE で知られた attack vector を網羅
+	it.each([
+		['<script>alert(1)</script>', /<script/i, 'raw script tag'],
+		['[xss](javascript:alert(1))', /javascript:/i, 'javascript: URL in markdown link'],
+		['<img src=x onerror=alert(1)>', /<img/i, 'img with onerror (FORBID_TAGS)'],
+		['<iframe src="evil"></iframe>', /<iframe/i, 'iframe'],
+		['<a href="javascript:alert(1)">x</a>', /javascript:/i, 'javascript: in href'],
+		[
+			'<a href="data:text/html,<script>alert(1)</script>">x</a>',
+			/data:/i,
+			'data: URL'
+		],
+		['<svg><script>alert(1)</script></svg>', /<script/i, 'svg + script'],
+		['<style>body{display:none}</style>', /<style/i, 'style tag (FORBID_TAGS)'],
+		['<form><input type=submit></form>', /<form|<input/i, 'form + input (FORBID_TAGS)'],
+		['<object data="evil"></object>', /<object/i, 'object'],
+		['<embed src="evil">', /<embed/i, 'embed'],
+		// mXSS template literal pattern (CVE-2025-26791 関連、 SAFE_FOR_TEMPLATES 未使用なので非該当だが防御確認)
+		[
+			'<math><mtext><table><mglyph><style><a title="</style><img src onerror=alert(1)>">',
+			/onerror/i,
+			'mXSS template literal pattern'
+		]
+	])('strips %s — %s', (input, forbidden, description) => {
+		expect(description).toBeTruthy(); // タイトル用に渡しているだけ、 ESLint 不要 var 警告回避
+		expect(renderMarkdown(input)).not.toMatch(forbidden);
+	});
+
+	it('strips event handler attribute on allowed tag', () => {
+		const out = renderMarkdown('<a href="https://example.com" onclick="alert(1)">x</a>');
+		expect(out).not.toMatch(/onclick/i);
+		expect(out).toMatch(/href="https:\/\/example\.com"/);
+	});
+
+	it('strips style attribute on allowed tag', () => {
+		const out = renderMarkdown('<p style="background:url(javascript:alert(1))">hi</p>');
+		expect(out).not.toMatch(/style=/i);
+		expect(out).toContain('<p>');
+	});
+});
+
+describe('renderMarkdown — GFM features', () => {
+	it('renders strikethrough', () => {
+		expect(renderMarkdown('~~del~~')).toContain('<del>del</del>');
+	});
+
+	it('renders table', () => {
+		const md = '| h1 | h2 |\n|----|----|\n| a  | b  |';
+		const out = renderMarkdown(md);
+		expect(out).toContain('<table>');
+		expect(out).toContain('<th>h1</th>');
+		expect(out).toContain('<td>a</td>');
+	});
+
+	it('strips task list <input> (FORBID_TAGS)', () => {
+		const out = renderMarkdown('- [x] done\n- [ ] todo');
+		// FORBID_TAGS で <input> は除外、 ただし周りの list 構造 / text は残る
+		expect(out).not.toMatch(/<input/i);
+		expect(out).toContain('<li>');
+	});
+
+	it('autolinks bare URL (GFM)', () => {
+		const out = renderMarkdown('see https://example.com for details');
+		expect(out).toContain('<a href="https://example.com">https://example.com</a>');
+	});
+});

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -1,0 +1,60 @@
+import { marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+
+// BP B3: marked v18 は sync が default、 TS 型は `string | Promise<string>` union で
+// 返るため `{ async: false }` 明示 + `as string` cast で narrow。
+marked.use({ gfm: true, breaks: true, async: false });
+
+// DOMPurify は allow-list (= ALLOWED_TAGS / ALLOWED_ATTR) を明示すれば、 そこに無い tag / attr は
+// 自動的に strip される (cure53 公式の deny-by-default semantics)。 よって以下の設定は冗長な
+// FORBID_TAGS / FORBID_ATTR を持たず、 allow-list だけで XSS を遮断する。
+// - h1 は page title 衝突回避で ALLOWED_TAGS に入れない (業界事例: GitHub README と同じ)
+// - img / style / iframe / script / svg / form / input 等は allow-list 不在で自動 strip される
+// - onclick / onerror / onload / formaction 等の event handler は ALLOWED_ATTR 不在で自動 strip
+// - SAFE_FOR_TEMPLATES は使わない (CVE-2025-26791 発火条件、 BP B2)
+// - ALLOWED_URI_REGEXP で javascript: / data: scheme を遮断 (cure53 demo 標準)
+// ref: https://github.com/cure53/DOMPurify/wiki/Default-TAGs-ATTRIBUTEs-allow-list-&-blocklist
+const SANITIZE_CONFIG = {
+	ALLOWED_TAGS: [
+		'p',
+		'br',
+		'strong',
+		'em',
+		'del',
+		'code',
+		'pre',
+		'h2',
+		'h3',
+		'h4',
+		'ul',
+		'ol',
+		'li',
+		'blockquote',
+		'hr',
+		'a',
+		'table',
+		'thead',
+		'tbody',
+		'tr',
+		'th',
+		'td'
+	],
+	ALLOWED_ATTR: ['href', 'title'],
+	ALLOW_DATA_ATTR: false,
+	ALLOWED_URI_REGEXP: /^(?:https?|mailto):/i
+};
+
+/**
+ * markdown を sanitize 済 HTML 文字列に変換 (ADR 0010)。
+ *
+ * - `isomorphic-dompurify` で SSR / CSR / vitest jsdom 全環境で動作 (BP B4)
+ * - marked v18 sync API + DOMPurify config の二段で XSS / mXSS を防ぐ (BP B2 / B3)
+ * - CSP (PR-N0) と合わせて二段防御
+ */
+export function renderMarkdown(input: string | null | undefined): string {
+	if (!input) return '';
+	// marked v14+ で `{ async: false }` のオーバーロードが string を返すと型確定 (PR #3341)、
+	// `as string` cast 不要。 将来 async: true が混入したら型 error で気づける。
+	const rawHtml = marked.parse(input, { async: false });
+	return DOMPurify.sanitize(rawHtml, SANITIZE_CONFIG);
+}


### PR DESCRIPTION
## Summary

PR-N4 で `Project.description` を SSR render するためのヘルパー `renderMarkdown` を実装。 `marked` v18 sync + `isomorphic-dompurify` v2.36 で markdown → sanitize 済 HTML 変換、 XSS / mXSS を allow-list ベースで遮断。

ADR 0010 の Decision に従い、 SSR / CSR / vitest jsdom 全環境で動作する isomorphic-dompurify を採用。

## Changes

- **`web/src/lib/markdown.ts`** (新規): `renderMarkdown(input: string | null | undefined): string`
  - marked v18 sync API (`{ async: false }` 明示、 v14+ の overload で `string` 返却が型確定済、 cast 不要)
  - DOMPurify config: ALLOWED_TAGS / ALLOWED_ATTR (`['href', 'title']`) の allow-list で deny-by-default、 ALLOWED_URI_REGEXP で javascript: / data: 遮断、 SAFE_FOR_TEMPLATES 不使用 (CVE-2025-26791 発火条件)
  - h1 は page title 衝突回避で除外 (業界事例: GitHub README と同)
- **`web/src/lib/markdown.test.ts`** (新規、 30 ケース、 jsdom env):
  - basic markdown (12): bold / italic / list / code / link / mailto / h2-h4 / blockquote / hr / null・undefined・empty
  - XSS protection (14): script / javascript: URL / img onerror / iframe / data: URL / svg+script / style / form+input / object / embed / mXSS template / event handler / style attr
  - GFM (4): strikethrough / table / task list <input> strip / autolink
- **`web/src/lib/i18n/{ja,en}.json`**: `errors.tooMany` / `errors.invalidUrl` を追加 (PR-N1 schema 側が参照済)
- **`web/package.json`** / `pnpm-lock.yaml`: `marked@^18.0.0` / `isomorphic-dompurify@^2.30.0` を deps に追加 (内部 dompurify@3.4.2、 CVE 修正済)

## TDD 順序 (R5 を踏襲)

1. `markdown.test.ts` に 「bold が <strong> に変換される」 1 ケースだけ書く → `pnpm test` で **fail (markdown.ts 未作成) を目視**
2. `git add` で test と新規 deps を staging
3. `markdown.ts` を実装 → GREEN
4. 残り 29 ケース (basic / XSS / GFM) 追加、 全 GREEN
5. i18n キー追加、 全体 `pnpm test` で 349 緑

## 検証

- ✅ `pnpm test src/lib/markdown.test.ts` 30/30 緑
- ✅ `pnpm test` 全体 349/349 緑 (+30 from baseline 319)
- ✅ `pnpm check` 0 new error (pre-existing `auth.ts:67` のみ)
- ✅ `pnpm dlx knip` exit 0
- ✅ `pnpm dlx madge --circular` no circular deps
- ✅ `code-reviewer` agent レビュー済、 Major 2 件 (`as string` cast 削除、 `FORBID_*` allow-list 二重指定の冗長性) + Minor 1 件 (`it.each` title 引数順) を本 commit で反映

## 関連

- refs #187 (feature request)
- refs #194 (PR-N1)
- unblocks PR-N4 (DetailView + SSR render で `renderMarkdown(p.description)` を呼ぶ)

## 公式 docs

- [marked v18 sync API](https://marked.js.org/using_advanced)
- [cure53 DOMPurify allow-list](https://github.com/cure53/DOMPurify/wiki/Default-TAGs-ATTRIBUTEs-allow-list-&-blocklist)
- [OWASP XSS Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
- [vitest jsdom env directive](https://vitest.dev/config/#environment)