### PR TITLE
feat(ui): Input / Textarea コンポーネント追加 (#177-ext)

### DIFF
--- a/web/src/lib/components/AssignmentCreator.svelte
+++ b/web/src/lib/components/AssignmentCreator.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import Plus from 'phosphor-svelte/lib/Plus';
 	import { Button } from './ui/button';
+	import { Input } from './ui/input';
 	import Dialog from './Dialog.svelte';
 	import { formatLocalDate } from '$lib/date';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
@@ -126,14 +127,7 @@
 		<div class="grid grid-cols-2 gap-3">
 			<label class="flex flex-col gap-1 text-sm">
 				<span>{t('assignments.startDate')}</span>
-				<input
-					name="startDate"
-					type="date"
-					bind:value={startDate}
-					required
-					class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-					style="border-radius: calc(var(--radius) * 0.6)"
-				/>
+				<Input name="startDate" type="date" bind:value={startDate} required />
 				{#if formError?.startDate}
 					<span class="text-xs text-destructive">{formError.startDate}</span>
 				{/if}
@@ -141,15 +135,7 @@
 
 			<label class="flex flex-col gap-1 text-sm">
 				<span>{t('assignments.endDate')}</span>
-				<input
-					name="endDate"
-					type="date"
-					bind:value={endDate}
-					required
-					min={startDate}
-					class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-					style="border-radius: calc(var(--radius) * 0.6)"
-				/>
+				<Input name="endDate" type="date" bind:value={endDate} required min={startDate} />
 				{#if formError?.endDate}
 					<span class="text-xs text-destructive">{formError.endDate}</span>
 				{/if}

--- a/web/src/lib/components/AssignmentEditor.svelte
+++ b/web/src/lib/components/AssignmentEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
 	import { Button } from './ui/button';
+	import { Input } from './ui/input';
 	import Dialog from './Dialog.svelte';
 	import { addDays } from '$lib/date';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
@@ -76,12 +77,7 @@
 </script>
 
 <Dialog bind:open title={t('assignments.editTitle')} description={t('assignments.description')}>
-	<form
-		method="POST"
-		action="/?/updateAssignment"
-		use:enhance={submit}
-		class="flex flex-col gap-3"
-	>
+	<form method="POST" action="/?/updateAssignment" use:enhance={submit} class="flex flex-col gap-3">
 		{#if assignment}
 			<input type="hidden" name="id" value={assignment.id} />
 			<input type="hidden" name="prevStartDate" value={assignment.startDate} />
@@ -128,14 +124,7 @@
 		<div class="grid grid-cols-2 gap-3">
 			<label class="flex flex-col gap-1 text-sm">
 				<span>{t('assignments.startDate')}</span>
-				<input
-					name="startDate"
-					type="date"
-					bind:value={formStartDate}
-					required
-					class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-					style="border-radius: calc(var(--radius) * 0.6)"
-				/>
+				<Input name="startDate" type="date" bind:value={formStartDate} required />
 				{#if formError?.startDate}
 					<span class="text-xs text-destructive">{formError.startDate}</span>
 				{/if}
@@ -143,15 +132,7 @@
 
 			<label class="flex flex-col gap-1 text-sm">
 				<span>{t('assignments.endDate')}</span>
-				<input
-					name="endDate"
-					type="date"
-					bind:value={formEndDate}
-					required
-					min={formStartDate}
-					class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-					style="border-radius: calc(var(--radius) * 0.6)"
-				/>
+				<Input name="endDate" type="date" bind:value={formEndDate} required min={formStartDate} />
 				{#if formError?.endDate}
 					<span class="text-xs text-destructive">{formError.endDate}</span>
 				{/if}

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import Folder from 'phosphor-svelte/lib/Folder';
 	import { Button } from './ui/button';
+	import { Input } from './ui/input';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { confirmDialog } from '$lib/forms/confirm-dialog';
@@ -154,15 +155,13 @@
 
 		<label class="flex flex-col gap-1 text-sm">
 			<span>{t('projects.name')}</span>
-			<input
+			<Input
 				name="name"
 				type="text"
 				bind:value={formName}
 				required
-				maxlength="100"
+				maxlength={100}
 				autocomplete="off"
-				class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-				style="border-radius: calc(var(--radius) * 0.6)"
 			/>
 			{#if formError?.name}
 				<span class="text-xs text-destructive">{formError.name}</span>

--- a/web/src/lib/components/ResourceManager.svelte
+++ b/web/src/lib/components/ResourceManager.svelte
@@ -2,6 +2,7 @@
 	import { enhance } from '$app/forms';
 	import Users from 'phosphor-svelte/lib/Users';
 	import { Button } from './ui/button';
+	import { Input } from './ui/input';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { confirmDialog } from '$lib/forms/confirm-dialog';
@@ -92,7 +93,8 @@
 					if (onRollbackCreate) onRollbackCreate(tempSnapshot);
 					const recovered = rollbackRecoverState({
 						temp: tempSnapshot,
-						failureData: result.type === 'failure' ? (result.data as { errors?: ServerErrors }) : undefined,
+						failureData:
+							result.type === 'failure' ? (result.data as { errors?: ServerErrors }) : undefined,
 						translate: translateServerError,
 						fallback: t('errors.generic'),
 						field: 'name'
@@ -201,15 +203,13 @@
 		{/if}
 		<label class="flex flex-col gap-1 text-sm">
 			<span>{t('resources.name')}</span>
-			<input
+			<Input
 				name="name"
 				type="text"
 				bind:value={formName}
 				required
-				maxlength="100"
+				maxlength={100}
 				autocomplete="off"
-				class="h-9 border border-input bg-background px-2 text-sm focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none"
-				style="border-radius: calc(var(--radius) * 0.6)"
 			/>
 		</label>
 		{#if formError}

--- a/web/src/lib/components/ui/input/index.ts
+++ b/web/src/lib/components/ui/input/index.ts
@@ -1,0 +1,7 @@
+import Root from './input.svelte';
+
+export {
+	Root,
+	//
+	Root as Input
+};

--- a/web/src/lib/components/ui/input/input.svelte
+++ b/web/src/lib/components/ui/input/input.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from 'svelte/elements';
+	import { cn, type WithElementRef } from '$lib/utils.js';
+
+	type InputType = Exclude<HTMLInputTypeAttribute, 'file'>;
+
+	type Props = WithElementRef<
+		Omit<HTMLInputAttributes, 'type'> &
+			({ type: 'file'; files?: FileList } | { type?: InputType; files?: undefined })
+	>;
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		type,
+		files = $bindable(),
+		class: className,
+		'data-slot': dataSlot = 'input',
+		...restProps
+	}: Props = $props();
+
+	// #177-ext: 既存 4 form の hardcode class (h-9 / border / focus-visible:ring 等) と同等を
+	// flat に記述。 button は tv() で variant 分岐するが Input は variant が無いため flat で十分。
+	const baseClass =
+		'h-9 w-full min-w-0 border border-input bg-background px-2 text-sm ' +
+		'placeholder:text-muted-foreground ' +
+		'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ' +
+		'aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 ' +
+		'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50';
+</script>
+
+{#if type === 'file'}
+	<input
+		bind:this={ref}
+		data-slot={dataSlot}
+		class={cn(baseClass, 'file:inline-flex file:border-0 file:bg-transparent', className)}
+		style="border-radius: calc(var(--radius) * 0.6); {restProps.style ?? ''}"
+		type="file"
+		bind:files
+		bind:value
+		{...restProps}
+	/>
+{:else}
+	<input
+		bind:this={ref}
+		data-slot={dataSlot}
+		class={cn(baseClass, className)}
+		style="border-radius: calc(var(--radius) * 0.6); {restProps.style ?? ''}"
+		{type}
+		bind:value
+		{...restProps}
+	/>
+{/if}

--- a/web/src/lib/components/ui/input/input.svelte.test.ts
+++ b/web/src/lib/components/ui/input/input.svelte.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { Input } from './index.js';
+
+/**
+ * #177-ext: shadcn-svelte 互換の Input wrapper。
+ * 既存 4 form の hardcode `<input>` を統一する用途。
+ *
+ * テスト戦略: button.svelte.test.ts と同じく render の smoke + 主要 prop pass-through。
+ * value は $bindable なので、 render 時に渡せば DOM の value 属性に反映される。
+ */
+describe('Input (#177-ext)', () => {
+	it('renders an input element with given value', () => {
+		const { container } = render(Input, { value: 'hello' });
+		const el = container.querySelector('input');
+		expect(el).not.toBeNull();
+		expect(el?.value).toBe('hello');
+	});
+
+	it('passes through aria-describedby for accessibility (a11y)', () => {
+		const { container } = render(Input, { 'aria-describedby': 'help-text' });
+		expect(container.querySelector('input')?.getAttribute('aria-describedby')).toBe('help-text');
+	});
+
+	it('uses type="text" by default (HTML default) and supports type="date"', () => {
+		const { container } = render(Input, { type: 'date' });
+		expect(container.querySelector('input')?.getAttribute('type')).toBe('date');
+	});
+
+	it('has data-slot="input" for shadcn-svelte convention', () => {
+		const { container } = render(Input);
+		expect(container.querySelector('input')?.getAttribute('data-slot')).toBe('input');
+	});
+
+	it('applies merged className (consumer class wins via twMerge)', () => {
+		const { container } = render(Input, { class: 'w-32' });
+		const cls = container.querySelector('input')?.className ?? '';
+		// consumer の w-32 が baseClass の w-full に勝つ (tailwind-merge)
+		expect(cls).toMatch(/\bw-32\b/);
+		expect(cls).not.toMatch(/\bw-full\b/);
+	});
+});

--- a/web/src/lib/components/ui/textarea/index.ts
+++ b/web/src/lib/components/ui/textarea/index.ts
@@ -1,0 +1,7 @@
+import Root from './textarea.svelte';
+
+export {
+	Root,
+	//
+	Root as Textarea
+};

--- a/web/src/lib/components/ui/textarea/textarea.svelte
+++ b/web/src/lib/components/ui/textarea/textarea.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { cn, type WithElementRef, type WithoutChildren } from '$lib/utils.js';
+	import type { HTMLTextareaAttributes } from 'svelte/elements';
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		class: className,
+		'data-slot': dataSlot = 'textarea',
+		...restProps
+	}: WithoutChildren<WithElementRef<HTMLTextareaAttributes>> = $props();
+
+	const baseClass =
+		'min-h-16 w-full border border-input bg-background px-2 py-1 text-sm ' +
+		'placeholder:text-muted-foreground ' +
+		'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ' +
+		'aria-invalid:border-destructive aria-invalid:ring-1 aria-invalid:ring-destructive/20 ' +
+		'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 ' +
+		'resize-none';
+</script>
+
+<textarea
+	bind:this={ref}
+	data-slot={dataSlot}
+	class={cn(baseClass, className)}
+	style="border-radius: calc(var(--radius) * 0.6); {restProps.style ?? ''}"
+	bind:value
+	{...restProps}
+></textarea>

--- a/web/src/lib/components/ui/textarea/textarea.svelte.test.ts
+++ b/web/src/lib/components/ui/textarea/textarea.svelte.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { render } from '@testing-library/svelte';
+import { describe, expect, it } from 'vitest';
+import { Textarea } from './index.js';
+
+/**
+ * #177-ext: shadcn-svelte 互換の Textarea wrapper。
+ * 現状 form では使われていないが、 #197 以降の ProjectDetailView (description 編集) で使う前提で追加。
+ */
+describe('Textarea (#177-ext)', () => {
+	it('renders a textarea element with given value', () => {
+		const { container } = render(Textarea, { value: 'hello' });
+		const el = container.querySelector('textarea');
+		expect(el).not.toBeNull();
+		expect(el?.value).toBe('hello');
+	});
+
+	it('passes through aria-describedby for accessibility (a11y)', () => {
+		const { container } = render(Textarea, { 'aria-describedby': 'help-text' });
+		expect(container.querySelector('textarea')?.getAttribute('aria-describedby')).toBe('help-text');
+	});
+
+	it('has data-slot="textarea" for shadcn-svelte convention', () => {
+		const { container } = render(Textarea);
+		expect(container.querySelector('textarea')?.getAttribute('data-slot')).toBe('textarea');
+	});
+
+	it('applies merged className (consumer class wins via twMerge)', () => {
+		const { container } = render(Textarea, { class: 'min-h-32' });
+		const cls = container.querySelector('textarea')?.className ?? '';
+		expect(cls).toMatch(/\bmin-h-32\b/);
+		expect(cls).not.toMatch(/\bmin-h-16\b/);
+	});
+});

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -4,3 +4,17 @@
  * - 各 component test ファイル先頭に `// @vitest-environment jsdom` directive を付けて jsdom 化
  */
 import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+
+// bits-ui v2 の `body-scroll-lock` は Dialog unmount 時に 24ms 遅延の setTimeout で
+// document.body のスタイル復元 cleanup を schedule する。 component test 終了で jsdom が
+// teardown された後に当該 timer が発火すると `document is not defined` で Unhandled Error が
+// 出て CI が exit 1 で落ちる (test 自体は全 pass)。
+// 各 test 終了時に短い await で当該 timer を確実に消費させる (jsdom 環境のみ)。
+// ref: https://github.com/huntabyte/bits-ui/issues/1639
+//      bits-ui/dist/internal/body-scroll-lock.svelte.js (cleanupTimeoutId = setTimeout(cleanupFn, 24))
+afterEach(async () => {
+	if (typeof document !== 'undefined') {
+		await new Promise((resolve) => setTimeout(resolve, 30));
+	}
+});


### PR DESCRIPTION
## Summary

- shadcn-svelte verbatim source ベースの薄い `Input` / `Textarea` wrapper を `web/src/lib/components/ui/{input,textarea}/` に追加
- 既存 4 form (ResourceManager / ProjectManager / AssignmentCreator / AssignmentEditor) の hardcode `<input>` (同一 class) を `<Input>` で統一
- `<input type=\"color\">` (専用 UI) と `<select>` (`ui/select` で別途対応予定) は scope 外
- Textarea は本 PR では未使用、 後続 ProjectDetailView (description 編集) で使う前提で同 pattern で追加

## Changes

| File | Change |
|------|--------|
| `web/src/lib/components/ui/input/{input.svelte,input.svelte.test.ts,index.ts}` | 新規 |
| `web/src/lib/components/ui/textarea/{textarea.svelte,textarea.svelte.test.ts,index.ts}` | 新規 |
| `web/src/lib/components/{ResourceManager,ProjectManager,AssignmentCreator,AssignmentEditor}.svelte` | hardcode `<input>` を `<Input>` へ置換 |

`web/src/lib/utils.ts` の `WithoutChildren<T>` / `WithElementRef<T>` は既存利用、 追加なし。 package.json / i18n の追加もなし。

## TDD R1-R5

1. **R5** — Input: `index.js` import 解決不可で失敗するテスト 1 件を staging → fail 確認 → 実装 → GREEN → 残テスト (aria-describedby / type=date / data-slot / className merge) 追加 → 5 test 全 GREEN
2. **R5** — Textarea: 同手順で 4 test 全 GREEN
3. 既存 form 4 ファイル: 1 つずつ置換 → 既存 component test (61 test) 全 GREEN を確認

## 検証

- [x] `TZ=UTC pnpm test src/lib/components/` 14 file / 61 test 全 GREEN、 regression なし
- [x] `pnpm check` 0 error (pre-existing CSS warning 1 のみ、 `+page.svelte:197 .empty-state .hint`)
- [x] `pnpm dlx knip` exit 0
- [x] `pnpm dlx madge --circular --extensions ts,svelte src/` no circular
- [x] `pnpm exec prettier --check` 全 file 整形済

## 関連 issue

- 元 tracking: #177 (UI 統一の親 issue)
- 後続: ProjectDetailView (description / tags / links UI) で `<Textarea>` を初使用予定

## Test plan

- [ ] CI で `pnpm test` が緑であること
- [ ] CI で `pnpm check` が 0 error であること
- [ ] preview / staging で resource / project の form が従来通り入力 / 送信できること
- [ ] preview / staging で assignment 作成 / 編集 dialog の date input が動作すること