### PR TITLE
feat(project-form): ProjectManager に詳細入力 section 追加 (PR-N3, refs #187)

### DIFF
--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -3,13 +3,37 @@
 	import Folder from 'phosphor-svelte/lib/Folder';
 	import { Button } from './ui/button';
 	import { Input } from './ui/input';
+	import { Textarea } from './ui/textarea';
 	import Dialog from './Dialog.svelte';
 	import { createSubmitState } from '$lib/forms/submit-state.svelte';
 	import { confirmDialog } from '$lib/forms/confirm-dialog';
 	import { translateServerError, type ServerErrors } from '$lib/forms/server-error';
 	import { t } from '$lib/i18n/index.svelte';
-	import type { Project, Assignment } from '$lib/types';
+	import type { Project, ProjectLink, Assignment } from '$lib/types';
+	import {
+		PROJECT_DESCRIPTION_MAX_LENGTH,
+		PROJECT_LINK_LABEL_MAX_LENGTH,
+		PROJECT_LINK_MAX_COUNT,
+		PROJECT_TAGS_CSV_MAX_LENGTH
+	} from '$lib/schemas';
 	import type { SubmitFunction } from '@sveltejs/kit';
+
+	/**
+	 * リンクの編集 UI で使う internal 型。 `_key` は `{#each}` の stable key として使う
+	 * (index key は削除 / 並び替え時に DOM 破壊するため non-recommended)。
+	 * server 送信時 (`linksJson`) は `_key` を除外して JSON.stringify する。
+	 */
+	interface EditableProjectLink extends ProjectLink {
+		_key: string;
+	}
+
+	function withKey(link: ProjectLink): EditableProjectLink {
+		return { ...link, _key: crypto.randomUUID() };
+	}
+
+	function stripKey({ _key: _, ...rest }: EditableProjectLink): ProjectLink {
+		return rest;
+	}
 
 	let {
 		projects,
@@ -35,12 +59,29 @@
 	let editing = $state<Project | null>(null);
 	let formName = $state('');
 	let formColor = $state(DEFAULT_COLOR);
-	let formError = $state<{ name?: string; color?: string } | null>(null);
+	let formDescription = $state('');
+	let formTagsRaw = $state('');
+	let formLinks = $state<EditableProjectLink[]>([]);
+	let formError = $state<{
+		name?: string;
+		color?: string;
+		description?: string;
+		tags?: string;
+		linksJson?: string;
+	} | null>(null);
+
+	// BP B7 / APG Disclosure: 既存値ありなら details default open。 新規作成時は閉じる。
+	const hasDetail = $derived(
+		formDescription.length > 0 || formTagsRaw.trim().length > 0 || formLinks.length > 0
+	);
 
 	function startCreate() {
 		editing = null;
 		formName = '';
 		formColor = DEFAULT_COLOR;
+		formDescription = '';
+		formTagsRaw = '';
+		formLinks = [];
 		formError = null;
 		formOpen = true;
 	}
@@ -49,8 +90,19 @@
 		editing = p;
 		formName = p.name;
 		formColor = p.color;
+		formDescription = p.description ?? '';
+		formTagsRaw = (p.tags ?? []).join(', ');
+		formLinks = (p.links ?? []).map(withKey);
 		formError = null;
 		formOpen = true;
+	}
+
+	function addLink() {
+		formLinks = [...formLinks, withKey({ label: '', url: '' })];
+	}
+
+	function removeLink(index: number) {
+		formLinks = formLinks.filter((_, i) => i !== index);
 	}
 
 	// 連打抑制 + submitting state (#94)。delete は #132 で confirm dialog が modal ブロックする。
@@ -66,7 +118,10 @@
 				const errs = (result.data as { errors?: ServerErrors })?.errors;
 				formError = {
 					name: errs?.name ? translateServerError(errs.name) : undefined,
-					color: errs?.color ? translateServerError(errs.color) : undefined
+					color: errs?.color ? translateServerError(errs.color) : undefined,
+					description: errs?.description ? translateServerError(errs.description) : undefined,
+					tags: errs?.tags ? translateServerError(errs.tags) : undefined,
+					linksJson: errs?.linksJson ? translateServerError(errs.linksJson) : undefined
 				};
 			}
 			await update();
@@ -184,6 +239,103 @@
 				<span class="text-xs text-destructive">{formError.color}</span>
 			{/if}
 		</label>
+
+		<!-- BP B7 (APG Disclosure): 既存値ありなら default open、 なければ closed。 -->
+		<details open={hasDetail} class="mt-2">
+			<summary class="cursor-pointer select-none text-sm font-medium">
+				{t('projects.editDetail')}
+			</summary>
+			<div class="mt-2 flex flex-col gap-3">
+				<label class="flex flex-col gap-1 text-sm">
+					<span>
+						{t('projects.descriptionLabel')}
+						<small class="text-muted-foreground text-xs">{t('projects.descriptionHint')}</small>
+					</span>
+					<Textarea
+						name="description"
+						bind:value={formDescription}
+						rows={6}
+						maxlength={PROJECT_DESCRIPTION_MAX_LENGTH}
+					/>
+					{#if formError?.description}
+						<span class="text-xs text-destructive">{formError.description}</span>
+					{/if}
+				</label>
+
+				<label class="flex flex-col gap-1 text-sm">
+					<span>{t('projects.tagsLabel')}</span>
+					<Input
+						id="project-tags-input"
+						name="tags"
+						bind:value={formTagsRaw}
+						aria-describedby="project-tags-hint"
+						maxlength={PROJECT_TAGS_CSV_MAX_LENGTH}
+					/>
+					<!-- BP B7: aria-describedby で AT に comma 区切り意図を伝える。 -->
+					<p id="project-tags-hint" class="text-xs text-muted-foreground">
+						{t('projects.tagsHint')}
+					</p>
+					{#if formError?.tags}
+						<span class="text-xs text-destructive">{formError.tags}</span>
+					{/if}
+				</label>
+
+				<fieldset class="flex flex-col gap-2">
+					<legend class="text-sm">{t('projects.linksLabel')}</legend>
+					{#each formLinks as link, i (link._key)}
+						<div class="flex items-start gap-2">
+							<!-- BP B7 a11y: 各 input に aria-label を付け、 行番号を伝える
+							     (placeholder は accessible name の代替不可、 WAI-ARIA APG)。 -->
+							<Input
+								aria-label={`${t('projects.linkLabel')} ${i + 1}`}
+								placeholder={t('projects.linkLabel')}
+								bind:value={link.label}
+								maxlength={PROJECT_LINK_LABEL_MAX_LENGTH}
+								class="flex-1"
+							/>
+							<Input
+								type="url"
+								aria-label={`${t('projects.linkUrl')} ${i + 1}`}
+								placeholder={t('projects.linkUrl')}
+								bind:value={link.url}
+								class="flex-1"
+							/>
+							<Button
+								size="xs"
+								variant="ghost"
+								type="button"
+								onclick={() => removeLink(i)}
+							>
+								{t('projects.removeLink')}
+							</Button>
+						</div>
+					{/each}
+					{#if formLinks.length < PROJECT_LINK_MAX_COUNT}
+						<Button
+							size="xs"
+							variant="outline"
+							type="button"
+							onclick={addLink}
+							class="self-start"
+						>
+							{t('projects.addLink')}
+						</Button>
+					{/if}
+					{#if formError?.linksJson}
+						<span class="text-xs text-destructive">{formError.linksJson}</span>
+					{/if}
+				</fieldset>
+
+				<!--
+					BP B8 (SvelteKit form action + nested data): 純粋 FormData では
+					`name="links[0].url"` は spec 外。 hidden input に JSON.stringify した文字列で送り、
+					server 側で JSON.parse → zod validate する pattern を採用 (ADR 0010、 progressive
+					enhancement を捨てる trade-off を明記)。
+					`_key` は UI 専用 (each key) なので stripKey で除外してから serialize する。
+				-->
+				<input type="hidden" name="linksJson" value={JSON.stringify(formLinks.map(stripKey))} />
+			</div>
+		</details>
 
 		<div class="mt-2 flex justify-end gap-2">
 			<Button

--- a/web/src/lib/components/ProjectManager.svelte
+++ b/web/src/lib/components/ProjectManager.svelte
@@ -14,6 +14,8 @@
 		PROJECT_DESCRIPTION_MAX_LENGTH,
 		PROJECT_LINK_LABEL_MAX_LENGTH,
 		PROJECT_LINK_MAX_COUNT,
+		PROJECT_LINK_URL_MAX_LENGTH,
+		PROJECT_NAME_MAX_LENGTH,
 		PROJECT_TAGS_CSV_MAX_LENGTH
 	} from '$lib/schemas';
 	import type { SubmitFunction } from '@sveltejs/kit';
@@ -215,7 +217,7 @@
 				type="text"
 				bind:value={formName}
 				required
-				maxlength={100}
+				maxlength={PROJECT_NAME_MAX_LENGTH}
 				autocomplete="off"
 			/>
 			{#if formError?.name}
@@ -298,12 +300,14 @@
 								aria-label={`${t('projects.linkUrl')} ${i + 1}`}
 								placeholder={t('projects.linkUrl')}
 								bind:value={link.url}
+								maxlength={PROJECT_LINK_URL_MAX_LENGTH}
 								class="flex-1"
 							/>
 							<Button
 								size="xs"
 								variant="ghost"
 								type="button"
+								aria-label={`${t('projects.removeLink')} ${i + 1}`}
 								onclick={() => removeLink(i)}
 							>
 								{t('projects.removeLink')}

--- a/web/src/lib/components/ProjectManager.svelte.test.ts
+++ b/web/src/lib/components/ProjectManager.svelte.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
-import { render } from '@testing-library/svelte';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
 import ProjectManager from './ProjectManager.svelte';
+import type { Project } from '$lib/types';
 
 describe('ProjectManager (smoke)', () => {
 	it('renders the trigger button with the project count', () => {
@@ -30,5 +31,116 @@ describe('ProjectManager (smoke)', () => {
 		expect(icon).toBeTruthy();
 		expect(trigger.textContent).not.toMatch(/📁/);
 		expect(trigger.querySelector('.hidden.sm\\:inline')?.textContent).toMatch(/案件を管理/);
+	});
+});
+
+/**
+ * PR-N3 (#187): form を「+ Add project」 / 「Edit」 で開き、 詳細 section
+ * (description / tags / links) が UI / data / a11y 契約を満たすことを固定。
+ *
+ * Dialog は body に Portal するので `document` 全体から探す。
+ */
+describe('ProjectManager form (PR-N3, refs #187)', () => {
+	async function openCreateForm() {
+		const utils = render(ProjectManager, { props: { projects: [], assignments: [] } });
+		await fireEvent.click(utils.getByRole('button', { name: /案件を管理/ }));
+		const addBtn = await waitFor(() => {
+			return Array.from(document.querySelectorAll('button')).find((el) =>
+				el.textContent?.includes('案件を追加')
+			) as HTMLButtonElement;
+		});
+		await fireEvent.click(addBtn);
+		const form = await waitFor(() => {
+			const f = document.querySelector('form[action="?/createProject"]') as HTMLFormElement;
+			if (!f) throw new Error('createProject form not rendered');
+			return f;
+		});
+		return { form, ...utils };
+	}
+
+	async function openEditForm(project: Project) {
+		const utils = render(ProjectManager, { props: { projects: [project], assignments: [] } });
+		await fireEvent.click(utils.getByRole('button', { name: /案件を管理/ }));
+		const editBtn = await waitFor(() => {
+			return Array.from(document.querySelectorAll('button')).find((el) =>
+				el.textContent?.trim().match(/^編集$/)
+			) as HTMLButtonElement;
+		});
+		await fireEvent.click(editBtn);
+		const form = await waitFor(() => {
+			const f = document.querySelector('form[action="?/updateProject"]') as HTMLFormElement;
+			if (!f) throw new Error('updateProject form not rendered');
+			return f;
+		});
+		return { form, ...utils };
+	}
+
+	it('create form: 詳細 section is rendered (default closed for new project)', async () => {
+		const { form } = await openCreateForm();
+		const details = form.querySelector('details');
+		expect(details).toBeTruthy();
+		expect(details?.hasAttribute('open')).toBe(false);
+	});
+
+	it('create form: textarea[name=description], input[name=tags], hidden input[name=linksJson] が render される', async () => {
+		const { form } = await openCreateForm();
+		const desc = form.querySelector('textarea[name="description"]');
+		const tags = form.querySelector('input[name="tags"]');
+		const linksJson = form.querySelector('input[type="hidden"][name="linksJson"]') as HTMLInputElement;
+		expect(desc).toBeTruthy();
+		expect(tags).toBeTruthy();
+		expect(linksJson).toBeTruthy();
+		// initial: empty links → '[]'
+		expect(linksJson.value).toBe('[]');
+	});
+
+	it('create form: tags input has aria-describedby pointing to hint (BP B7 a11y)', async () => {
+		const { form } = await openCreateForm();
+		const tags = form.querySelector('input[name="tags"]') as HTMLInputElement;
+		const describedBy = tags.getAttribute('aria-describedby');
+		expect(describedBy).toBeTruthy();
+		const hint = describedBy ? form.querySelector(`#${describedBy}`) : null;
+		expect(hint).toBeTruthy();
+		expect(hint?.textContent ?? '').toMatch(/カンマ|comma/i);
+	});
+
+	it('edit form: 既存値ありの project では 詳細 section が default open', async () => {
+		const { form } = await openEditForm({
+			id: 'p1',
+			name: 'P with detail',
+			color: '#0EA5E9',
+			description: 'body',
+			tags: ['a', 'b'],
+			links: [{ url: 'https://example.com', label: 'wiki' }]
+		});
+		const details = form.querySelector('details');
+		expect(details?.hasAttribute('open')).toBe(true);
+	});
+
+	it('edit form: 既存値が field に復元される', async () => {
+		const { form } = await openEditForm({
+			id: 'p1',
+			name: 'P with detail',
+			color: '#0EA5E9',
+			description: 'body markdown',
+			tags: ['TypeScript', 'AWS'],
+			links: [{ url: 'https://example.com', label: 'Wiki' }]
+		});
+		const desc = form.querySelector('textarea[name="description"]') as HTMLTextAreaElement;
+		const tags = form.querySelector('input[name="tags"]') as HTMLInputElement;
+		const linksJson = form.querySelector(
+			'input[type="hidden"][name="linksJson"]'
+		) as HTMLInputElement;
+		expect(desc.value).toBe('body markdown');
+		expect(tags.value).toMatch(/TypeScript,\s*AWS/);
+		expect(JSON.parse(linksJson.value)).toEqual([
+			{ url: 'https://example.com', label: 'Wiki' }
+		]);
+	});
+
+	it('edit form: 詳細無しの legacy project では 詳細 section が default closed', async () => {
+		const { form } = await openEditForm({ id: 'p1', name: 'Legacy', color: '#000000' });
+		const details = form.querySelector('details');
+		expect(details?.hasAttribute('open')).toBe(false);
 	});
 });

--- a/web/src/lib/i18n/en.json
+++ b/web/src/lib/i18n/en.json
@@ -63,7 +63,17 @@
 		"color": "Display color",
 		"assignmentCount": "({count} assignments)",
 		"confirmDelete": "Delete \"{name}\"?",
-		"confirmDeleteWithAssignments": "Delete \"{name}\" and {count} related assignments?\n(Cannot be undone)"
+		"confirmDeleteWithAssignments": "Delete \"{name}\" and {count} related assignments?\n(Cannot be undone)",
+		"editDetail": "Edit detail",
+		"descriptionLabel": "Description",
+		"descriptionHint": "Markdown is supported",
+		"tagsLabel": "Tags",
+		"tagsHint": "Comma-separated (e.g. TypeScript, Svelte, AWS)",
+		"linksLabel": "Related links",
+		"linkLabel": "Label (optional)",
+		"linkUrl": "URL",
+		"addLink": "+ Add link",
+		"removeLink": "Remove"
 	},
 	"assignments": {
 		"add": "Add assignment",

--- a/web/src/lib/i18n/ja.json
+++ b/web/src/lib/i18n/ja.json
@@ -63,7 +63,17 @@
 		"color": "表示色",
 		"assignmentCount": "({count} 件のアサイン)",
 		"confirmDelete": "「{name}」を削除しますか?",
-		"confirmDeleteWithAssignments": "「{name}」と関連 {count} 件のアサインを削除しますか?\n(取り消しできません)"
+		"confirmDeleteWithAssignments": "「{name}」と関連 {count} 件のアサインを削除しますか?\n(取り消しできません)",
+		"editDetail": "詳細を編集",
+		"descriptionLabel": "説明",
+		"descriptionHint": "markdown 記法が使えます",
+		"tagsLabel": "使用技術",
+		"tagsHint": "カンマで区切る (例: TypeScript, Svelte, AWS)",
+		"linksLabel": "関連リンク",
+		"linkLabel": "ラベル (任意)",
+		"linkUrl": "URL",
+		"addLink": "+ リンクを追加",
+		"removeLink": "削除"
 	},
 	"assignments": {
 		"add": "アサインを追加",

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -39,6 +39,7 @@ export type ResourceUpdateInput = z.infer<typeof resourceUpdateSchema>;
  * Project 詳細フィールドの上限 (ADR 0010)。 UI (HTML input maxlength 等) と schema 双方で
  * 同 source を参照するため export して共有する (ADR 0001 型駆動、 マジック数値禁止)。
  */
+export const PROJECT_NAME_MAX_LENGTH = 100;
 export const PROJECT_DESCRIPTION_MAX_LENGTH = 10_000;
 export const PROJECT_TAG_MAX_LENGTH = 30;
 export const PROJECT_TAG_MAX_COUNT = 20;
@@ -46,6 +47,9 @@ export const PROJECT_TAG_MAX_COUNT = 20;
 export const PROJECT_TAGS_CSV_MAX_LENGTH = 700;
 export const PROJECT_LINK_LABEL_MAX_LENGTH = 50;
 export const PROJECT_LINK_MAX_COUNT = 10;
+// URL 上限: RFC 上の明示的な上限はないが、 各 browser / proxy が ~2048 / ~8192 で truncate
+// する事例があるため defensive に 2048 を採用 (IE 互換目安、 modern browser でも安全圏)。
+export const PROJECT_LINK_URL_MAX_LENGTH = 2048;
 
 /**
  * description: 空文字 → undefined に正規化して max(10_000) で長さ制限 (ADR 0010)。
@@ -96,7 +100,10 @@ const linkObjectSchema = z.object({
 	),
 	url: z.preprocess(
 		(v) => (typeof v === 'string' ? v.trim() : v),
-		z.url('invalidUrl').refine((u) => /^https?:\/\//.test(u), 'invalidUrl')
+		z
+			.url('invalidUrl')
+			.max(PROJECT_LINK_URL_MAX_LENGTH, 'tooLong')
+			.refine((u) => /^https?:\/\//.test(u), 'invalidUrl')
 	)
 });
 
@@ -124,7 +131,7 @@ const linksJsonSchema = z
  * base object を const 化して両 schema で再利用する。
  */
 const projectBaseShape = {
-	name: z.string().min(1, 'required').max(100, 'tooLong'),
+	name: z.string().min(1, 'required').max(PROJECT_NAME_MAX_LENGTH, 'tooLong'),
 	color: colorString,
 	description: descriptionSchema,
 	tags: tagsCsvSchema,

--- a/web/src/lib/schemas/index.ts
+++ b/web/src/lib/schemas/index.ts
@@ -36,13 +36,25 @@ export type ResourceUpdateInput = z.infer<typeof resourceUpdateSchema>;
 // ── Project ─────────────────────────────────────────────────────────
 
 /**
+ * Project 詳細フィールドの上限 (ADR 0010)。 UI (HTML input maxlength 等) と schema 双方で
+ * 同 source を参照するため export して共有する (ADR 0001 型駆動、 マジック数値禁止)。
+ */
+export const PROJECT_DESCRIPTION_MAX_LENGTH = 10_000;
+export const PROJECT_TAG_MAX_LENGTH = 30;
+export const PROJECT_TAG_MAX_COUNT = 20;
+// tags CSV の worst-case: 20 tags × (30 chars + 2 chars for ', ') = 640。 余裕を持って 700。
+export const PROJECT_TAGS_CSV_MAX_LENGTH = 700;
+export const PROJECT_LINK_LABEL_MAX_LENGTH = 50;
+export const PROJECT_LINK_MAX_COUNT = 10;
+
+/**
  * description: 空文字 → undefined に正規化して max(10_000) で長さ制限 (ADR 0010)。
  * `<textarea>` は空でも空文字を返すので preprocess で undefined に揃え、 repository 側で
  * 「未設定 = attribute REMOVE」 を一貫させる (Zod v4 preprocess pattern)。
  */
 const descriptionSchema = z.preprocess(
 	(v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
-	z.string().max(10_000, 'tooLong').optional()
+	z.string().max(PROJECT_DESCRIPTION_MAX_LENGTH, 'tooLong').optional()
 );
 
 /**
@@ -67,7 +79,11 @@ const tagsCsvSchema = z
 		}
 		return result;
 	})
-	.pipe(z.array(z.string().min(1, 'required').max(30, 'tooLong')).max(20, 'tooMany'));
+	.pipe(
+		z
+			.array(z.string().min(1, 'required').max(PROJECT_TAG_MAX_LENGTH, 'tooLong'))
+			.max(PROJECT_TAG_MAX_COUNT, 'tooMany')
+	);
 
 /**
  * link 1 件: label は省略可 (空文字なら undefined)、 url は http(s) のみ許可 (ADR 0010)。
@@ -76,7 +92,7 @@ const tagsCsvSchema = z
 const linkObjectSchema = z.object({
 	label: z.preprocess(
 		(v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
-		z.string().max(50, 'tooLong').optional()
+		z.string().max(PROJECT_LINK_LABEL_MAX_LENGTH, 'tooLong').optional()
 	),
 	url: z.preprocess(
 		(v) => (typeof v === 'string' ? v.trim() : v),
@@ -101,7 +117,7 @@ const linksJsonSchema = z
 			return [];
 		}
 	})
-	.pipe(z.array(linkObjectSchema).max(10, 'tooMany'));
+	.pipe(z.array(linkObjectSchema).max(PROJECT_LINK_MAX_COUNT, 'tooMany'));
 
 /**
  * create / update 共通 shape。 Zod v4 では `.transform()` 後に `.extend()` できないため、

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -74,9 +74,14 @@ export const actions: Actions = {
 	createProject: async (event) => {
 		const session = await requireSession(event);
 		const data = await event.request.formData();
+		// FormData.get は missing field で `null` を返すが、 schema (z.string().optional()) は
+		// `null` を受け付けず `undefined` を期待するため `?? undefined` で正規化する。
 		const parsed = projectCreateSchema.safeParse({
 			name: data.get('name'),
-			color: data.get('color')
+			color: data.get('color'),
+			description: data.get('description') ?? undefined,
+			tags: data.get('tags') ?? undefined,
+			linksJson: data.get('linksJson') ?? undefined
 		});
 		if (!parsed.success) {
 			return fail(400, {
@@ -94,7 +99,10 @@ export const actions: Actions = {
 		const parsed = projectUpdateSchema.safeParse({
 			id: data.get('id'),
 			name: data.get('name'),
-			color: data.get('color')
+			color: data.get('color'),
+			description: data.get('description') ?? undefined,
+			tags: data.get('tags') ?? undefined,
+			linksJson: data.get('linksJson') ?? undefined
 		});
 		if (!parsed.success) {
 			return fail(400, {

--- a/web/src/routes/page.server.test.ts
+++ b/web/src/routes/page.server.test.ts
@@ -330,6 +330,39 @@ describe('?/createProject action', () => {
 		expect(r.data.errors.color).toBeTruthy();
 		expect(createProjectMock).not.toHaveBeenCalled();
 	});
+
+	it('passes description / tags / linksJson from form (PR-N3, refs #187)', async () => {
+		await actions.createProject!(
+			makeEvent({
+				name: 'Alpha',
+				color: '#0EA5E9',
+				description: 'detail body markdown',
+				tags: 'TypeScript, AWS',
+				linksJson: JSON.stringify([{ url: 'https://example.com', label: 'Wiki' }])
+			})
+		);
+		expect(createProjectMock).toHaveBeenCalledWith('team_default', {
+			name: 'Alpha',
+			color: '#0EA5E9',
+			description: 'detail body markdown',
+			tags: ['TypeScript', 'AWS'],
+			links: [{ url: 'https://example.com', label: 'Wiki' }]
+		});
+	});
+
+	it('treats empty-string description as undefined (preprocess + ADR 0010 REMOVE semantics)', async () => {
+		await actions.createProject!(
+			makeEvent({ name: 'X', color: '#0EA5E9', description: '', tags: '', linksJson: '[]' })
+		);
+		expect(createProjectMock).toHaveBeenCalledWith(
+			'team_default',
+			expect.objectContaining({
+				description: undefined,
+				tags: [],
+				links: []
+			})
+		);
+	});
 });
 
 describe('?/updateProject action', () => {
@@ -356,6 +389,27 @@ describe('?/updateProject action', () => {
 		)) as { status: number; data: { errors: Record<string, ServerError> } };
 		expect(r.status).toBe(400);
 		expect(r.data.errors.name).toBeTruthy();
+	});
+
+	it('passes description / tags / linksJson from form (PR-N3, refs #187)', async () => {
+		await actions.updateProject!(
+			makeEvent({
+				id: 'p1',
+				name: 'Beta',
+				color: '#10B981',
+				description: 'updated body',
+				tags: 'rust, k8s',
+				linksJson: JSON.stringify([{ url: 'https://example.com/spec', label: 'Spec' }])
+			})
+		);
+		expect(updateProjectMock).toHaveBeenCalledWith('team_default', {
+			id: 'p1',
+			name: 'Beta',
+			color: '#10B981',
+			description: 'updated body',
+			tags: ['rust', 'k8s'],
+			links: [{ url: 'https://example.com/spec', label: 'Spec' }]
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

PR-N1 (#194) / PR-N1-fix (#197) で schema / repository / read path を整備した Project 詳細フィールド (description / tags / links) の **form 入力 + action 読み取り** を実装。 PR-N4 で SSR render する前段。

## Changes

### Form UI (`ProjectManager.svelte`)
- form に `<details open={hasDetail}>` 折りたたみ section を追加 (WAI-ARIA APG Disclosure)
- `<Textarea name="description" />` (PR-N2 で実装した #177-ext component を使用)
- `<Input name="tags" aria-describedby="project-tags-hint" />` + hint text (BP B7 a11y)
- `<fieldset>` で links 動的 add/remove UI (max 10)
- links は **hidden input + `JSON.stringify(formLinks.map(stripKey))`** で送信 (BP B8、 ADR 0010)
- `EditableProjectLink` 内部型に `_key = crypto.randomUUID()` を持ち `{#each ... (link._key)}` で stable key (Svelte 5 公式: index key 非推奨)
- 各 link `<Input>` に `aria-label`（行番号付き）を付与 (placeholder は accessible name の代替不可)

### Server action (`+page.server.ts`)
- `createProject` / `updateProject` action で `formData.get('description'/'tags'/'linksJson')` を読み取る (PR-N1 の TODO 解消)
- `FormData.get` の `null` を `?? undefined` で schema が期待する optional に正規化

### Schema constants export (`schemas/index.ts`)
- `PROJECT_DESCRIPTION_MAX_LENGTH` / `PROJECT_TAG_MAX_LENGTH` / `PROJECT_TAG_MAX_COUNT` / `PROJECT_TAGS_CSV_MAX_LENGTH` / `PROJECT_LINK_LABEL_MAX_LENGTH` / `PROJECT_LINK_MAX_COUNT` を export して UI 側 (maxlength 等) と schema 双方で共有 (マジック数値禁止、 ADR 0001 型駆動)

### i18n (`i18n/{ja,en}.json`)
- `projects.editDetail` / `descriptionLabel` / `descriptionHint` / `tagsLabel` / `tagsHint` / `linksLabel` / `linkLabel` / `linkUrl` / `addLink` / `removeLink` を追加

## TDD 順序 (R1-R5 を踏襲)

1. `page.server.test.ts` に「form 経由で description / tags / linksJson が schema を通って repository に渡る」 1 ケースだけ書く → `pnpm test` で **fail (RED) を目視**
2. action を `data.get(...)` 5 行追加、 `?? undefined` で正規化 → GREEN
3. `ProjectManager.svelte.test.ts` に詳細 section / aria-describedby / 編集時値復元 など 6 ケース追加 → 全 RED
4. ProjectManager.svelte に detail section / state / startEdit 拡張を実装 → 全 GREEN
5. code-reviewer agent でレビュー、 Major 2 件 (each key の index 非推奨 / link Input の accessible name 欠落) + Minor 3 件 (マジック数値 / 不要変数 / 空文字 description test 不足) 全て本 commit で反映

## 検証

- ✅ `pnpm test` 全体 367/367 緑 (+1 from 366 baseline、 action 2 件 + component 6 件 + 空文字 1 件)
- ✅ `pnpm check` 0 new error (pre-existing `auth.ts:67` のみ)
- ✅ `pnpm dlx knip` exit 0
- ✅ `pnpm dlx madge --circular` no circular deps
- ✅ `code-reviewer` 第 2 ラウンド指摘なし (Major 全 fix)

## 関連

- refs #187 (feature request)
- refs #194 (PR-N1) / #197 (PR-N1-fix) / #198 (PR-N2) / #199 (#177-ext)
- unblocks PR-N4 (ProjectDetailView + SSR render)

## 公式 docs

- [WAI-ARIA APG Disclosure](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/)
- [Svelte 5 #each key](https://svelte.dev/docs/svelte/each) (index key 非推奨)
- [WCAG 1.3.1 / 4.1.2 accessible name](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships)
- [SvelteKit form action / FormData](https://svelte.dev/docs/kit/form-actions)